### PR TITLE
PYIC-1059 Enable Access Logging on Core Front API Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -263,6 +263,14 @@ Resources:
       ApiId: !Ref ApiGwHttpEndpoint
       StageName: $default
       AutoDeploy: true
+      AccessLogSettings:
+        DestinationArn: !GetAtt APIGWAccessLogsGroup.Arn
+        Format: $context.identity.sourceIp - - [$context.requestTime] $context.httpMethod $context.path $context.routeKey $context.protocol $context.status $context.responseLength $context.requestId
+
+  APIGWAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreFront-API-GW-AccessLogs
 
 Outputs:
   CoreFrontUrl:


### PR DESCRIPTION
This enables access logs on Core Front's API Gateway.
## Proposed changes

### What changed

as above.

### Why did it change

This will help with debugging of issues.

### Testing
This has been deployed into development environment and we can see the access logs as expected. The format is subject to change as we align on access log formats but is easily changed in future.

### Issue tracking


- [PYIC-1059](https://govukverify.atlassian.net/browse/PYIC-1059)

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

