### PR TITLE
PYIC-1254 Remove unused ApiBaseUrl Parameter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -20,10 +20,6 @@ Parameters:
   ImageTag:
     Description: The tag of core-front image to deploy in the task definition.
     Type: String
-  ApiBaseUrl:
-    Description: The url for the core internal API gateway.
-    Type: String
-    Default: This is being removed. Default value in the interim whilst we update Concourse.
   SubnetIds:
     Description: >-
       A comma separated list of subnet ids to create the ECS service and Load Balancer


### PR DESCRIPTION
This is no longer used because the template imports the new private API
gateway.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above. We have updated Concourse so it will no longer attempt to set this parameter.
