### PR TITLE
PYIC-452: Pass the orc oauth params along with the back-end session start request

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -2,18 +2,6 @@ const axios = require("axios");
 const { API_BASE_URL, AUTH_PATH } = require("../../lib/config");
 
 module.exports = {
-  addAuthParamsToSession: async (req, res, next) => {
-    const authParams = {
-      response_type: req.query.response_type,
-      client_id: req.query.client_id,
-      state: req.query.state,
-      redirect_uri: req.query.redirect_uri,
-    };
-
-    req.session.authParams = authParams;
-
-    next();
-  },
   renderOauthPage: async (req, res) => {
     res.render("index-hmpo");
   },
@@ -28,7 +16,15 @@ module.exports = {
 
   setIpvSessionId: async (req, res, next) => {
     try {
-      const response = await axios.post(`${API_BASE_URL}/session/start`);
+      const authParams = {
+        responseType: req.query.response_type,
+        clientId: req.query.client_id,
+        redirectUri: req.query.redirect_uri,
+        state: req.query.state,
+        scope: req.query.scope
+      };
+
+      const response = await axios.post(`${API_BASE_URL}/session/start`, authParams);
       req.session.ipvSessionId = response?.data?.ipvSessionId;
     } catch (error) {
       res.error = error.name;

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -26,7 +26,9 @@ describe("oauth middleware", () => {
     next = sinon.fake();
   });
 
-  describe("addAuthParamsToSession", () => {
+  describe("setIpvSessionId", () => {
+    let axiosResponse;
+
     beforeEach(() => {
       req = {
         query: {
@@ -36,33 +38,6 @@ describe("oauth middleware", () => {
           redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
           unusedParam: "not used",
         },
-        session: {},
-      };
-    });
-
-    it("should save authParams to session", async function () {
-      await middleware.addAuthParamsToSession(req, res, next);
-
-      expect(req.session.authParams).to.deep.equal({
-        response_type: req.query.response_type,
-        client_id: req.query.client_id,
-        state: req.query.state,
-        redirect_uri: req.query.redirect_uri,
-      });
-    });
-
-    it("should call next", async function () {
-      await middleware.addAuthParamsToSession(req, res, next);
-
-      expect(next).to.have.been.called;
-    });
-  });
-
-  describe("setIpvSessionId", () => {
-    let axiosResponse;
-
-    beforeEach(() => {
-      req = {
         session: {
           ipvSessionId: {},
         }

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -3,7 +3,6 @@ const express = require("express");
 const router = express.Router();
 
 const {
-  addAuthParamsToSession,
   redirectToCallback,
   redirectToDebugPage,
   redirectToJourney,
@@ -13,7 +12,6 @@ const {
 
 router.get(
   "/debug-authorize",
-  addAuthParamsToSession,
   setIpvSessionId,
   redirectToDebugPage
 );


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Pass the orc oauth clients in with the back-end start session POST request instead of storing them within the front-end session.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These details now need to be stored within the back-end session so that they can be returned during the session/end endpoint.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-452](https://govukverify.atlassian.net/browse/PYIC-452)

