### PR TITLE
BAU: Update error page content and duplicate existing page for core-back

### DIFF
--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,12 +1,15 @@
 
+# this page is the default error page for core-front. \
+# WARNING: the content for error: is also used to generate the content for views/ipv/pyi-technical-unrecoverable.html
+
 error:
   title: Sorry, there is a problem with the service
   content:
     - We cannot prove your identity right now.
     - <h2>What you can do</h2>
-    - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage
+    - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 pageNotFound:
   title: Page not found
@@ -15,7 +18,7 @@ pageNotFound:
   - If you pasted the web address, check you copied the entire address.
   - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
   - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
-  - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+  - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 sessionEnded:
   title: Session expired

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -13,13 +13,13 @@ criRedirectionError:
 pyiNoMatch:
   title: Sorry, we cannot prove your identity right now
   content:
-    - This might be because we could not match your details to information from another database
+    - This might be because we could not match your details to information from another database.
     - To keep your information safe, we cannot show which of your details we had trouble finding a match for.
     - This could also be because you were unsuccessful when you've previously tried to prove your identity online.
-    - <h2> What you can do </h2>
+    - <h2>What you can do</h2>
     - Continue to the service you were trying to use and look for other ways to prove your identity.
     - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">{{ translate("buttons.next") }}</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 pyiTechnical:
   title: Sorry, there is a problem with the service
@@ -28,17 +28,17 @@ pyiTechnical:
     - <h2>What you can do</h2>
     - Continue to the service you were trying to use and look for other ways to prove your identity.
     - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">{{ translate("buttons.next") }}</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 pyiKbvFail:
   title: Sorry, we cannot prove your identity right now
   content:
     - This might be because you gave the wrong answer to some of the security questions.
     - To keep your information safe, we cannot show which questions you answered incorrectly. 
-    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - <h2>What you can do</h2>
     - Continue to the service you were trying to use and look for other ways to prove your identity.
     - <a href="/ipv/journey/next" class="govuk-button" data-module="govuk-button"> {{ translate("buttons.next") }} </a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 pageIpvIdentityStart:
   title: You’ve signed in to your GOV.UK account
@@ -61,7 +61,7 @@ pagePreKbvTransition:
   detailsSummaryText:
   - How we know what questions to ask you
   detailsHTML:
-  - <p>We’ll work with <a href="https://www.experian.co.uk/">Experian (opens in a new tab)</a> to make sure we ask you questions that only you can answer. This is because companies like Experian have access to lots of information that we can check your answers against.</p><p><a href="https://signin.account.gov.uk/privacy-statement">Read our privacy notice</a> if you’d like to know more about how your details will be used to prove your identity.</p>
+  - <p>We’ll work with <a target="_blank" rel="noopener noreferrer" href="https://www.experian.co.uk/">Experian (opens in a new tab)</a> to make sure we ask you questions that only you can answer. This is because companies like Experian have access to lots of information that we can check your answers against.</p><p><a href="https://signin.account.gov.uk/privacy-statement">Read our privacy notice</a> if you’d like to know more about how your details will be used to prove your identity.</p>
 
 pageIpvSuccess:
   title: You’ve successfully proved your identity

--- a/src/views/ipv/pyi-technical-unrecoverable.html
+++ b/src/views/ipv/pyi-technical-unrecoverable.html
@@ -1,0 +1,6 @@
+{% extends "hmpo-template.njk" %}
+{% set hmpoPageKey = "errors.error" %}
+
+{% block beforeContent %}
+  {% include "../shared/phase-banner.html" %}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
These changes include:
* Grammar and copy updates as a result of page proofreading and observations from user research
* Links that are indicated as opening in a new window now open in a new window, using the code suggested in the [HMRC design system notes](http://hmrc.github.io/assets-frontend/components/open-links-in-a-new-window-or-tab/index.html)
* The `technical-unrecoverable` page is now mirrored in the ipv folder - because the page is set to use the same yaml content, editing the default error page will also change the content on the new page.

## Proposed changes

### What changed

* Two yaml files updated
* New html page added (but see note above about its content)

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

* requests from the UX team
* requests from core-back team

