### PR TITLE
Pyic 1018 docker ecr build artifact

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -2,7 +2,7 @@ name: Docker build, ECR push, template copy to S3
 on:
   push:
     branches:
-      - PYIC-1018-docker-ecr-build-artifact
+      - main
 jobs:
   dockerBuildAndPush:
     name: Docker build and push

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -2,7 +2,7 @@ name: Docker build, ECR push, template copy to S3
 on:
   push:
     branches:
-      - main
+      - PYIC-1018-docker-ecr-build-artifact
 jobs:
   dockerBuildAndPush:
     name: Docker build and push
@@ -42,8 +42,9 @@ jobs:
       - name: Create template.yaml and sha zip file and upload to artifacts S3
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
         run: |
           cd ${GITHUB_WORKSPACE}/deploy || exit 1
           echo "${IMAGE_TAG}" > image_tag.txt
           zip template.zip template.yaml image_tag.txt
-          aws s3 cp template.zip s3://di-ipv-core-build-artifacts/core-front/
+          aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/core-front/template.zip"


### PR DESCRIPTION

## Proposed changes
On every merge, Github Actions should build the docker image and push it to ECR.
Upload the cloudformation template.yaml along with the commit sha (image_tag.txt created during GA run) to S3: $ARTIFACT_BUCKET/core-front/template.zip

### What changed
$ARTIFACT_BUCKET used as variable reference for s3 location for template.zip to be added.



### Issue tracking
[PYIC-1018](https://govukverify.atlassian.net/browse/PYIC-1018)


### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

