### PR TITLE
PYI 1014 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:16.13.1-alpine3.15@sha256:a7cab437ba7f3cd405cf6d6446a0e944aabd7d5c4573fc24f93ab85cbc0f0a70 AS builder
+
+WORKDIR /app
+RUN [ "yarn", "set", "version", "1.22.17" ]
+COPY /src ./src
+COPY package.json ./
+COPY yarn.lock ./
+
+RUN yarn install
+RUN yarn build
+
+# 'yarn install --production' does not prune test packages which are necessary
+# to build the app. So delete nod_modules and reinstall only production packages.
+RUN [ "rm", "-rf", "node_modules" ]
+RUN yarn install --production
+
+FROM node:16.13.1-alpine3.15@sha256:a7cab437ba7f3cd405cf6d6446a0e944aabd7d5c4573fc24f93ab85cbc0f0a70 as final
+
+RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "add", "--no-cache", "tini"]
+RUN [ "yarn", "set", "version", "1.22.17" ]
+
+WORKDIR /app
+# Copy in compile assets and deps from build container
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/yarn.lock ./
+
+ENV PORT 8080
+EXPOSE 8080
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["yarn", "start"]


### PR DESCRIPTION
Add a Dockerfile to build core-front into a docker image. This builds
the image similar to the way it is currently built on Concourse prior to
being deployed to PaaS. This image will be used to deploy core-front to
ECS Fargate in future.

## Testing ##
This has been built and run locally, it successfully shows the `You’ve signed in to your GOV.UK account`. To reproduce when reviewing this pr you can...

```
docker build -t myfrontend .

docker run --rm -it -p 8080:8080 --env API_BASE_URL=https://rd3be2w425.execute-api.eu-west-2.amazonaws.com/build --env EXTERNAL_WEBSITE_HOST=localhost:8080  myfrontend

visit: http://localhost:8080/oauth2/authorize?response_type=code&client_id=test-client-id&state=test-state&redirect_uri=www.bbc.com&scope=openid
```


## Proposed changes
Builds a docker image for ECS.
