### PR TITLE
PYI-770 handle page event

### DIFF
--- a/src/app/journey/middleware.js
+++ b/src/app/journey/middleware.js
@@ -45,13 +45,15 @@ module.exports = {
       const {pageId} = req.query;
       switch (pageId) {
         case 'transition':
-        return res.render('journey/transition', {message: 'You are about to be transitioned'})
+          return res.render('journey/transition', {message: 'You are about to be transitioned'})
+        default:
+          return res.render(`journey/${pageId}`);
       }
     }catch (error) {
       res.error = error.name;
-      return next(error);
+      res.status(500);
+      next(error);
     }
-    next()
   }
 };
 

--- a/src/app/journey/middleware.js
+++ b/src/app/journey/middleware.js
@@ -45,7 +45,7 @@ module.exports = {
       const {pageId} = req.query;
       switch (pageId) {
         case 'transition':
-        return res.render('journey/transition')
+        return res.render('journey/transition', {message: 'You are about to be transitioned'})
       }
     }catch (error) {
       res.error = error.name;

--- a/src/app/journey/middleware.js
+++ b/src/app/journey/middleware.js
@@ -3,9 +3,13 @@ const {
   API_BASE_URL
 } = require("../../lib/config");
 
+
 async function journeyApi(action, ipvSessionId) {
+  if(action.startsWith('/')){
+    action = action.substr(1);
+  }
   return await axios.post(
-    `${API_BASE_URL}/journey${action}`,
+    `${API_BASE_URL}/journey/${action}`,
     {
       headers: {
         "ipv-session-id": ipvSessionId
@@ -22,7 +26,7 @@ async function handleJourneyResponse(action, res, ipvSessionId) {
     return;
   }
   if (response?.data?.page?.type) {
-    return res.redirect(`${response?.data?.page?.type}`);
+    return res.redirect(`/journey/journeyPage?pageId=${response?.data?.page?.type}`);
   }
 }
 
@@ -35,6 +39,19 @@ module.exports = {
     }
 
     next();
+  },
+  handleJourneyPage: async (req, res, next) => {
+    try {
+      const {pageId} = req.query;
+      switch (pageId) {
+        case 'transition':
+        return res.render('journey/transition')
+      }
+    }catch (error) {
+      res.error = error.name;
+      return next(error);
+    }
+    next()
   }
 };
 

--- a/src/app/journey/middleware.test.js
+++ b/src/app/journey/middleware.test.js
@@ -71,4 +71,45 @@ describe("journey", () => {
       expect(axiosStub.post.getCall(2)).to.have.been.calledWith(`${configStub.API_BASE_URL}/journey/startCri`);
     });
   });
+
+  context('Calling JourneyPage', () => {
+    const axiosStub = {};
+    const configStub = {
+      API_BASE_URL: "https://example.org/subpath",
+    };
+
+    const middleware = proxyquire("./middleware", {
+      axios: axiosStub,
+      "../../lib/config": configStub,
+    });
+
+
+
+    describe("renderJourneyPage", () => {
+      it("should render transition page", async () => {
+
+        req = {
+          query: {pageId: 'transition'},
+          baseURL: "/journey/journeyPage",
+          session: { ipvSessionId: "ipv-session-id" },
+        };
+
+        await middleware.handleJourneyPage(req, res);
+
+        expect(res.render).to.have.been.calledWith("journey/transition");
+      });
+
+      it("on error", async () => {
+        req = {
+          baseURL: "/journey/journeyPage",
+          session: { ipvSessionId: "ipv-session-id" },
+        };
+
+        await middleware.handleJourneyPage(req, res, next);
+        expect(res.status).to.have.been.calledWith(500);
+      });
+    });
+
+
+  })
 });

--- a/src/app/journey/middleware.test.js
+++ b/src/app/journey/middleware.test.js
@@ -22,19 +22,20 @@ describe("journey", () => {
 
   context("From a sequence of events that ends with a page response", () => {
 
+    const pageType = 'pageTransition';
     const eventResponses = [
       {
-        data: { redirect: { event: "/next" } }
+        data: { redirect: { event: "next" } }
       },
       {
-        data: { redirect: { event: "/startCri" } }
+        data: { redirect: { event: "startCri" } }
       },
       {
-        data: { page: { type: "/journeyTransition" } }
+        data: { page: { type: pageType } }
       }
     ];
 
-    let axiosStub = {};
+    const axiosStub = {};
     const configStub = {
       API_BASE_URL: "https://example.org/subpath",
     };
@@ -58,9 +59,9 @@ describe("journey", () => {
       };
     });
 
-    it("should redirect to journey transition page", async function() {
+    it("should redirect to journey transition page with message in query string", async function() {
       await middleware.updateJourneyState(req, res, next);
-      expect(res.redirect).to.have.been.calledWith("/journeyTransition");
+      expect(res.redirect).to.have.been.calledWith(`/journey/journeyPage?pageId=${pageType}`);
     });
 
     it("should have called the network in the correct sequence", async function() {

--- a/src/app/journey/router.js
+++ b/src/app/journey/router.js
@@ -2,8 +2,10 @@ const express = require("express");
 
 const router = express.Router();
 
-const { updateJourneyState } = require("./middleware");
+const { updateJourneyState, handleJourneyPage } = require("./middleware");
 
+router.get("/journeyPage", handleJourneyPage)
 router.get("/", updateJourneyState);
+
 
 module.exports = router;

--- a/src/views/journey/transition.html
+++ b/src/views/journey/transition.html
@@ -1,0 +1,39 @@
+{% extends "govuk/template.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %} {{ title }} – Example – GOV.UK Design System {% endblock %}
+
+{% block head %}
+<meta name="robots" content="noindex, nofollow">
+<link href="/public/stylesheets/application.css" rel="stylesheet" media="all" />
+{% endblock %}
+
+{% block header %}
+{{ govukHeader({
+homepageUrl: "https://www.gov.uk"
+}) }}
+{% endblock %}
+
+
+{% block main %}
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Transition page</h1>
+
+        <h2>{{message}}</h2>
+
+      </div>
+    </div>
+  </main>
+</div>
+
+
+
+
+{% endblock %}
+
+{% block bodyEnd %}
+{% endblock %}


### PR DESCRIPTION
## Proposed changes
Modify Generic Journey method to handle page events

### What changed
When we receive a page event , we redirect to a journeyPage route passing in the event as a query param.

### Why did it change
Allows the front end to decide what to do with the event type and display screens accordingly without having to make changes to the generic journey method code when new pages are required.

### Issue tracking


- [PYI-770](https://govukverify.atlassian.net/browse/PYI-770)
- [PYI-771](https://govukverify.atlassian.net/browse/PYI-771)
- [PYI-772](https://govukverify.atlassian.net/browse/PYI-772)


