### PR TITLE
[PYIC-1192] Use BUILD ECR in higher environments.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -224,7 +224,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: !If [IsNotDevelopment, !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-${Environment}:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-development:${ImageTag}"]
+          Image: !If [IsNotDevelopment, !Sub "457601271792.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-build:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/core-front-development:${ImageTag}"] # Uses build account and ECR when not in development.
           Name: app
           Environment:
             - Name: API_BASE_URL


### PR DESCRIPTION
## Proposed changes

### What changed

Instead of using an ECR in each account, all higher accounts read from the build ECR repo.

### Why did it change

This aligns with the secure pipelines approach, as copying images up through ECR repos in different accounts was painful in concorse.

### Issue tracking

- [PYIC-1192](https://govukverify.atlassian.net/browse/PYIC-1192)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
