### PR TITLE
refactor: Use oauth2/authorize path

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,3 +25,4 @@ const { router } = setup({
 });
 
 router.use("/", require("./app/router"));
+router.use("/oauth2", require("./app/oauth2/router"));

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -1,0 +1,43 @@
+const { API_BASE_URL, AUTH_PATH } = require("../../lib/config");
+const express = require("express");
+const axios = require("axios");
+
+const router = express.Router();
+
+router.get("/authorize", (req, res) => {
+  const authParams = {
+    response_type: req.query.response_type,
+    client_id: req.query.client_id,
+    state: req.query.state,
+    redirect_uri: req.query.redirect_uri,
+  };
+
+  req.session.authParams = authParams;
+
+  res.render("index-hmpo");
+});
+
+router.get("/index-hmpo", (req, res) => {
+  res.render("index-hmpo");
+});
+
+router.post("/authorize", async (req, res) => {
+  try {
+    const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
+      params: {
+        redirect_uri: req.session.authParams.redirect_uri,
+        client_id: req.session.authParams.client_id,
+        response_type: req.session.authParams.response_type,
+        scope: "openid",
+      },
+    });
+
+    const redirectURL = `${apiResponse.data.redirectionURI}?state=${apiResponse.data.state}&authorizationCode=${apiResponse.data.authorizationCode.value}`;
+    res.redirect(redirectURL);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+    res.status(500).send(e.message);
+  }
+});
+module.exports = router;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Copy oauth router to standard /oauth/authorize path
- Render using HMPO forms
- Handle authorize on form posting

### Why did it change

This is now using the standard `oauth2` paths for compatibility with other systems.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-XXXX](https://govukverify.atlassian.net/browse/PYI-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
