### PR TITLE
PYI-536: get the cri config from core-back lambda and store in the session

### DIFF
--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -1,4 +1,20 @@
+const axios = require("axios");
+const { API_BASE_URL, API_REQUEST_CONFIG_PATH } = require("../../lib/config");
+
 module.exports = {
+  setCriConfig: async (req, res, next) =>  {
+    if (!req.session.criConfig) {
+      try {
+        const apiResponse = await axios.get(`${API_BASE_URL}${API_REQUEST_CONFIG_PATH}`);
+        req.session.criConfig = apiResponse.data;
+      } catch (error) {
+        res.error = error.name;
+        return next(error);
+      }
+    }
+    next();
+  },
+
   renderDebugPage: async (req, res) => {
     res.render("debug/debug");
   },

--- a/src/app/debug/middleware.test.js
+++ b/src/app/debug/middleware.test.js
@@ -38,7 +38,7 @@ describe("debug middleware", () => {
         axiosResponse = {
           data: [
             {
-              criId: "PassportIssuer",
+              id: "PassportIssuer",
               name: "Passport (Stub)",
               authorizeUrl: "http://passport-stub-1/authorize",
               tokenUrl: "http://passport-stub-1/token",
@@ -46,7 +46,7 @@ describe("debug middleware", () => {
               ipvClientId: "test-ipv-client"
             },
             {
-              criId: "FraudIssuer",
+              id: "FraudIssuer",
               name: "Fraud (Stub)",
               authorizeUrl: "http://fraud-stub-1/authorize",
               tokenUrl: "http://fraud-stub-1/token",
@@ -54,7 +54,7 @@ describe("debug middleware", () => {
               ipvClientId: "test-ipv-client"
             },
             {
-              criId: "AddressIssuer",
+              id: "AddressIssuer",
               name: "Address (Stub)",
               authorizeUrl: "http://address-stub-1/authorize",
               tokenUrl: "http://address-stub-1/token",
@@ -98,7 +98,7 @@ describe("debug middleware", () => {
           session: {
             criConfig: [
               {
-                criId: "PassportIssuer",
+                id: "PassportIssuer",
                 name: "Passport (Stub)",
                 authorizeUrl: "http://passport-stub-1/authorize",
                 tokenUrl: "http://passport-stub-1/token",

--- a/src/app/debug/middleware.test.js
+++ b/src/app/debug/middleware.test.js
@@ -1,0 +1,130 @@
+const proxyquire = require("proxyquire");
+
+const axiosStub = {};
+
+const configStub = {
+  API_REQUEST_CONFIG_PATH: "/request-config",
+  API_BASE_URL: "https://example.org/subpath",
+};
+
+const middleware = proxyquire("./middleware", {
+  axios: axiosStub,
+  "../../lib/config": configStub,
+});
+
+describe("debug middleware", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    res = {
+      status: sinon.fake(),
+      redirect: sinon.fake(),
+      send: sinon.fake(),
+      render: sinon.fake(),
+    };
+
+    next = sinon.fake();
+  });
+
+  describe("setCriConfig", () => {
+    let axiosResponse;
+    describe("without criConfig in current session", () => {
+      beforeEach(() => {
+        req = {
+          session: {}
+        };
+        axiosResponse = {
+          data: [
+            {
+              criId: "PassportIssuer",
+              name: "Passport (Stub)",
+              authorizeUrl: "http://passport-stub-1/authorize",
+              tokenUrl: "http://passport-stub-1/token",
+              credentialUrl: "http://passport-stub-1/credential",
+              ipvClientId: "test-ipv-client"
+            },
+            {
+              criId: "FraudIssuer",
+              name: "Fraud (Stub)",
+              authorizeUrl: "http://fraud-stub-1/authorize",
+              tokenUrl: "http://fraud-stub-1/token",
+              credentialUrl: "http://fraud-stub-1/credential",
+              ipvClientId: "test-ipv-client"
+            },
+            {
+              criId: "AddressIssuer",
+              name: "Address (Stub)",
+              authorizeUrl: "http://address-stub-1/authorize",
+              tokenUrl: "http://address-stub-1/token",
+              credentialUrl: "http://address-stub-1/credential",
+              ipvClientId: "test-ipv-client"
+            }
+          ],
+        };
+      });
+
+      context("successfully gets criConfig from core-back", () => {
+        it("should set criConfig in session", async function () {
+          axiosStub.get = sinon.fake.returns(axiosResponse);
+
+          await middleware.setCriConfig(req, res, next);
+
+          expect(req.session.criConfig).to.eq(axiosResponse.data);
+        });
+
+        it("should call next", async function () {
+          await middleware.setCriConfig(req, res, next);
+
+          expect(next).to.have.been.called;
+        });
+      });
+
+      context("failed to get criConfig from core-back", () => {
+        it("should throw error", async function () {
+          axiosStub.get = sinon.fake.throws(axiosResponse);
+
+          await middleware.setCriConfig(req, res, next);
+
+          expect(res.error).to.be.eql("Error");
+        });
+      });
+    });
+
+    describe("with criConfig already in session", () => {
+      beforeEach(() => {
+        req = {
+          session: {
+            criConfig: [
+              {
+                criId: "PassportIssuer",
+                name: "Passport (Stub)",
+                authorizeUrl: "http://passport-stub-1/authorize",
+                tokenUrl: "http://passport-stub-1/token",
+                credentialUrl: "http://passport-stub-1/credential",
+                ipvClientId: "test-ipv-client"
+              }
+            ]
+          }
+        }
+      });
+
+      it("request-config endpoint has not been called", async function () {
+        axiosStub.get = sinon.stub();
+
+        await middleware.setCriConfig(req, res, next);
+
+        expect(axiosStub.get).to.not.have.been.called;
+      })
+    });
+  });
+
+  describe("renderDebugPage", () => {
+    it("should render debug page", () => {
+      middleware.renderDebugPage(req, res);
+
+      expect(res.render).to.have.been.calledWith("debug/debug");
+    });
+  });
+});

--- a/src/app/debug/router.js
+++ b/src/app/debug/router.js
@@ -2,8 +2,8 @@ const express = require("express");
 
 const router = express.Router();
 
-const { renderDebugPage } = require("./middleware");
+const { renderDebugPage, setCriConfig} = require("./middleware");
 
-router.get("/", renderDebugPage);
+router.get("/", setCriConfig, renderDebugPage);
 
 module.exports = router;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,9 +10,10 @@ if (!appEnv.isLocal) {
 
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
+  CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
   AUTH_PATH: "/authorize",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
-  CREDENTIAL_ISSUER_BASE_URL: process.env.CREDENTIAL_ISSUER_BASE_URL,
+  API_REQUEST_CONFIG_PATH: "/request-config",
   CREDENTIAL_ISSUER_AUTH_PATH: "/authorize",
   CREDENTIAL_ISSUER_ID: "PassportIssuer",
   DCS_CREDENTIAL_ISSUER_BASE_URL: process.env.DCS_CREDENTIAL_ISSUER_BASE_URL,


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated debug middleware to retrieve the cri config from core-back and store that in the session. If the criConfig already exists in session then we don't need to retrieve it.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This config will be used to dynamically generate what links we display on the debug page in order to show all configured CRI's we have.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-536](https://govukverify.atlassian.net/browse/PYI-536)


