### PR TITLE
BAU: Spike into skipping page redirect

### DIFF
--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -2,9 +2,8 @@ const express = require("express");
 
 const router = express.Router();
 
-const { updateJourneyState, handleJourneyPage } = require("./middleware");
+const { updateJourneyState } = require("./middleware");
 
-router.get("/journeyPage", handleJourneyPage)
 router.get("/*", updateJourneyState);
 
 module.exports = router;


### PR DESCRIPTION
This is an experiment to see if we can render pages directly when we
receive a page journey response from the backend.

This renders pages at the `/ipv/journey/next` page, rather than
redirecting the user again to a `/journeyPage?pageid=...` URL.

It saves a round trip for the user but might be confusing rendering
different pages on the `/next` page.

This is not tested and may be (probably is) handling errors incorrectly.
