### PR TITLE
PYI-555: Call backend for issued credentials and display

### DIFF
--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { API_BASE_URL, API_REQUEST_CONFIG_PATH } = require("../../lib/config");
+const { API_BASE_URL, API_REQUEST_CONFIG_PATH, API_ISSUED_CREDENTIALS_PATH } = require("../../lib/config");
 
 module.exports = {
   setCriConfig: async (req, res, next) =>  {
@@ -15,7 +15,35 @@ module.exports = {
     next();
   },
 
+  getIssuedCredentials: async (req, res, next) => {
+    try {
+      const apiResponse = await axios.get(
+        `${API_BASE_URL}${API_ISSUED_CREDENTIALS_PATH}`,
+        {
+          headers: {
+            "ipv-session-id": req.session.ipvSessionId
+          }
+        }
+      );
+
+      const parsedResponse = {};
+      for (const credential in apiResponse.data) {
+        parsedResponse[credential] = JSON.parse(apiResponse.data[credential])
+      }
+
+      req.issuedCredentials = parsedResponse;
+
+    } catch (error) {
+      res.error = error.name;
+      return next(error);
+    }
+    next();
+  },
+
   renderDebugPage: async (req, res) => {
-    res.render("debug/debug", { criConfig: req.session.criConfig });
+    res.render("debug/debug", {
+      criConfig: req.session.criConfig,
+      issuedCredentials: req.issuedCredentials
+    });
   },
 };

--- a/src/app/debug/middleware.test.js
+++ b/src/app/debug/middleware.test.js
@@ -120,6 +120,51 @@ describe("debug middleware", () => {
     });
   });
 
+  describe("getIssuedCredentials", () => {
+
+    const issuedCredentialsResponse = {
+      data: {
+        addressIssuer: '{"attributes":{"address":{"postcode":"SW1A1AA","houseNumber":10}}}',
+        passportIssuer: '{"attributes":{"names":{"givenNames":["Mary"],"familyName":"Watson"},"passportNo":"824159121","passportExpiryDate":"2030-01-01","dateOfBirth":"2021-03-01"},"gpg45Score":{"evidence":{"strength":5,"validity":3}}}',
+        fraudIssuer: '{"attributes":{"names":{"givenNames":["Mary"],"familyName":"Watson"},"someFraudAttribute":"notsurewhatthatmightbe"},"gpg45Score":{"fraud":0}}'
+      },
+    };
+
+    beforeEach(() => {
+      req = {
+        session: {}
+      };
+    });
+
+    context("successfully gets issued credentials from core-back", () => {
+      it("should set issued credentials on request in session", async function () {
+        axiosStub.get = sinon.fake.returns(issuedCredentialsResponse);
+
+        await middleware.getIssuedCredentials(req, res, next);
+
+        expect(req.issuedCredentials.addressIssuer).to.eql(JSON.parse(issuedCredentialsResponse.data.addressIssuer));
+      });
+
+      it("should call next", async function () {
+        axiosStub.get = sinon.fake.returns(issuedCredentialsResponse);
+
+        await middleware.getIssuedCredentials(req, res, next);
+
+        expect(next).to.have.been.calledOnceWith();
+      });
+    });
+
+    context("failed to get issued credentials from core-back", () => {
+      it("should throw error", async function () {
+        axiosStub.get = sinon.fake.throws("Something bad happened...");
+
+        await middleware.getIssuedCredentials(req, res, next);
+
+        expect(res.error).to.be.eql("Error");
+      });
+    });
+  })
+
   describe("renderDebugPage", () => {
     it("should render debug page", () => {
       middleware.renderDebugPage(req, res);

--- a/src/app/debug/router.js
+++ b/src/app/debug/router.js
@@ -2,8 +2,8 @@ const express = require("express");
 
 const router = express.Router();
 
-const { renderDebugPage, setCriConfig} = require("./middleware");
+const { getIssuedCredentials, renderDebugPage, setCriConfig} = require("./middleware");
 
-router.get("/", setCriConfig, renderDebugPage);
+router.get("/", setCriConfig, getIssuedCredentials, renderDebugPage);
 
 module.exports = router;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,9 +10,10 @@ if (!appEnv.isLocal) {
 
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
-  AUTH_PATH: "/authorize",
-  API_REQUEST_EVIDENCE_PATH: "/request-evidence",
+  API_ISSUED_CREDENTIALS_PATH: "/issued-credentials",
   API_REQUEST_CONFIG_PATH: "/request-config",
+  API_REQUEST_EVIDENCE_PATH: "/request-evidence",
+  AUTH_PATH: "/authorize",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/views/debug/debug.html
+++ b/src/views/debug/debug.html
@@ -15,24 +15,45 @@
 {% endblock %}
 
 {% block main %}
-  {% macro criDisplay(data) %}
-    {% for cri in data %}
+  {% macro criDisplay(cris, issuedCredentials) %}
+    {% for cri in cris %}
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             <a class="govuk-heading-s" href="/credential-issuer/authorize?id={{ cri.id }}">{{cri.name}}</a>
           </dt>
+          {% if issuedCredentials[cri.id] %}
+            {% set issuedCredential = issuedCredentials[cri.id] %}
+            <dd class="govuk-summary-list__value">
+              <h3 class="govuk-heading-s">GPG45 Score</h3>
+
+              {% if issuedCredential.gpg45Score %}
+                <pre>{{ issuedCredential.gpg45Score | dump(2) }}</pre>
+              {% else %}
+                <p class="govuk-body">No GPG45 score found for this issued credential.<p class="govuk-body">
+              {% endif %}
+
+              <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">Credential attributes</span>
+                </summary>
+                <div class="govuk-details__text">
+                  <pre>{{ issuedCredential.attributes | dump(2) }}</pre>
+                </div>
+              </details>
+            </dd>
+          {% endif %}
         </div>
       </dl>
     {% endfor %}
   {% endmacro %}
-  
+
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-xl">di-ipv-core-front</h1>
-          {{ criDisplay(criConfig) }}        
+          {{ criDisplay(criConfig, issuedCredentials) }}
           <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Show the issued credentials for each CRI on the debug page. This will
call the backend every time a user hits the debug page; there may be
something better we can do with caching. This will work as a first pass
though.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-555](https://govukverify.atlassian.net/browse/PYI-555)

### Screenshot
![Screenshot 2022-01-20 at 16 24 40](https://user-images.githubusercontent.com/13836290/150391278-b5410c04-6fc1-411a-91e5-bc4fbb4e368d.png)

