### PR TITLE
PYI-518: Provide shared attributes to the credential issuers

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -19,10 +19,17 @@ module.exports = {
       );
 
       const jwt = apiResponse?.jwt;    //will need to be confirmed
+      const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
       if (!jwt) {
         res.status(500);
-        return res.send("Missing jwt");
+        return res.send("Missing JWT");
+      } else if (jwt.length > 6000) { // this figure can be changed
+        res.status(500);
+        return res.send("JWT exceeds maximum limit");
+      } else if (!base64regex.test(jwt)) { 
+        res.status(500);
+        return res.send("Invalid base64 encoded JWT");
       }
 
       req.session.jwt = jwt;

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -4,13 +4,14 @@ const router = express.Router();
 
 const {
   addCallbackParamsToRequest,
+  getJwt,
   buildCredentialIssuerRedirectURL,
   redirectToAuthorize,
   redirectToDebugPage,
   sendParamsToAPI,
 } = require("./middleware");
 
-router.get("/authorize", buildCredentialIssuerRedirectURL, redirectToAuthorize);
+router.get("/authorize", getJwt, buildCredentialIssuerRedirectURL, redirectToAuthorize);
 router.get(
   "/callback",
   addCallbackParamsToRequest,

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -4,14 +4,14 @@ const router = express.Router();
 
 const {
   addCallbackParamsToRequest,
-  getJwt,
+  getSharedAttributesJwt,
   buildCredentialIssuerRedirectURL,
   redirectToAuthorize,
   redirectToDebugPage,
   sendParamsToAPI,
 } = require("./middleware");
 
-router.get("/authorize", getJwt, buildCredentialIssuerRedirectURL, redirectToAuthorize);
+router.get("/authorize", getSharedAttributesJwt, buildCredentialIssuerRedirectURL, redirectToAuthorize);
 router.get(
   "/callback",
   addCallbackParamsToRequest,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,11 +11,12 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_ISSUED_CREDENTIALS_PATH: "/issued-credentials",
-  API_ISSUED_JWT_PATH: "/issued-jwt",   //will need to be confirmed
+  API_SHARED_ATTRIBUTES_JWT_PATH: "/shared-attributes",
   API_REQUEST_CONFIG_PATH: "/request-config",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
   AUTH_PATH: "/authorize",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,
+  SHARED_ATTRIBUTES_JWT_SIZE_LIMIT: process.env.SHARED_ATTRIBUTES_JWT_SIZE_LIMIT || 6000,
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,6 +11,7 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_ISSUED_CREDENTIALS_PATH: "/issued-credentials",
+  API_ISSUED_JWT_PATH: "/issued-jwt",   //will need to be confirmed
   API_REQUEST_CONFIG_PATH: "/request-config",
   API_REQUEST_EVIDENCE_PATH: "/request-evidence",
   AUTH_PATH: "/authorize",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make a call to core-back to retrieve the JWT
Store JWT in session and send it as part of the auth request to the CRI's

Added testing
Using Regex to check that the jwt is base64 encoded
Raising an error if JWT is missing, is over 6000 characters and if is not valid base64 encoded

### Why did it change

When a user is redirected to a frontend CRI, the shared attribute set should be included, encoded in a JWT in the authorization request.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-518](https://govukverify.atlassian.net/browse/PYI-518)

