### PR TITLE
BAU: Update signed JWT base64 regex 

### DIFF
--- a/src/app/shared/sharedAttributeHelper.js
+++ b/src/app/shared/sharedAttributeHelper.js
@@ -18,7 +18,7 @@ module.exports = {
       );
 
       const sharedAttributesJwt = apiResponse?.data;
-      const base64regex = /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/;
+      const base64regex = /^([A-Za-z0-9-_=]+\.){2}([A-Za-z0-9-_=]+)$/;
 
       if (!sharedAttributesJwt) {
         res.status(500);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Why did it change

The previous version of the base64 regex was being flagged by Sonarcloud
as being [susceptible to DOS due to backtracking](https://sonarcloud.io/project/security_hotspots?id=alphagov_di-ipv-core-front&pullRequest=97&resolved=false&types=SECURITY_HOTSPOT). Whilst we control the
input to this regex so this shouldn't be too much of a concern, it would
be good to clear this up just in case we fall foul of it
unintentionally.

This version checks that we have three groups of base64url characters (+
and / have been replaced with - and _). The first two groups must be
suffixed with a `.`. The shared attribute JWTs we're returning from
core-back should never deviate from this pattern.
