### PR TITLE
BAU: Fix bug with returning two responses

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -8,7 +8,7 @@ const { generateAxiosConfig } = require("../shared/axiosHelper");
 
 
 module.exports = {
-  addCallbackParamsToRequest: async (req, res, next) => {
+  addCallbackParamsToRequest: async (req, _res, next) => {
     req.credentialIssuer = {};
 
     req.credentialIssuer.code = req.query?.code;

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -55,7 +55,7 @@ module.exports = {
         ]);
 
         const journeyResponse = await axios.post(`${API_BASE_URL}/journey/cri/error`, errorParams, generateAxiosConfig(req.session.ipvSessionId))
-        res.redirect(`/ipv${journeyResponse.data?.journey}`);
+        return res.redirect(`/ipv${journeyResponse.data?.journey}`);
       }
 
       return next();

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -210,7 +210,7 @@ describe("credential issuer middleware", () => {
       axiosStub.post = sinon.fake.returns(axiosResponse);
 
       const errorParams = new URLSearchParams([
-        ["error", null],
+        ["error", 'undefined'],
         ["error_description", error_description],
       ]);
 

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -2,24 +2,24 @@ const axios = require("axios");
 const { API_BASE_URL } = require("../../lib/config");
 
 module.exports = {
-  renderOauthPage: async (req, res) => {
+  renderOauthPage: async (_req, res) => {
     res.render("index-hmpo");
   },
 
-  redirectToDebugPage: async (req, res) => {
+  redirectToDebugPage: async (_req, res) => {
     res.redirect("/debug");
   },
 
-  redirectToJourney: async (req, res) => {
+  redirectToJourney: async (_req, res) => {
     res.redirect("/ipv/journey/next");
   },
 
-  setDebugJourneyType: (req, res, next) => {
+  setDebugJourneyType: (req, _res, next) => {
     req.session.isDebugJourney = true;
     next();
   },
 
-  setRealJourneyType: (req, res, next) => {
+  setRealJourneyType: (req, _res, next) => {
     req.session.isDebugJourney = false;
     next();
   },
@@ -35,7 +35,7 @@ module.exports = {
         isDebugJourney: req.session.isDebugJourney,
         request: req.query.request
       };
-      
+
       if(!authParams.request){ return next(new Error('Request JWT Missing'));}
       if(!authParams.clientId){ return next(new Error('Client ID Missing'));}
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix bug with returning two responses

### Why did it change

When we were receiving an error response from a CRI we were calling
redirect and then calling next. This resulted in two responses being
sent to the client which resulted in an error that crashed the app.
