### PR TITLE
PYIC-1254 Prepare to remove ApiBaseUrl param

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -23,6 +23,7 @@ Parameters:
   ApiBaseUrl:
     Description: The url for the core internal API gateway.
     Type: String
+    Default: This is being removed. Default value in the interim whilst we update Concourse.
   SubnetIds:
     Description: >-
       A comma separated list of subnet ids to create the ECS service and Load Balancer


### PR DESCRIPTION
Add a default value so that we can remove setting it via Concourse. The
entire ApiBaseUrl will then be removed from the template as it is no
longer used.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above. The next step is to stop Concourse setting the value before removing it entirely.
### What changed

<!-- Describe the changes in detail - the "what"-->
