### PR TITLE
[PYIC-1221] initial implementation of global beta notice and footer content

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -12,3 +12,17 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
+  betaBannerRequired: true
+  footerNavItems:
+    meta:
+      items:
+          - href: 'https://signin.account.gov.uk/contact-us'
+            text: 'Help'
+          - href: 'https://signin.account.gov.uk/privacy-notice'
+            text: 'Privacy'
+          - href: 'https://www.gov.uk/help/cookies'
+            text: 'Cookies'
+          - href: 'https://signin.account.gov.uk/accessibility-statement'
+            text: 'Accessibility'
+          - href: 'https://signin.account.gov.uk/terms-and-conditions'
+            text: 'Terms and conditions'

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,12 +1,12 @@
 
-# this page is the default error page for core-front. \
+# this page is the default error page for core-front.
 # WARNING: the content for error: is also used to generate the content for views/ipv/pyi-technical-unrecoverable.html
 
 error:
   title: Sorry, there is a problem with the service
   content:
     - We cannot prove your identity right now.
-    - <h2>What you can do</h2>
+    - '## What you can do'
     - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
     - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -1,2 +1,25 @@
 {% extends "hmpo-template.njk" %}
 {% set hmpoPageKey = "errors.pageNotFound" %}
+
+{# import beta banner boolean and footer link content #}
+{% set betaBannerRequired = translate("govuk.betaBannerRequired") %}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{# if service name is not set, overwrite the page title from gov-uk/template.njk #}
+{% set hmpoPageTitle = "pages."+hmpoPageKey+".title" %}
+{% block pageTitle %}
+{{ translate(hmpoPageTitle) }} – GOV.UK
+{% endblock %}
+
+{# show the beta banner if the boolean is true #}
+{% block beforeContent %}
+{% if 'true' in betaBannerRequired %}
+{% include "../shared/phase-banner.html" %}
+{% endif %}
+{% endblock %}
+
+{# output the correct service footer #}
+{% block footer %}
+{{ govukFooter( footerNavItems ) }}
+{% endblock %}
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

[PYIC-1221] This is the initial thinking to create a global setting in the yaml and nunjucks files for core-front to allow us to show the beta message and the footer content on each page while controlling changes from a single file, currently `default.yml`. The global settings that have been added in `default.yml` are

* `betaBannerRequired: true` to turn the banner off and on
* `footerNavItems` which holds a list of footer nav items as request by the content design team

To use these new variables, the nunjucks pages have the following code added:

### To allow for greater control over the page title tag
```
{% set hmpoPageTitle = "pages."+hmpoPageKey+".title" %}
{# override page title #}
{% block pageTitle %}
{{ translate(hmpoPageTitle) }} – GOV.UK
{% endblock %}
```
### To have a global setting for the beta banner
```
{% set betaBannerRequired = translate("govuk.betaBannerRequired") %}
{# output beta banner if set #}
{% block beforeContent %}
{% if 'true' in betaBannerRequired %}
{% include "../shared/phase-banner.html" %}
{% endif %}
{% endblock %}
```
### To output a standard footer with the footer content coming from `default.yml`

```
{# output IPV standard footer #}
{% block footer %}
{{ govukFooter( footerNavItems ) }}
{% endblock %}
```

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1221](https://govukverify.atlassian.net/browse/PYIC-1221)

### Other considerations

If this is a suitable direction then the same needs adding to the passport-front CRI repository.


[PYIC-1221]: https://govukverify.atlassian.net/browse/PYIC-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ