### PR TITLE
PYIC-1273: Create Identity proofing failure page

### DIFF
--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -10,6 +10,18 @@ pageIpvEnd:
 criRedirectionError:
   title: Cri Redirection error
 
+pyiNoMatch:
+  title: Sorry, we cannot prove your identity right now
+  content:
+    - This might be because we could not match your details to information from another database
+    - To keep your information safe, we cannot show which of your details we had trouble finding a match for.
+    - This could also be because you were unsuccessful when you've previously tried to prove your identity online.
+    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - Continue to the service you were trying to use and look for other ways to prove your identity.
+    - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button"> {{ translate("buttons.next") }} </a>
+    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
+
+
 # Pages created from the prototype
 
 pageIpvIdentityStart:

--- a/src/views/ipv/pyi-no-match.html
+++ b/src/views/ipv/pyi-no-match.html
@@ -1,0 +1,6 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pyiNoMatch" %}
+
+{% block beforeContent %}
+  {% include "../shared/phase-banner.html" %}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Created a template for when there is a no match error
This follows the design on [Figma](https://www.figma.com/file/nglBHtbzJYEeST43Iu1jW3/PYI-DBS-Return-Journey-Mockups-(Unhappy-Paths))
Figma design:
<img width="600" alt="Screenshot 2022-05-23 at 14 53 20" src="https://user-images.githubusercontent.com/24409958/169843504-2c9b249f-7d88-41e8-ac14-e71f4d381bfd.png">

core-front:
<img width="600" alt="Screenshot 2022-05-23 at 15 12 36" src="https://user-images.githubusercontent.com/24409958/169842986-ca8cf34a-21b6-4c79-9f07-3295d55a693e.png">

### Why did it change

We need an error page to display to the user if the service is unable to match there details

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1273](https://govukverify.atlassian.net/browse/PYIC-1273)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
