### PR TITLE
BAU: Extract BASE_URL from the environment

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -12,6 +12,7 @@ module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   AUTH_PATH: "/authorize",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
+  BASE_URL: process.env.BASE_URL,
   CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
   CREDENTIAL_ISSUER_AUTH_PATH: "/authorize",
   CREDENTIAL_ISSUER_ID: "PassportIssuer",


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We're using the BASE_URL env variable to construct a redirect URL to
send to the credential issuer, but never actually extracting it from the
environment. This resulted in redirect URL's with `undefined` as the
host.


<!-- Describe the reason these changes were made - the "why" -->

