### PR TITLE
[PYIC-994] Remove call to shared-attributes handler on core-front

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -10,7 +10,6 @@ describe("journey middleware", () => {
   const axiosStub = {};
   const configStub = {
     API_BASE_URL: "https://example.org/subpath",
-    API_SHARED_ATTRIBUTES_JWT_PATH: '/jwtPath',
     EXTERNAL_WEBSITE_HOST: "https://callbackaddres.org"
   };
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,12 +11,10 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_ISSUED_CREDENTIALS_PATH: "/issued-credentials",
-  API_SHARED_ATTRIBUTES_JWT_PATH: "/shared-attributes",
   API_REQUEST_CONFIG_PATH: "/request-config",
   API_CRI_RETURN_PATH: "/journey/cri/return",
   AUTH_PATH: "/authorize",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,
-  SHARED_ATTRIBUTES_JWT_SIZE_LIMIT: process.env.SHARED_ATTRIBUTES_JWT_SIZE_LIMIT || 6000,
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Proposed changes

Remove calls to the shared-attributes handler

### What changed

Constants removed from the files below

### Why did it change

Shared attributes are handled with a different method

### Issue tracking
- [PYIC-994](https://govukverify.atlassian.net/browse/PYIC-994)

## Checklists

### Environment variables or secrets

API_SHARED_ATTRIBUTES_JWT_PATH: "/shared-attributes" **removed**
<!-- Delete if changes DO include new environment variables or secrets -->

<!-- Delete if changes DO NOT include new environment variables or secrets -->


