### PR TITLE
BAU Do not Output ALB Access Logs in Developer Environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -99,6 +99,7 @@ Resources:
       SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
 
   AccessLogsBucket:
+    Condition: IsNotDevelopment
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ipv-core-${Environment}-access-logs
@@ -115,6 +116,7 @@ Resources:
               SSEAlgorithm: AES256
 
   CoreFrontAccessLogsBucketPolicy:
+    Condition: IsNotDevelopment
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref AccessLogsBucket
@@ -139,15 +141,15 @@ Resources:
         - !GetAtt LoadBalancerSG.GroupId
       Subnets: !Ref SubnetIds
       Type: application
-      LoadBalancerAttributes:
-        - Key: access_logs.s3.enabled
-          Value: true
-        - Key: access_logs.s3.bucket
-          Value: !Ref AccessLogsBucket
-        - Key: access_logs.s3.prefix
-          Value: !Sub core-front-${Environment}
-    DependsOn:
-      - CoreFrontAccessLogsBucketPolicy
+      LoadBalancerAttributes: !If
+        - IsNotDevelopment
+        - - Key: access_logs.s3.enabled
+            Value: true
+          - Key: access_logs.s3.bucket
+            Value: !Ref AccessLogsBucket
+          - Key: access_logs.s3.prefix
+            Value: !Sub core-front-${Environment}
+        - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
The ALB access logs bucket makes it harder to destroy the core-front
stacks because the ALB access logs bucket cannot be deleted by CFN once
it has objects in it. There is little value in ALB access logs in the
developer environments and if absolutely necessary this can be enabled
on their environment as and when needed.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Do not output ALB access logs to an S3 bucket in the developer environments to make it simpler to delete the core-front stacks when necessary.

I have created a change set for this change against build and it reported no changes to make which is expected.