### PR TITLE
Pyic 1018 docker ecr build

### DIFF
--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     environment: test
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748

--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -8,7 +8,8 @@ jobs:
     name: Docker build and push
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
+      contents: read
     environment: test
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748

--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -2,7 +2,7 @@ name: Docker build and push to ECR
 on:
   push:
     branches:
-      - PYIC-1018-docker_ecr_build
+      - main
 jobs:
   dockerBuildAndPush:
     name: Docker build and push
@@ -35,7 +35,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           docker build -t "core-front-build:${IMAGE_TAG}" .
           docker tag "core-front-build:${IMAGE_TAG}" "${{ steps.login-ecr.outputs.registry }}/core-front-build:${IMAGE_TAG}"
-          docker image ls
       - name: Push docker image
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}

--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -23,13 +23,29 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@aaf69d68aa3fb14c1d5a6be9ac61fe15b48453a2
+      - name: Create tag
+        id: create-tag
+        run: |
+          IMAGE_TAG="${{ github.sha }}-$(date +'%Y-%m-%d-%H%M%S')"
+          echo "::set-output name=image_tag::$IMAGE_TAG"
       - name: Build docker image
+        env:
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
           cd ${GITHUB_WORKSPACE}
-          docker build -t core-front-build:${{ github.sha }} .
-          docker tag core-front-build:${{ github.sha }} ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}
+          docker build -t "core-front-build:${IMAGE_TAG}" .
+          docker tag "core-front-build:${IMAGE_TAG}" "${{ steps.login-ecr.outputs.registry }}/core-front-build:${IMAGE_TAG}"
           docker image ls
-          uname -a
       - name: Push docker image
+        env:
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-          docker push ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}
+          docker push "${{ steps.login-ecr.outputs.registry }}/core-front-build:${IMAGE_TAG}"
+      - name: Create template.yaml and sha zip file and upload to artifacts S3
+        env:
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/deploy
+          echo "${IMAGE_TAG}" > image_tag.txt
+          zip template.zip template.yaml image_tag.txt
+          aws s3 cp template.zip s3://di-ipv-core-build-artifacts/core-front/

--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -1,0 +1,33 @@
+name: Docker build and push to ECR
+on:
+  push:
+    branches:
+      - PYIC-1018-docker_ecr_build
+jobs:
+  dockerBuildAndPush:
+    name: Docker build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment: test
+    steps:
+      - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+        with:
+          fetch-depth: '0'
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@aaf69d68aa3fb14c1d5a6be9ac61fe15b48453a2
+      - name: Build docker image
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          docker build -t core-front-build:${{ github.sha }} .
+          docker tag core-front-build:${{ github.sha }} ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}
+          docker image ls
+      - name: Push docker image
+        run: |
+          docker push ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}

--- a/.github/workflows/ecr-docker-build.yml
+++ b/.github/workflows/ecr-docker-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
+      contents: read
     environment: test
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
@@ -29,6 +29,7 @@ jobs:
           docker build -t core-front-build:${{ github.sha }} .
           docker tag core-front-build:${{ github.sha }} ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}
           docker image ls
+          uname -a
       - name: Push docker image
         run: |
           docker push ${{ steps.login-ecr.outputs.registry }}/core-front-build:${{ github.sha }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    environment: test
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
         with:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,4 +1,4 @@
-name: Docker build and push to ECR
+name: Docker build, ECR push, template copy to S3 
 on:
   push:
     branches:
@@ -32,7 +32,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-          cd ${GITHUB_WORKSPACE}
+          cd ${GITHUB_WORKSPACE} || exit 1
           docker build -t "core-front-build:${IMAGE_TAG}" .
           docker tag "core-front-build:${IMAGE_TAG}" "${{ steps.login-ecr.outputs.registry }}/core-front-build:${IMAGE_TAG}"
       - name: Push docker image
@@ -44,7 +44,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-          cd ${GITHUB_WORKSPACE}/deploy
+          cd ${GITHUB_WORKSPACE}/deploy || exit 1
           echo "${IMAGE_TAG}" > image_tag.txt
           zip template.zip template.yaml image_tag.txt
           aws s3 cp template.zip s3://di-ipv-core-build-artifacts/core-front/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.1-alpine3.15@sha256:a7cab437ba7f3cd405cf6d6446a0e944aabd7d5c4573fc24f93ab85cbc0f0a70 AS builder
+FROM node:16.13.1-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92 AS builder
 
 WORKDIR /app
 RUN [ "yarn", "set", "version", "1.22.17" ]
@@ -14,7 +14,7 @@ RUN yarn build
 RUN [ "rm", "-rf", "node_modules" ]
 RUN yarn install --production
 
-FROM node:16.13.1-alpine3.15@sha256:a7cab437ba7f3cd405cf6d6446a0e944aabd7d5c4573fc24f93ab85cbc0f0a70 as final
+FROM node:16.13.1-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92 as final
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini"]


### PR DESCRIPTION

## Proposed changes
- On every merge, Github Actions should build the docker image and push it to ECR. 
- Upload the cloudformation template.yaml along with the commit sha (image_tag.txt created during GA run) to S3: di-ipv-core-build-artifacts/core-front/template.zip

### Issue tracking
- [PYIC-1018](https://govukverify.atlassian.net/browse/PYIC-1018)
