### PR TITLE
PYI-368: Added Credential Issuer button

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -1,7 +1,9 @@
 
 buttons:
+  authorizeAndReturn: Authorize And Return
   next: Continue
   cancel: Cancel
+  credentialIssuer: Credential Issuer
 govuk:
   serviceName: Prove your identity
   backLink: Back

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -21,7 +21,12 @@ homepageUrl: "https://www.gov.uk"
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">di-ipv-core-front</h1>
         <p class="govuk-body">{{ govukButton({
-          text: translate("buttons.next"),
+          text: translate("buttons.credentialIssuer"),
+          href:"/credential-issuer/authorize"
+          }) }}
+        </p>
+        <p class="govuk-body">{{ govukButton({
+          text: translate("buttons.authorizeAndReturn"),
           href:"/authorize"
           }) }}
         </p>


### PR DESCRIPTION
Co-authored-by: Robin Harrison <robin.harrison@digital.cabinet-office.gov.uk>
Co-authored-by: Amrit Sidhu <Amrit.Sidhu@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Added a button to represent the redirecting to the Credential Issuer from the core frontend

### What changed

Index page of core-frontend was updated to have a button for redirecting to the authorize endpoint of the credential Issure

### Why did it change

We want to have a debug page so we can see the flow from core frontend to the Credential Issuer


- [PYI-368](https://govukverify.atlassian.net/browse/PYI-368)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
