### PR TITLE
PYI-427: Restore test coverage

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -4,11 +4,12 @@ include:
   - "src/**/*.js"
 exclude:
   - "**/*.test.js"
+  - "src/app/debug/"
 report-dir: coverage
-statements: 10
-branches: 10
-functions: 10
-lines: 20
+statements: 70
+branches: 80
+functions: 80
+lines: 70
 watermarks:
   statements:
     - 60

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -203,6 +203,14 @@ describe("credential issuer middleware", () => {
       expect(res.status).to.be.eql(200);
     });
 
+    it("should call next", async () => {
+      axiosStub.post = sinon.fake.returns(axiosResponse);
+
+      await middleware.sendParamsToAPI(req, res, next);
+
+      expect(next).to.have.been.called;
+    });
+
     it("should send code to core backend and return with a 404 response", async () => {
       axiosResponse.status = 404;
       const axiosError = new Error("api error");

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -26,12 +26,14 @@ module.exports = {
     try {
       const response = await axios.post(`${API_BASE_URL}/ipv-session`);
       req.session.ipvSessionId = response?.data?.ipvSessionId;
-    } catch (e) {
-      next(e);
+    } catch (error) {
+      res.error = error.name;
+      return next(error);
     }
 
     next();
   },
+
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
       const oauthParams = {


### PR DESCRIPTION
## Proposed changes

### What changed

Restored test coverage minimum back to 80  - Lines/Statements set to 70 for the time being
Fixed previously skipped test to check a ipvSessionId is being returned
Added test to check that it correctly errors when ipvSessionId is not returned
Added test for redirectToDebugPage which was previously missing
Exclude coverage on the debug section

### Why did it change

This was temporarily changed when trying to wire up the credential-issuer work, we always planned to revert this back.
A few tests where also skipped in the interest of time.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-427](https://govukverify.atlassian.net/browse/PYI-427)
