### PR TITLE
[PYIC-1061] - configure ecs container logging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -204,6 +204,10 @@ Resources:
     DependsOn:
       - LoadBalancerListener
 
+  ECSAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/ecs/${AWS::StackName}-CoreFront-ECS
   ECSServiceTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
@@ -219,6 +223,12 @@ Resources:
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group : !Ref ECSAccessLogsGroup
+              awslogs-region : !Sub ${AWS::Region}
+              awslogs-stream-prefix : !Sub core-front-${Environment}
       Cpu: '512'
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Memory: '1024'
@@ -249,7 +259,13 @@ Resources:
                   - "ecr:GetAuthorizationToken"
                 Resource:
                   - '*'
-
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - !GetAtt "ECSAccessLogsGroup.Arn"
+                  - !Sub "${ECSAccessLogsGroup.Arn}:*"
   ECSTaskRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
## Proposed changes
ECS container application should log to its own cloudwatch log group.

Create a log group
Grant ECSTaskExecutionRole write access to the above log group
Configure container to log to the log group (awslogs)

### What changed
See above

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Requirement to capture all ECS application logs


### Issue tracking
- [PYIC-1061](https://govukverify.atlassian.net/browse/PYIC-1061)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

