### PR TITLE
PYIC-795: Pass details of what journey type is being run to the /sess…

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -14,6 +14,16 @@ module.exports = {
     res.redirect("/journey/next");
   },
 
+  setDebugJourneyType: (req, res, next) => {
+    req.session.isDebugJourney = true;
+    next();
+  },
+
+  setRealJourneyType: (req, res, next) => {
+    req.session.isDebugJourney = false;
+    next();
+  },
+
   setIpvSessionId: async (req, res, next) => {
     try {
       const authParams = {
@@ -21,7 +31,8 @@ module.exports = {
         clientId: req.query.client_id,
         redirectUri: req.query.redirect_uri,
         state: req.query.state,
-        scope: req.query.scope
+        scope: req.query.scope,
+        isDebugJourney: req.session.isDebugJourney,
       };
 
       const response = await axios.post(`${API_BASE_URL}/session/start`, authParams);

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -16,6 +16,10 @@ describe("oauth middleware", () => {
   let next;
 
   beforeEach(() => {
+    req = {
+      session: {}
+    };
+
     res = {
       status: sinon.fake(),
       redirect: sinon.fake(),
@@ -24,6 +28,22 @@ describe("oauth middleware", () => {
     };
 
     next = sinon.fake();
+  });
+
+  describe("setDebugJourneyType", () => {
+    it("should set isDebugJourney to true in session", () => {
+      middleware.setDebugJourneyType(req, res, next);
+
+      expect(req.session.isDebugJourney).to.eq(true);
+    });
+  });
+
+  describe("setRealJourneyType", () => {
+    it("should set isDebugJourney to false in session", () => {
+      middleware.setRealJourneyType(req, res, next);
+
+      expect(req.session.isDebugJourney).to.eq(false);
+    });
   });
 
   describe("setIpvSessionId", () => {

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -7,17 +7,19 @@ const {
   redirectToDebugPage,
   redirectToJourney,
   retrieveAuthorizationCode,
-  setIpvSessionId,
+  setIpvSessionId, setDebugJourneyType, setRealJourneyType,
 } = require("./middleware");
 
 router.get(
   "/debug-authorize",
+  setDebugJourneyType,
   setIpvSessionId,
   redirectToDebugPage
 );
 
 router.get(
   "/authorize",
+  setRealJourneyType,
   setIpvSessionId,
   redirectToJourney
 );


### PR DESCRIPTION
…ion/start endpoint

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add middlware to set the journey type being run in the front-end session and then use that value to pass it along to the back-end through the /session/start endpoint in order to correctly configure the starting user state.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
When running a debug journey the user state will need to be DEBUG_PAGE, so when we create a new back-end session we need to pass in details of what kind of journey is being run.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-795](https://govukverify.atlassian.net/browse/PYIC-795)

