### PR TITLE
PYI-370: Add route to handle credential issuer callback

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -3,12 +3,30 @@ const {
   CREDENTIAL_ISSUER_AUTH_PATH,
 } = require("../../lib/config");
 
-const redirectToAuthorize = async (req, res) => {
-  if (!CREDENTIAL_ISSUER_BASE_URL) {
-    return res.send(500);
-  }
+module.exports = {
+  redirectToAuthorize: async (req, res) => {
+    if (!CREDENTIAL_ISSUER_BASE_URL) {
+      return res.send(500);
+    }
 
-  const redirectURL = `${CREDENTIAL_ISSUER_BASE_URL}${CREDENTIAL_ISSUER_AUTH_PATH}`;
-  res.redirect(redirectURL);
+    const redirectURL = `${CREDENTIAL_ISSUER_BASE_URL}${CREDENTIAL_ISSUER_AUTH_PATH}`;
+    res.redirect(redirectURL);
+  },
+
+  addCallbackParamsToSession: async (req, res, next) => {
+    const callbackParams = {
+      response_type: req.query.response_type,
+      client_id: req.query.client_id,
+      state: req.query.state,
+      authorization_code: req.query.authorization_code,
+      // need to confirm these are the correct params
+    };
+
+    req.session.callbackParams = callbackParams;
+
+    next();
+  },
+  renderDebugPage: async (req, res) => {
+    res.render("index");
+  },
 };
-module.exports = redirectToAuthorize;

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -14,7 +14,7 @@ describe("credential issuer middleware", () => {
     it("should successfully be redirected", async function () {
       configStub.CREDENTIAL_ISSUER_BASE_URL = "http://example.com";
 
-      const redirectToAuthorize = proxyquire("./middleware", {
+      const {redirectToAuthorize} = proxyquire("./middleware", {
         "../../lib/config": configStub,
       });
 
@@ -31,7 +31,7 @@ describe("credential issuer middleware", () => {
       });
 
       it("should send 500 error", async () => {
-        const redirectToAuthorize = proxyquire("./middleware", {
+        const {redirectToAuthorize} = proxyquire("./middleware", {
           "../../lib/config": configStub,
         });
 
@@ -40,7 +40,7 @@ describe("credential issuer middleware", () => {
         expect(res.send).to.have.been.calledWith(500);
       });
       it("should not call redirect", async () => {
-        const redirectToAuthorize = proxyquire("./middleware", {
+        const {redirectToAuthorize} = proxyquire("./middleware", {
           "../../lib/config": configStub,
         });
 
@@ -48,6 +48,75 @@ describe("credential issuer middleware", () => {
 
         expect(res.redirect).not.to.have.been.called;
       });
+    });
+  });
+
+  describe("addCallbackParamsToSession", () => {
+    let req;
+    let res;
+    let next;
+    let configStub;
+
+    beforeEach(() => {
+      req = {
+        query: {
+          response_type: "code",
+          client_id: "s6BhdRkqt3",
+          state: "xyz",
+          authorization_code: 1234,
+          unusedParam: "not used",
+        },
+        session: {},
+      };
+      configStub = {};
+      next = sinon.fake();
+    });
+
+    it("should save callbackParams to session", async function () {
+      const {addCallbackParamsToSession} = proxyquire("./middleware", {
+        "../../lib/config": configStub,
+      });
+      await addCallbackParamsToSession(req, res, next);
+
+      expect(req.session.callbackParams).to.deep.equal({
+        response_type: req.query.response_type,
+        client_id: req.query.client_id,
+        state: req.query.state,
+        authorization_code: req.query.authorization_code,
+      });
+    });
+
+    it("should call next", async function () {
+      const {addCallbackParamsToSession} = proxyquire("./middleware", {
+        "../../lib/config": configStub,
+      });
+
+      await addCallbackParamsToSession(req, res, next);
+
+      expect(next).to.have.been.called;
+    });
+  });
+
+  describe("renderDebugPage", () => {
+    let req;
+    let res;
+    let configStub;
+
+    beforeEach(() => {
+      res = {
+        render: sinon.fake(),
+      };
+      configStub = {};
+    });
+
+    it("should render index page", () => {
+      const {renderDebugPage} = proxyquire("./middleware", {
+        "../../lib/config": configStub,
+      });
+
+      renderDebugPage(req, res);
+
+      expect(res.render).to.have.been.calledWith("index");
     });
   });
 });

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -1,9 +1,15 @@
 
 const express = require("express");
-const redirectToAuthorize = require("./middleware");
 
 const router = express.Router();
 
-router.get("/authorize", redirectToAuthorize)
+const {
+  redirectToAuthorize,
+  addCallbackParamsToSession,
+  renderDebugPage,
+} = require("./middleware");
 
-module.exports = router
+router.get("/authorize", redirectToAuthorize);
+router.get("/callback", addCallbackParamsToSession, renderDebugPage);
+
+module.exports = router;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added a route to handle the callback route and the params from the credential issuer

Added unit tests to test that 
 - the params received are being saved into the session
 - that the debug page is rendered on the callback

<!-- Describe the changes in detail - the "what"-->

### Why did it change

So that core-front can retrieve authorization code from the credential issuer
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-370](https://govukverify.atlassian.net/browse/PYI-370)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
