### PR TITLE
BAU: Clean up unused calls to debug

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -46,10 +46,4 @@ module.exports = {
       next(error);
     }
   },
-  redirectToAuthorize: async (req, res) => {
-    res.redirect(req.redirectURL);
-  },
-  redirectToDebugPage: async (req, res) => {
-    res.redirect("/debug/");
-  },
 };

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -2,32 +2,6 @@ const { expect } = require("chai");
 const proxyquire = require("proxyquire");
 
 describe("credential issuer middleware", () => {
-  describe("redirectToAuthorize", () => {
-    let req;
-    let res;
-    let configStub;
-
-    beforeEach(() => {
-      req = {
-        redirectURL: "http://the.credentialissuer.authorize.url",
-      };
-      res = {
-        redirect: sinon.fake(),
-        send: sinon.fake(),
-      };
-      configStub = {};
-    });
-    it("should successfully be redirected", async function () {
-      const { redirectToAuthorize } = proxyquire("./middleware", {
-        "../../lib/config": configStub,
-      });
-
-      await redirectToAuthorize(req, res);
-
-      expect(res.redirect).to.have.been.calledWith(req.redirectURL);
-    });
-  });
-
   describe("addCallbackParamsToRequest", () => {
     let req;
     let res;
@@ -62,29 +36,6 @@ describe("credential issuer middleware", () => {
       await addCallbackParamsToRequest(req, res, next);
 
       expect(next).to.have.been.called;
-    });
-  });
-
-  describe("renderDebugPage", () => {
-    let req;
-    let res;
-    let configStub;
-
-    beforeEach(() => {
-      res = {
-        redirect: sinon.fake(),
-      };
-      configStub = {};
-    });
-
-    it("should redirectToDebugPage", () => {
-      const { redirectToDebugPage } = proxyquire("./middleware", {
-        "../../lib/config": configStub,
-      });
-
-      redirectToDebugPage(req, res);
-
-      expect(res.redirect).to.have.been.calledWith("/debug/");
     });
   });
 

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -4,11 +4,10 @@ const router = express.Router();
 
 const {
   addCallbackParamsToRequest,
-  redirectToAuthorize,
   sendParamsToAPI,
 } = require("./middleware");
 
-const { buildCredentialIssuerRedirectURL } = require('../shared/criHelper');
+const { buildCredentialIssuerRedirectURL, redirectToAuthorize } = require('../shared/criHelper');
 const { getSharedAttributesJwt } = require('../shared/sharedAttributeHelper');
 
 router.get("/authorize", getSharedAttributesJwt, buildCredentialIssuerRedirectURL, redirectToAuthorize);

--- a/src/app/journey/middleware.js
+++ b/src/app/journey/middleware.js
@@ -3,7 +3,7 @@ const {
   API_BASE_URL
 } = require("../../lib/config");
 const { getSharedAttributesJwt } = require("../shared/sharedAttributeHelper");
-const { buildCredentialIssuerRedirectURL } = require("../shared/criHelper");
+const { buildCredentialIssuerRedirectURL, redirectToAuthorize } = require("../shared/criHelper");
 
 async function journeyApi(action, ipvSessionId) {
   if(action.startsWith('/')){
@@ -36,7 +36,7 @@ async function handleJourneyResponse(req, res, action) {
       await getSharedAttributesJwt(req, res);
       req.cri = response?.data?.redirect?.cri;
       await buildCredentialIssuerRedirectURL(req, res)
-      return res.redirect(req.redirectURL);
+      return redirectToAuthorize(req, res);
     }
     return;
   }

--- a/src/app/journey/middleware.test.js
+++ b/src/app/journey/middleware.test.js
@@ -31,9 +31,6 @@ describe("journey middleware", () => {
     "../shared/../shared/criHelper": sharedCriHelper,
   });
 
-
-
-
   beforeEach(() => {
     res = {
       status: sinon.fake(),

--- a/src/app/journey/router.js
+++ b/src/app/journey/router.js
@@ -7,5 +7,4 @@ const { updateJourneyState, handleJourneyPage } = require("./middleware");
 router.get("/journeyPage", handleJourneyPage)
 router.get("/", updateJourneyState);
 
-
 module.exports = router;

--- a/src/app/shared/criHelper.js
+++ b/src/app/shared/criHelper.js
@@ -20,7 +20,7 @@ module.exports = {
       next();
     }
   },
-    redirectToAuthorize: async (req, res) => {
+  redirectToAuthorize: async (req, res) => {
     res.redirect(req.redirectURL);
   }
 }

--- a/src/app/shared/criHelper.test.js
+++ b/src/app/shared/criHelper.test.js
@@ -77,4 +77,30 @@ describe("cri Helper", () => {
       });
     });
   });
+
+  describe("redirectToAuthorize", () => {
+    let req;
+    let res;
+    let configStub;
+
+    beforeEach(() => {
+      req = {
+        redirectURL: "http://the.credentialissuer.authorize.url",
+      };
+      res = {
+        redirect: sinon.fake(),
+        send: sinon.fake(),
+      };
+      configStub = {};
+    });
+    it("should successfully be redirected", async function () {
+      const { redirectToAuthorize } = proxyquire("../shared/criHelper", {
+        "../../lib/config": configStub,
+      });
+  
+      await redirectToAuthorize(req, res);
+
+      expect(res.redirect).to.have.been.calledWith(req.redirectURL);
+    });
+  });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

We no longer need to render the debug page from the credential issuers
This means we can also remove the tests for rendering that debug page
Use the redirectToAuthorize method thats in the helper
Fix some spacing
Move the tests for redirectToAuthorize in the shared criHelperTests
