### PR TITLE
PYI-773: Create multiple transition pages

### DIFF
--- a/src/app/journey/middleware.js
+++ b/src/app/journey/middleware.js
@@ -8,7 +8,8 @@ async function journeyApi(action, ipvSessionId) {
   if(action.startsWith('/')){
     action = action.substr(1);
   }
-  return await axios.post(
+
+  return axios.post(
     `${API_BASE_URL}/journey/${action}`,
     {
       headers: {
@@ -17,7 +18,6 @@ async function journeyApi(action, ipvSessionId) {
     }
   );
 }
-
 
 async function handleJourneyResponse(action, res, ipvSessionId) {
   const response = await journeyApi(action, ipvSessionId);
@@ -45,16 +45,14 @@ module.exports = {
       const {pageId} = req.query;
       switch (pageId) {
         case 'transition':
-          return res.render('journey/transition', {message: 'You are about to be transitioned'})
+          return res.render('journey/transition')
         default:
           return res.render(`journey/${pageId}`);
       }
-    }catch (error) {
+    } catch (error) {
       res.error = error.name;
       res.status(500);
       next(error);
     }
   }
 };
-
-

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,2 +1,16 @@
 index:
   title: di-ipv-core-front
+
+pageIpvStart:
+  title: Start page
+  content:
+    - "Example content - This is the first transition page a user will see"
+
+pageIpvError:
+  title: Error page
+
+pageCriTransition:
+  title: CRI Transition page
+
+pageIpvEnd:
+  title: End page

--- a/src/views/journey/page-cri-transition.html
+++ b/src/views/journey/page-cri-transition.html
@@ -1,0 +1,2 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pageCriTransition" %}

--- a/src/views/journey/page-ipv-end.html
+++ b/src/views/journey/page-ipv-end.html
@@ -1,0 +1,2 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pageIpvEnd" %}

--- a/src/views/journey/page-ipv-error.html
+++ b/src/views/journey/page-ipv-error.html
@@ -1,0 +1,2 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pageIpvError" %}

--- a/src/views/journey/page-ipv-start.html
+++ b/src/views/journey/page-ipv-start.html
@@ -1,0 +1,2 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pageIpvStart" %}

--- a/src/views/journey/transition.html
+++ b/src/views/journey/transition.html
@@ -14,7 +14,6 @@ homepageUrl: "https://www.gov.uk"
 }) }}
 {% endblock %}
 
-
 {% block main %}
 
 <div class="govuk-width-container">
@@ -22,16 +21,10 @@ homepageUrl: "https://www.gov.uk"
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Transition page</h1>
-
-        <h2>{{message}}</h2>
-
       </div>
     </div>
   </main>
 </div>
-
-
-
 
 {% endblock %}
 


### PR DESCRIPTION
## Proposed changes

### What changed

Create pages with the following pageIds: `page-ipv-start` `page-cri-transition` `page-ipv-error` `page-ipv-end`
Using the pages.yml to populate the pages with text
Refactor and clean up some tests

### Why did it change

This is to show we can handle different pageIds and we can display the correct pages to the user

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-773](https://govukverify.atlassian.net/browse/PYI-773)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
