### PR TITLE
PYIC-1220 Export the Core Front API Gateway ID

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -363,3 +363,9 @@ Outputs:
     Description: >-
       The API Gateway URL which Core Front can be invoked on.
     Value: !GetAtt  ApiGwHttpEndpoint.ApiEndpoint
+  IPVCoreFrontGatewayID:
+    Description: Core Front API Gateway ID
+    Export:
+      Name: !Sub "${AWS::StackName}-IPVCoreFrontGatewayID"
+    Value: !Ref ApiGwHttpEndpoint
+


### PR DESCRIPTION
This will be consumed by the DNS stack to create the necessary alias
records.



### Why did it change
Required by the DNS stack to create a `AWS::ApiGateway::BasePathMapping` for the identity custom domain name and core front api gateway.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1220](https://govukverify.atlassian.net/browse/PYIC-1220)

