### PR TITLE
PYIC-875: Return state in auth response

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -33,8 +33,12 @@ async function handleJourneyResponse(req, res, action) {
   }
 
   if(response?.client && tryValidateClientResponse(response.client)) {
-    const { redirectUrl, authCode} = response.client;
-    return res.redirect(`${redirectUrl}?code=${authCode}`);
+    const { redirectUrl, authCode, state} = response.client;
+    let redirectWithQueryParams = `${redirectUrl}?code=${authCode}`
+    if (response.client.state) {
+      redirectWithQueryParams += `&state=${state}`
+    }
+    return res.redirect(redirectWithQueryParams);
   }
 
   if (response?.page) {
@@ -54,11 +58,11 @@ function tryValidateClientResponse(client) {
   const { redirectUrl, authCode} = client;
 
   if(!redirectUrl) {
-    throw new Error(`Client Response Redirect url is missing`)
+    throw new Error(`Client Response redirect url is missing`)
   }
 
   if(!authCode) {
-    throw new Error(`Client Response Authcode is missing is missing`)
+    throw new Error(`Client Response authcode is missing`)
   }
 
   return true;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Why did it change

The Oauth spec states that if a value for state is sent in the
authentication request, we should return in in the response. See here:
https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2

Core-back has been updated to return the state value supplied in the
auth request. The state value is not mandatory so may not appear in the
client data received from core-back. This change will add it as a query
param to the redirect URL if it's provided.

The auth teams client validates that the state received in the response
is the same as that sent in the initial auth request. We need to return
it to allow this to happen.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-875](https://govukverify.atlassian.net/browse/PYIC-875)
