### PR TITLE
PYIC-1129 Conditional for dev envs to use development ecr

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -16,12 +16,7 @@ Parameters:
   Environment:
     Description: The name of the environment to deploy to.
     Type: String
-    AllowedValues:
-      - development
-      - build
-      - staging
-      - integration
-      - production
+    AllowedPattern: ((production)|(integration)|(staging)|(build)|(dev.*))
   ImageTag:
     Description: The tag of core-front image to deploy in the task definition.
     Type: String
@@ -44,6 +39,13 @@ Parameters:
     Description: >-
       The number of core front ecs tasks to run.
     Type: Number
+
+Conditions:
+  IsNotDevelopment: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -213,7 +215,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-${Environment}:${ImageTag}
+          Image: !If [IsNotDevelopment, !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-${Environment}:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-development:${ImageTag}"]
           Name: app
           Environment:
             - Name: API_BASE_URL


### PR DESCRIPTION
## Proposed changes
Currently, developer environments use the ENVIRONMENT variable when creating a stack in concourse.

In the current form this template uses ENVIRONMENT to access the correct ECR repository, which will fail as we don't have a repository for each developer.

This change will use the development ecr repository for those builds.

### What changed
To accommodate developer environment stacks:
- Change the allowed environments to allow for dev*
- Create a condition that is set if the environment is not build, staging, integration or production. Use that condition to set the ecr repository to `development`.


### Issue tracking
- [PYIC-1129](https://govukverify.atlassian.net/browse/PYIC-1129)

