### PR TITLE
BAU: Remove Oauth params from redirect request onto the CRI's

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -164,7 +164,7 @@ describe("journey middleware", () => {
 
     it("should be redirected to a valid redirectURL", async function() {
       await middleware.updateJourneyState(req, res, next);
-      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?response_type=code&client_id=clientId&state=test-state&redirect_uri=https%3A%2F%2Fcallbackaddres.org%2Fcredential-issuer%2Fcallback%3Fid%3Dsomeid&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
+      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
     });
 
     it("should be redirected to a valid redirectURL when given specific cri id", async function() {
@@ -178,7 +178,7 @@ describe("journey middleware", () => {
         session: { ipvSessionId: "ipv-session-id" },
       };
       await middleware.updateJourneyState(req, res, next);
-      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?response_type=code&client_id=clientId&state=test-state&redirect_uri=https%3A%2F%2Fcallbackaddres.org%2Fcredential-issuer%2Fcallback%3Fid%3Dsomeid&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
+      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
     });
 
     it("should raise an error when missing authorizeUrl", async () => {

--- a/src/app/shared/criHelper.js
+++ b/src/app/shared/criHelper.js
@@ -1,5 +1,3 @@
-const { EXTERNAL_WEBSITE_HOST } = require("../../lib/config");
-
 module.exports = {
   buildCredentialIssuerRedirectURL: async (req, res, next) => {
     const cri = req.cri ? req.cri : req.session?.criConfig?.find(criConfig => criConfig.id === req.query.id);
@@ -10,10 +8,7 @@ module.exports = {
     }
 
     req.redirectURL = new URL(cri.authorizeUrl);
-    req.redirectURL.searchParams.append("response_type", "code");
     req.redirectURL.searchParams.append("client_id", cri.ipvClientId);
-    req.redirectURL.searchParams.append("state", "test-state");
-    req.redirectURL.searchParams.append("redirect_uri", `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback?id=${cri.id}`);
     req.redirectURL.searchParams.append("request", cri.request);
 
     if(next) {

--- a/src/app/shared/criHelper.test.js
+++ b/src/app/shared/criHelper.test.js
@@ -56,7 +56,7 @@ describe("cri Helper", () => {
       await buildCredentialIssuerRedirectURL(req, res, next);
 
       expect(req.redirectURL.toString()).to.equal(
-        "http://passport-stub-1/authorize?response_type=code&client_id=test-ipv-client&state=test-state&redirect_uri=https%3A%2F%2Fexample.org%2Fsubpath%2Fcredential-issuer%2Fcallback%3Fid%3DPassportIssuer&request=undefined"
+        "http://passport-stub-1/authorize?client_id=test-ipv-client&request=undefined"
       );
     });
 
@@ -97,7 +97,7 @@ describe("cri Helper", () => {
       const { redirectToAuthorize } = proxyquire("../shared/criHelper", {
         "../../lib/config": configStub,
       });
-  
+
       await redirectToAuthorize(req, res);
 
       expect(res.redirect).to.have.been.calledWith(req.redirectURL);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removed the Oauth params from the core-front redirect request onto the CRI.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We no longer need these query params as all the Oauth values are inside the JAR. Both the real passport cri and the stubs are setup to read these params from the contents of the "request" JWT.
<!-- Describe the reason these changes were made - the "why" -->

