### PR TITLE
BAU: update yarn version to match pass buildpacks

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
 
-yarnPath: .yarn/releases/yarn-1.22.10.cjs
+yarnPath: .yarn/releases/yarn-1.22.17.cjs

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16.13.1-alpine
 ENV PORT 3000
 WORKDIR /app
-RUN yarn set version 1.22.10
+RUN yarn set version 1.22.17
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "engines": {
     "node": "16.13.1",
-    "yarn": "1.22.10"
+    "yarn": "1.22.17"
   },
   "scripts": {
     "start": "node src/app.js",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update yarn version number to use 1.22.17
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PaaS updated their buildpacks which removed 1.22.10
