### PR TITLE
BAU: Remove redirect_uri param from CRI return request

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -2,7 +2,6 @@ const axios = require("axios");
 const {
   API_BASE_URL,
   API_CRI_RETURN_PATH,
-  EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
 const { generateAxiosConfig } = require("../shared/axiosHelper");
 
@@ -21,7 +20,6 @@ module.exports = {
     const evidenceParam = new URLSearchParams([
       ["authorization_code", req.credentialIssuer.code],
       ["credential_issuer_id", req.query.id],
-      ["redirect_uri", `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback?id=${req.query.id}`],
     ]);
 
 

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -81,7 +81,6 @@ describe("credential issuer middleware", () => {
         const searchParams = new URLSearchParams([
           ["authorization_code", req.credentialIssuer.code],
           ["credential_issuer_id", req.query.id],
-          ["redirect_uri", `http://example.com/credential-issuer/callback?id=${req.query.id}`],
         ]);
 
         await middleware.sendParamsToAPI(req, res, next);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Why did it change

The redirect URI was being included as a param to the CRI return lambda.
That lambda exchanges the auth code for a token and then uses it to
fetch the VC from the CRI - the redirect URI is not used for these
operations.


