### PR TITLE
PYI-555: Fix the rendering of an empty gpg45 score object

### DIFF
--- a/src/views/debug/debug.html
+++ b/src/views/debug/debug.html
@@ -27,7 +27,7 @@
             <dd class="govuk-summary-list__value">
               <h3 class="govuk-heading-s">GPG45 Score</h3>
 
-              {% if issuedCredential.gpg45Score %}
+              {% if issuedCredential.gpg45Score|length %}
                 <pre>{{ issuedCredential.gpg45Score | dump(2) }}</pre>
               {% else %}
                 <p class="govuk-body">No GPG45 score found for this issued credential.<p class="govuk-body">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Check if gpg45Score is an empty object when deciding how to render gpg45Score property
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Was previously rendering "{}" instead of the NoGPG45 score found message, the additional check will now ensure we check the objects length as well.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-555](https://govukverify.atlassian.net/browse/PYI-555)
