### PR TITLE
refactor: Use API as REST API not oAuth API

### DIFF
--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -24,27 +24,23 @@ router.get("/index-hmpo", (req, res) => {
 router.post("/authorize", async (req, res) => {
   try {
     const oauthParams = {
-      redirect_uri: req.session.authParams.redirect_uri,
-      client_id: req.session.authParams.client_id,
-      response_type: req.session.authParams.response_type,
+      ...req.session.authParams,
       scope: "openid",
     };
 
     const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
-      validateStatus: (status) => {
-        return status === 302;
-      },
-      maxRedirects: 0,
       params: oauthParams,
     });
 
-    const redirectURL = apiResponse.headers?.location;
+    const code = apiResponse.data?.code?.value;
 
-    if (!redirectURL) {
-      res.status(500).send("Missing redirect url");
+    if (!code) {
+      res.status(500).send("Missing authorization code");
     }
 
-    return res.redirect(redirectURL);
+    const redirectURL = `${req.session.authParams.redirect_uri}?code=${code}`;
+
+    res.redirect(redirectURL);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Frontend is a part of the oAuth flow exposed to the user, but the
  backend does not need to respond in the same way, so backend will
  respond as a normal REST API
- Refactor to use standard GET/POST methods
- Spread authParams into API request directly

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-332](https://govukverify.atlassian.net/browse/PYI-332)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
