### PR TITLE
PYIC-1059 Use JSON log format for API Gateway Access Logs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -265,7 +265,18 @@ Resources:
       AutoDeploy: true
       AccessLogSettings:
         DestinationArn: !GetAtt APIGWAccessLogsGroup.Arn
-        Format: $context.identity.sourceIp - - [$context.requestTime] $context.httpMethod $context.path $context.routeKey $context.protocol $context.status $context.responseLength $context.requestId
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip": "$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path": "$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength"
+          }
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
This will be easier to query in Splunk.


## Proposed changes
Switching from Common Log Format (CLF) to JSON because it will be easier to query in Splunk without having to create parsers for these logs.

This has been deployed into development account and works as expected:

```
{
    "requestId": "RlwUIj2pLPEEPjg=",
    "ip": "[redacted]",
    "requestTime": "04/May/2022:07:39:31 +0000",
    "httpMethod": "GET",
    "path": "/some-path",
    "routeKey": "ANY /{proxy+}",
    "status": "404",
    "protocol": "HTTP/1.1",
    "responseLength": "7464"
}
```

Note that the JSON format string in the yaml template cannot be formatted quite with the expected indentation such as
```
 {
    "requestId":"$context.requestId",
```

 despite using `>-` (which removes line breaks in a multi-line string)  because indenting the contents seems to confuse CloudFormation into thinking there are additional line breaks (https://github.com/serverless/serverless/issues/7162)..


### Issue tracking
- [PYIC-1059](https://govukverify.atlassian.net/browse/PYIC-1059)

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed