### PR TITLE
PYIC-1040: Fix broken header link

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -5,10 +5,9 @@ buttons:
   cancel: Cancel
   credentialIssuer: Credential Issuer
 govuk:
-  serviceName: Prove your identity
+  serviceName: " "
   backLink: Back
   errorSummaryTitle: There’s a problem
   error: Error
   warning: Warning
   skipLink: Skip to main content
-

--- a/src/views/ipv/page-transition-default.html
+++ b/src/views/ipv/page-transition-default.html
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block pageTitle %} {{ title }} – Example – GOV.UK Design System {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The link was originally trying to hit the default "/" route which we never defined. 
A service name is required from hmpo-components as it tries to look for it as part of the internationalisation 

### Why did it change

The IPV start page has a "Prove your identity" header link which goes to a 404 page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1040](https://govukverify.atlassian.net/browse/PYIC-1040)
