### PR TITLE
PYIC-1127 - Removed redundant Oauth params from query string

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -163,7 +163,7 @@ describe("journey middleware", () => {
 
     it("should be redirected to a valid redirectURL", async function() {
       await middleware.updateJourneyState(req, res, next);
-      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?response_type=code&client_id=clientId&state=test-state&redirect_uri=https%3A%2F%2Fcallbackaddres.org%2Fcredential-issuer%2Fcallback%3Fid%3Dsomeid&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
+      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
     });
 
     it("should be redirected to a valid redirectURL when given specific cri id", async function() {
@@ -177,7 +177,7 @@ describe("journey middleware", () => {
         session: { ipvSessionId: "ipv-session-id" },
       };
       await middleware.updateJourneyState(req, res, next);
-      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?response_type=code&client_id=clientId&state=test-state&redirect_uri=https%3A%2F%2Fcallbackaddres.org%2Fcredential-issuer%2Fcallback%3Fid%3Dsomeid&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
+      expect(req.redirectURL.toString()).to.equal("https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D");
     });
 
     it("should raise an error when missing authorizeUrl", async () => {

--- a/src/app/shared/criHelper.js
+++ b/src/app/shared/criHelper.js
@@ -1,4 +1,3 @@
-const { EXTERNAL_WEBSITE_HOST } = require("../../lib/config");
 
 module.exports = {
   buildCredentialIssuerRedirectURL: async (req, res, next) => {
@@ -10,10 +9,7 @@ module.exports = {
     }
 
     req.redirectURL = new URL(cri.authorizeUrl);
-    req.redirectURL.searchParams.append("response_type", "code");
     req.redirectURL.searchParams.append("client_id", cri.ipvClientId);
-    req.redirectURL.searchParams.append("state", "test-state");
-    req.redirectURL.searchParams.append("redirect_uri", `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback?id=${cri.id}`);
     req.redirectURL.searchParams.append("request", cri.request);
 
     if(next) {

--- a/src/app/shared/criHelper.test.js
+++ b/src/app/shared/criHelper.test.js
@@ -56,7 +56,7 @@ describe("cri Helper", () => {
       await buildCredentialIssuerRedirectURL(req, res, next);
 
       expect(req.redirectURL.toString()).to.equal(
-        "http://passport-stub-1/authorize?response_type=code&client_id=test-ipv-client&state=test-state&redirect_uri=https%3A%2F%2Fexample.org%2Fsubpath%2Fcredential-issuer%2Fcallback%3Fid%3DPassportIssuer&request=undefined"
+        "http://passport-stub-1/authorize?client_id=test-ipv-client&request=undefined"
       );
     });
 
@@ -97,7 +97,7 @@ describe("cri Helper", () => {
       const { redirectToAuthorize } = proxyquire("../shared/criHelper", {
         "../../lib/config": configStub,
       });
-  
+
       await redirectToAuthorize(req, res);
 
       expect(res.redirect).to.have.been.calledWith(req.redirectURL);


### PR DESCRIPTION
### What changed
Removed Oauth params response_type, state and redirect_uri are no longer required to be sent in the query and can be found in the JAR.

- [PYIC-1127 ](https://govukverify.atlassian.net/browse/PYIC-1127)
