### PR TITLE
PYIC-27: Add a dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+    - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x","18.x"]
+    commit-message:
+      prefix: BAU
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+    - dependabot
+    commit-message:
+      prefix: BAU


### PR DESCRIPTION
## Proposed changes

### What changed

Add a dependabot config file. Copied from kbv front as a first iteration.

### Why did it change

We want to have dependabot help us keep our dependencies up to date
