### PR TITLE
PYI-677 Add environment name to app name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 applications:
-  - name: di-ipv-core-front
+  - name: ((environment))-di-ipv-core-front
     memory: 256M
     buildpack: nodejs_buildpack
     command: yarn start
+    env:
+      API_BASE_URL: https://((api-gateway-id)).execute-api.eu-west-2.amazonaws.com/dev
+      EXTERNAL_WEBSITE_HOST: https://((environment))-di-ipv-core-front.london.cloudapps.digital
+


### PR DESCRIPTION
To enable multiple environments we need to add the environment name
to the app name since app names and their routs need to be unique on
PaaS.

This also adds two environment variables which have been set on the app
but had not been added to the manifest.

### Issue tracking
- [PYI-677](https://govukverify.atlassian.net/browse/PYI-677)

## Checklists

### Environment variables or secrets
The app was already using these variable they just hadn't been added to the manifest.

