### PR TITLE
PYIC-1067: Ship logs to Splunk

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -208,6 +208,15 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-CoreFront-ECS
+      RetentionInDays: 14
+
+  ECSAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref ECSAccessLogsGroup
+
   ECSServiceTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
@@ -309,7 +318,7 @@ Resources:
     Properties:
       ApiId: !Ref ApiGwHttpEndpoint
       RouteKey: 'ANY /{proxy+}'
-      Target: !Join 
+      Target: !Join
         - /
         - - integrations
           - !Ref ApiGwHttpEndpointIntegration
@@ -339,6 +348,13 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreFront-API-GW-AccessLogs
+
+  APIGWAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref APIGWAccessLogsGroup
 
 Outputs:
   CoreFrontUrl:


### PR DESCRIPTION




<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a subscription filter for the API gateway access logs, and the ECS
logs, to send them to Splunk via Cyber's Centralised Security Logging
Service (CSLS).

### Why did it change

See here for more details:
https://github.com/alphagov/centralised-security-logging-service

Also defines a retention period for the log groups of 14 days. This is
in line with what we're doing elsewhere and should be enough in case the
shipping breaks for some reason.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1067](https://govukverify.atlassian.net/browse/PYIC-1067)
