### PR TITLE
PYI-370/bau/add ipv session id upstream

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -42,13 +42,13 @@ module.exports = {
     const evidenceParam = new URLSearchParams([
       ["authorization_code", req.credentialIssuer.code],
       ["credential_issuer_id", CREDENTIAL_ISSUER_ID],
-      ["redirect_uri", `${BASE_URL}/credential-issuer/callback`]
+      ["redirect_uri", `${BASE_URL}/credential-issuer/callback`],
     ]);
 
     const config = {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": req.session.ipv_session_id,
+        "ipv-session-id": req.session.ipvSessionId,
       },
     };
 

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -43,6 +43,7 @@ module.exports = {
     const evidenceParam = new URLSearchParams([
       ["authorization_code", req.credentialIssuer.code],
       ["credential_issuer_id", CREDENTIAL_ISSUER_ID],
+      ["redirect_uri", `${BASE_URL}/credential-issuer/callback`]
     ]);
 
     const config = {

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
 const url = require("url");
-const { randomUUID } = require("crypto");
 const {
   CREDENTIAL_ISSUER_BASE_URL,
   CREDENTIAL_ISSUER_AUTH_PATH,
@@ -49,7 +48,7 @@ module.exports = {
     const config = {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": `${randomUUID()}`,
+        "ipv-session-id": req.session.ipv_session_id,
       },
     };
 

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -6,7 +6,7 @@ const {
   API_BASE_URL,
   CREDENTIAL_ISSUER_ID,
   API_REQUEST_EVIDENCE_PATH,
-  BASE_URL,
+  EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
         response_type: "code",
         client_id: "test",
         state: "test-state",
-        redirect_uri: `${BASE_URL}/credential-issuer/callback`,
+        redirect_uri: `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback`,
       },
     });
 
@@ -42,7 +42,7 @@ module.exports = {
     const evidenceParam = new URLSearchParams([
       ["authorization_code", req.credentialIssuer.code],
       ["credential_issuer_id", CREDENTIAL_ISSUER_ID],
-      ["redirect_uri", `${BASE_URL}/credential-issuer/callback`],
+      ["redirect_uri", `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback`],
     ]);
 
     const config = {

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -43,7 +43,7 @@ describe("credential issuer middleware", () => {
 
     it("should successfully return expected redirect url", async function () {
       configStub.CREDENTIAL_ISSUER_BASE_URL = "http://example.com";
-      configStub.BASE_URL = "https://example.org/subpath";
+      configStub.EXTERNAL_WEBSITE_HOST = "https://example.org/subpath";
       const { buildCredentialIssuerRedirectURL } = proxyquire("./middleware", {
         "../../lib/config": configStub,
       });
@@ -149,7 +149,7 @@ describe("credential issuer middleware", () => {
       configStub.API_REQUEST_EVIDENCE_PATH = "/ADD-EVIDENCE";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
-      configStub.BASE_URL = "http://example.com";
+      configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
 
       middleware = proxyquire("./middleware", {
         axios: axiosStub,

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -152,6 +152,7 @@ describe("credential issuer middleware", () => {
       });
       req = {
         credentialIssuer: { code: "authorize-code-issued" },
+        session: { ipv_session_id: "ipv-session-id" }
       };
       res = {
         status: sinon.fake(),

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -23,10 +23,13 @@ module.exports = {
     res.redirect("/debug");
   },
 
+  setIpvSessionId: async (req, res, next) => {
+    req.session.ipvSessionId = randomUUID();
+
+    next();
+  },
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
-      req.session.ipv_session_id = randomUUID();
-
       const oauthParams = {
         ...req.session.authParams,
         scope: "openid",
@@ -34,7 +37,7 @@ module.exports = {
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
         params: oauthParams,
-        headers: { "ipv-session-id": req.session.ipv_session_id}
+        headers: { "ipv-session-id": req.session.ipvSessionId },
       });
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -26,7 +26,6 @@ module.exports = {
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
       req.session.ipv_session_id = randomUUID();
-      req.headers[IPV_SESSION_ID] = req.session.ipv_session_id
 
       const oauthParams = {
         ...req.session.authParams,
@@ -35,7 +34,7 @@ module.exports = {
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
         params: oauthParams,
-        headers: req.headers
+        headers: { IPV_SESSION_ID: req.session.ipv_session_id}
       });
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const { randomUUID } = require("crypto");
-const { API_BASE_URL, AUTH_PATH } = require("../../lib/config");
+const { API_BASE_URL, AUTH_PATH, IPV_SESSION_ID } = require("../../lib/config");
 
 module.exports = {
   addAuthParamsToSession: async (req, res, next) => {
@@ -25,10 +25,8 @@ module.exports = {
 
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
-
-      if (req?.session?.ipv_session_id) {
-        req.session.ipv_session_id = randomUUID();
-      }
+      req.session.ipv_session_id = randomUUID();
+      req.headers[IPV_SESSION_ID] = req.session.ipv_session_id;
 
       const oauthParams = {
         ...req.session.authParams,
@@ -37,6 +35,7 @@ module.exports = {
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
         params: oauthParams,
+        headers: req.headers,
       });
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const { randomUUID } = require("crypto");
 const { API_BASE_URL, AUTH_PATH } = require("../../lib/config");
 
 module.exports = {
@@ -24,6 +25,11 @@ module.exports = {
 
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
+
+      if (req?.session?.ipv_session_id) {
+        req.session.ipv_session_id = randomUUID();
+      }
+
       const oauthParams = {
         ...req.session.authParams,
         scope: "openid",

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -26,7 +26,7 @@ module.exports = {
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
       req.session.ipv_session_id = randomUUID();
-      req.headers[IPV_SESSION_ID] = req.session.ipv_session_id;
+      req.headers[IPV_SESSION_ID] = req.session.ipv_session_id
 
       const oauthParams = {
         ...req.session.authParams,
@@ -35,7 +35,7 @@ module.exports = {
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
         params: oauthParams,
-        headers: req.headers,
+        headers: req.headers
       });
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const { randomUUID } = require("crypto");
-const { API_BASE_URL, AUTH_PATH, IPV_SESSION_ID } = require("../../lib/config");
+const { API_BASE_URL, AUTH_PATH } = require("../../lib/config");
 
 module.exports = {
   addAuthParamsToSession: async (req, res, next) => {
@@ -34,7 +34,7 @@ module.exports = {
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
         params: oauthParams,
-        headers: { IPV_SESSION_ID: req.session.ipv_session_id}
+        headers: { "ipv-session-id": req.session.ipv_session_id}
       });
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -75,9 +75,6 @@ describe("oauth middleware", () => {
             scope: "openid",
           }
         },
-        headers: {
-          "ipv-session-id": "ipv-session-id"
-        }
       };
 
       axiosResponse = {

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -73,8 +73,11 @@ describe("oauth middleware", () => {
             state: "xyz",
             redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
             scope: "openid",
-          },
+          }
         },
+        headers: {
+          "ipv-session-id": "ipv-session-id"
+        }
       };
 
       axiosResponse = {
@@ -126,8 +129,6 @@ describe("oauth middleware", () => {
 
       beforeEach(() => {
         errorMessage = "server error";
-
-        // axiosStub.get = sinon.fake.throws({ message: errorMessage });
         axiosStub.get = sinon.fake.throws(new Error(errorMessage));
       });
 

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -1,8 +1,13 @@
 const proxyquire = require("proxyquire");
 
 const axiosStub = {};
+const configStub = {
+  AUTH_PATH: "/subsubpath/auth",
+  API_BASE_URL: "https://example.org/subpath",
+};
 const middleware = proxyquire("./middleware", {
   axios: axiosStub,
+  "../../lib/config": configStub,
 });
 
 describe("oauth middleware", () => {
@@ -53,6 +58,25 @@ describe("oauth middleware", () => {
     });
   });
 
+  describe("setIpvSessionId", () => {
+    beforeEach(() => {
+      req = {
+        session: {},
+      };
+    });
+
+    it("should set ipvSessionId in session", async function () {
+      await middleware.setIpvSessionId(req, res, next);
+
+      expect(req.session.ipvSessionId).not.to.be.undefined;
+    });
+
+    it("should call next", async function () {
+      await middleware.setIpvSessionId(req, res, next);
+
+      expect(next).to.have.been.called;
+    });
+  });
   describe("renderOauthPage", () => {
     it("should render index page", () => {
       middleware.renderOauthPage(req, res);
@@ -73,7 +97,7 @@ describe("oauth middleware", () => {
             state: "xyz",
             redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
             scope: "openid",
-          }
+          },
         },
       };
 
@@ -84,6 +108,22 @@ describe("oauth middleware", () => {
       };
 
       axiosStub.get = sinon.fake.returns(axiosResponse);
+    });
+
+    context("auth request", () => {
+      it("should call axios with correct parameters", async () => {
+        req.session.ipvSessionId = "abadcafe";
+
+        await middleware.retrieveAuthorizationCode(req, res, next);
+
+        expect(axiosStub.get).to.have.been.calledWith(
+          "https://example.org/subpath/subsubpath/auth",
+          sinon.match({
+            params: { ...req.session.authParams },
+            headers: { "ipv-session-id": "abadcafe" },
+          })
+        );
+      });
     });
 
     context("with authorization code", () => {

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -7,9 +7,15 @@ const {
   redirectToCallback,
   redirectToDebugPage,
   retrieveAuthorizationCode,
+  setIpvSessionId,
 } = require("./middleware");
 
-router.get("/authorize", addAuthParamsToSession, redirectToDebugPage);
+router.get(
+  "/authorize",
+  addAuthParamsToSession,
+  setIpvSessionId,
+  redirectToDebugPage
+);
 router.post("/authorize", retrieveAuthorizationCode, redirectToCallback);
 
 module.exports = router;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -15,6 +15,7 @@ module.exports = {
   CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
   CREDENTIAL_ISSUER_AUTH_PATH: "/authorize",
   CREDENTIAL_ISSUER_ID: "PassportIssuer",
+  EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,7 +11,6 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   AUTH_PATH: "/authorize",
-  IPV_SESSION_ID: "ipv-session-id",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
   CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
   CREDENTIAL_ISSUER_AUTH_PATH: "/authorize",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,6 +11,7 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   AUTH_PATH: "/authorize",
+  IPV_SESSION_ID: "ipv-session-id",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
   CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
   CREDENTIAL_ISSUER_AUTH_PATH: "/authorize",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added the redirect_uri to the evidence param, so that core-back is aware of it.
Generated a placeholder value for ipv-session-id, added to a session variable for future use in core-front

### Why did it change

Having the redirect_uri as part of the post would allow core-back to ensure that it's a valid and know redirect_uri
Having the ipv-session-id would ensure tying the journey between core-front and core-back 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-370](https://govukverify.atlassian.net/browse/PYI-370)

