### PR TITLE
PYI-725: Fix express async error bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "copyfiles": "2.4.1",
     "dotenv": "^10.0.0",
     "express": "4.17.1",
+    "express-async-errors": "^3.1.1",
     "govuk-frontend": "3.14.0",
     "hmpo-app": "1.0.2",
     "hmpo-components": "4.6.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,6 @@
+require("express");
+require("express-async-errors");
+
 const { PORT, SESSION_SECRET } = require("./lib/config");
 const { setup } = require("hmpo-app");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,6 +1364,11 @@ execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+express-async-errors@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
+  integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
+
 express-session@^1.17.0:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.2.tgz#397020374f9bf7997f891b85ea338767b30d0efd"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Express by default does not always handle async/await errors, resulting
in an unhandled error and a crashed server.

This fix uses the express-async-errors library to monkepatch the Express
framework to handle the errors.

**This is the same implementation that the kbv team use on their front-end apps.**

I've tested this on passport-front by sending an incorrect post request to the /oauth2/authorize endpoint. Without this fix the app crashes, but with it the app keeps running and returns the something went wrong error page.


- [PYI-725](https://govukverify.atlassian.net/browse/PYI-725)