### PR TITLE
PYI-776: Update router to handle the new callback

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -91,7 +91,8 @@ module.exports = {
         config
       );
       res.status = apiResponse?.status;
-      next();
+
+      res.redirect("/journey/next")
     } catch (error) {
       if (error?.response?.status == 404) {
         res.status = error.response.status;

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -323,6 +323,7 @@ describe("credential issuer middleware", () => {
       };
       res = {
         status: sinon.fake(),
+        redirect: sinon.fake(),
       };
       next = sinon.fake();
       axiosResponse = {
@@ -365,12 +366,12 @@ describe("credential issuer middleware", () => {
       expect(res.status).to.be.eql(200);
     });
 
-    it("should call next", async () => {
+    it("should call /journey/next", async () => {
       axiosStub.post = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(next).to.have.been.called;
+      expect(res.redirect).to.have.been.calledWith("/journey/next");
     });
 
     it("should send code to core backend and return with a 404 response", async () => {

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -7,7 +7,6 @@ const {
   getSharedAttributesJwt,
   buildCredentialIssuerRedirectURL,
   redirectToAuthorize,
-  redirectToDebugPage,
   sendParamsToAPI,
 } = require("./middleware");
 
@@ -15,8 +14,7 @@ router.get("/authorize", getSharedAttributesJwt, buildCredentialIssuerRedirectUR
 router.get(
   "/callback",
   addCallbackParamsToRequest,
-  sendParamsToAPI,
-  redirectToDebugPage
+  sendParamsToAPI
 );
 
 module.exports = router;


### PR DESCRIPTION
## Proposed changes

### What changed

Instead of being redirected to debug page we now redirect to journey/next
For now we are manually hard coding journey/next until we can properly see the reponse we get back from the sendParamsToAPI

### Why did it change

Once the user has completed filling out details on the cri and then clicked the button to return to the core-front a call will be made to /event/cri/return. This call will loop back to the beginning of the flow by calling journey/next

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-776](https://govukverify.atlassian.net/browse/PYI-776)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

