### PR TITLE
Revert "BAU: Bump govuk-frontend from 4.0.1 to 4.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.1",
     "express": "4.18.1",
     "express-async-errors": "3.1.1",
-    "govuk-frontend": "4.1.0",
+    "govuk-frontend": "4.0.1",
     "hmpo-app": "2.0.0",
     "hmpo-components": "5.3.0",
     "hmpo-config": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1768,10 +1768,10 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-govuk-frontend@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.1.0.tgz#d3bc3af09baba539adee31f980ac0322b9eeb949"
-  integrity sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==
+govuk-frontend@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.0.1.tgz#bceff58ecb399272cba32bd2b357fe16198e3249"
+  integrity sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.8"


### PR DESCRIPTION
Reverts alphagov/di-ipv-core-front#184