### PR TITLE
PYIC-1253 Switch Core Front to Private API Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -230,7 +230,12 @@ Resources:
           Name: app
           Environment:
             - Name: API_BASE_URL
-              Value: !Ref ApiBaseUrl
+              Value: !Sub
+                  - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
+                  - APIGatewayId:
+                      Fn::ImportValue:
+                        !Sub ipv-core-back-${Environment}-IPVCorePrivateAPIGatewayID
+                    Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
           PortMappings:


### PR DESCRIPTION
This will switch Core Front to use the private API gateway for the
internal lambdas of core-back.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use the private api gateway id to call core-back.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Core front needs to use core back's private API gateway which is reached via VPC Endpoint. This uses the core-back exported value for the private api gateway rather than CI passing it in which should begin to align us with the way secure platform operates.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1253](https://govukverify.atlassian.net/browse/PYIC-1253)

### Testing
This has been deployed into my developer environment and it works as expected. The export names for the private api gateway id from core-back are consistent
```
GDS11321:deploy dan.worth$ for env in dev build int stag; do aws-vault exec di-ipv-${env} -- aws cloudformation list-exports --region eu-west-2 | jq '.Exports[] | select(.Name | contains("IPVCorePrivateAPIGatewayID")).Name' -r; done
ipv-core-back-dev-danw-IPVCorePrivateAPIGatewayID
ipv-core-back-build-IPVCorePrivateAPIGatewayID
ipv-core-back-integration-IPVCorePrivateAPIGatewayID
ipv-core-back-staging-IPVCorePrivateAPIGatewayID
```