### PR TITLE
PYIC-1060 Enable Core Front ALB Access Logs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -96,6 +96,38 @@ Resources:
       GroupId: !GetAtt ECSSecurityGroup.GroupId
       SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
 
+  AccessLogsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ipv-core-${Environment}-access-logs
+      VersioningConfiguration:
+        Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  CoreFrontAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AccessLogsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - arn:aws:iam::652711504416:root
+            Action:
+              - s3:PutObject
+            Resource:
+              - !Sub arn:aws:s3:::${AccessLogsBucket}/core-front-${Environment}/AWSLogs/${AWS::AccountId}/*
+
   # Private Application Load Balancer
   LoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
@@ -105,6 +137,15 @@ Resources:
         - !GetAtt LoadBalancerSG.GroupId
       Subnets: !Ref SubnetIds
       Type: application
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: !Ref AccessLogsBucket
+        - Key: access_logs.s3.prefix
+          Value: !Sub core-front-${Environment}
+    DependsOn:
+      - CoreFrontAccessLogsBucketPolicy
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
Turns on sending Core Front application Load Balancer access logs to S3
because these are useful for debugging. This creates an S3 bucket to
hold access logs, give the core-front ALB permission to put objects into it
and then enables access logs on the core front ALB.


### Testing
This has been deployed into development and the access logs are captured in S3 as expected. The follow command gets the test access logs from development environment.

```
GDS11321:di-ipv-core-front dan.worth$ aws-vault exec di-ipv-dev -- aws s3api get-object --bucket ipv-core-development-access-logs --key core-front/AWSLogs/130355686670/elasticloadbalancing/eu-west-2/2022/05/04/130355686670_elasticloadbalancing_eu-west-2_app.PYIC-LoadB-655DWMJQRXPF.92f771acf3c29f8f_20220504T0830Z_10.120.7.154_64qi87rn.log.gz  --region eu-west-2 >( gzip -d )
http 2022-05-04T08:26:18.430419Z app/PYIC-LoadB-655DWMJQRXPF/92f771acf3c29f8f 10.120.10.22:65242 10.120.7.29:8080 0.000 0.028 0.000 404 404 347 8057 "GET http://x7vwm2v3xl.execute-api.eu-west-2.amazonaws.com:80/some-path HTTP/1.1" "curl/7.79.1" - - arn:aws:elasticloadbalancing:eu-west-2:130355686670:targetgroup/PYIC-LoadB-OQ2MCM5HAANB/940dc46db8410310 "Self=1-627238aa-1e6e21ec42b34a981270f2f8;Root=1-627238aa-31bfceea0bbbfa382afb69cf" "-" "-" 0 2022-05-04T08:26:18.341000Z "forward" "-" "-" "10.120.7.29:8080" "404" "Acceptable" "GetHeadZeroContentLength"
http 2022-05-04T08:27:38.949728Z app/PYIC-LoadB-655DWMJQRXPF/92f771acf3c29f8f 10.120.9.231:18517 10.120.7.29:8080 0.000 0.034 0.000 404 404 350 8051 "GET http://x7vwm2v3xl.execute-api.eu-west-2.amazonaws.com:80/another-path HTTP/1.1" "curl/7.79.1" - - arn:aws:elasticloadbalancing:eu-west-2:130355686670:targetgroup/PYIC-LoadB-OQ2MCM5HAANB/940dc46db8410310 "Self=1-627238fa-5c8ccfdf3401e2747bd15af3;Root=1-627238fa-19c019075617878b3725009e" "-" "-" 0 2022-05-04T08:27:38.872000Z "forward" "-" "-" "10.120.7.29:8080" "404" "Acceptable" "GetHeadZeroContentLength"


```

## Proposed changes
See commit message above. Follows the instructions https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html

### What changed
See commit message above.

### Why did it change
ALB access logs are useful for debugging so we should capture them.

### Issue tracking
- [PYIC-1060](https://govukverify.atlassian.net/browse/PYIC-1060)

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

