### PR TITLE
PYIC-1311: Add pyi-kbv-fail error page

### DIFF
--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -21,8 +21,15 @@ pyiNoMatch:
     - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button"> {{ translate("buttons.next") }} </a>
     - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
 
-
-# Pages created from the prototype
+pyiKbvFail:
+  title: Sorry, we cannot prove your identity right now
+  content:
+    - This might be because you gave the wrong answer to some of the security questions.
+    - To keep your information safe, we cannot show which questions you answered incorrectly. 
+    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - Continue to the service you were trying to use and look for other ways to prove your identity.
+    - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button"> {{ translate("buttons.next") }} </a>
+    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
 
 pageIpvIdentityStart:
   title: You’ve signed in to your GOV.UK account

--- a/src/views/ipv/pyi-kbv-fail.html
+++ b/src/views/ipv/pyi-kbv-fail.html
@@ -1,0 +1,6 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "pyiKbvFail" %}
+
+{% block beforeContent %}
+  {% include "../shared/phase-banner.html" %}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Create an error page for the pyi-kbv-fail

Designs are copied from the [figma](https://www.figma.com/file/nglBHtbzJYEeST43Iu1jW3/PYI-DBS-Return-Journey-Mockups-(Unhappy-Paths)) diagrams

Figma:
<img width="600" alt="Screenshot 2022-05-25 at 11 27 25" src="https://user-images.githubusercontent.com/24409958/170242221-9b72c867-0c11-432b-b44a-aca003346c16.png">

core-front:
<img width="600" alt="Screenshot 2022-05-25 at 11 34 44" src="https://user-images.githubusercontent.com/24409958/170243048-4a259674-0ada-419d-bdfd-8f072fda3d18.png">

### Why did it change

We need to create a new error page for when a user fails a KBV check and can not continue their journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1311](https://govukverify.atlassian.net/browse/PYIC-1311)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
