### PR TITLE
BAU: Update CRI error path

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -52,7 +52,7 @@ module.exports = {
           ["error_description", error_description],
         ]);
 
-        await axios.post(`${API_BASE_URL}/event/cri/error`, errorParams, generateAxiosConfig(req.session.ipvSessionId))
+        await axios.post(`${API_BASE_URL}/journey/cri/error`, errorParams, generateAxiosConfig(req.session.ipvSessionId))
         return res.render("errors/credential-issuer", {error, error_description})
       }
     } catch (error) {

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -181,7 +181,7 @@ describe("credential issuer middleware", () => {
       await middleware.tryHandleRedirectError(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        `${configStub.API_BASE_URL}/event/cri/error`,
+        `${configStub.API_BASE_URL}/journey/cri/error`,
         errorParams,
         sinon.match({
           headers: {


### PR DESCRIPTION
### Why did it change

The backend is configured to receive errors at `/journey/cri/error`, not
`/event/cri/error`
