### PR TITLE
PYIC-1022: Accept new auth params from session lambda

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -44,6 +44,8 @@ module.exports = {
 
       const response = await axios.post(`${API_BASE_URL}/session/start`, authParams);
       req.session.ipvSessionId = response?.data?.ipvSessionId;
+      req.session.oauthParams = response?.data;
+
     } catch (error) {
       res.error = error.name;
       return next(error);
@@ -55,8 +57,7 @@ module.exports = {
   retrieveAuthorizationCode: async (req, res, next) => {
     try {
       const oauthParams = {
-        ...req.session.authParams,
-        scope: "openid",
+        ...req.session.oauthParams,
       };
 
       const apiResponse = await axios.get(`${API_BASE_URL}${AUTH_PATH}`, {
@@ -80,7 +81,7 @@ module.exports = {
   },
 
   redirectToCallback: async (req, res) => {
-    const redirectURL = `${req.session.authParams.redirect_uri}?code=${req.authorization_code}`;
+    const redirectURL = `${req.session.oauthParams.redirect_uri}?code=${req.authorization_code}`;
 
     res.redirect(redirectURL);
   },

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -168,7 +168,7 @@ describe("oauth middleware", () => {
     beforeEach(() => {
       req = {
         session: {
-          authParams: {
+          oauthParams: {
             response_type: "code",
             client_id: "s6BhdRkqt3",
             state: "xyz",
@@ -196,7 +196,7 @@ describe("oauth middleware", () => {
         expect(axiosStub.get).to.have.been.calledWith(
           "https://example.org/subpath/subsubpath/auth",
           sinon.match({
-            params: { ...req.session.authParams },
+            params: { ...req.session.oauthParams },
             headers: { "ipv-session-id": "abadcafe" },
           })
         );
@@ -264,7 +264,7 @@ describe("oauth middleware", () => {
     beforeEach(() => {
       req = {
         session: {
-          authParams: {
+          oauthParams: {
             redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
           },
         },


### PR DESCRIPTION
## Proposed changes

### What changed

OAuth params are no longer to be retrieved from query params from the original orchestrator request, now they come from values within the encrypted JAR from the sessionStart lambda.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1022](https://govukverify.atlassian.net/browse/PYIC-1022)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
