### PR TITLE
BAU: Add code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @alphagov/digital-identity-ipv
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # di-ipv-core-front
+
+### Code Owners
+
+This repo has a `CODEOWNERS` file in the root and is configured to require PRs to reviewed by Code Owners.


### PR DESCRIPTION
Add code owners file for digitial-identity-ipv. We will also require
reviews from code owners.