### PR TITLE
PYIC-1367: Update debug rouet to use journey engine

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -6,10 +6,6 @@ module.exports = {
     res.render("index-hmpo");
   },
 
-  redirectToDebugPage: async (_req, res) => {
-    res.redirect("/debug");
-  },
-
   redirectToJourney: async (_req, res) => {
     res.redirect("/ipv/journey/next");
   },

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -139,14 +139,6 @@ describe("oauth middleware", () => {
     });
   });
 
-  describe("redirectToDebugPage", () => {
-    it("should redirect to debug page", () => {
-      middleware.redirectToDebugPage(req, res);
-
-      expect(res.redirect).to.have.been.calledWith("/debug");
-    });
-  });
-
   describe("redirectToJourney", () => {
     it("should redirect to journey route", () => {
       middleware.redirectToJourney(req, res);

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -3,7 +3,6 @@ const express = require("express");
 const router = express.Router();
 
 const {
-  redirectToDebugPage,
   redirectToJourney,
   setIpvSessionId, setDebugJourneyType, setRealJourneyType,
 } = require("./middleware");
@@ -12,7 +11,7 @@ router.get(
   "/debug-authorize",
   setDebugJourneyType,
   setIpvSessionId,
-  redirectToDebugPage
+  redirectToJourney
 );
 
 router.get(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the landing debug-journey route to use the journey engine instead of always going straight to the debug page.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
In case there is a recoverable error on the debug journey then the starting state might not be the DEBUG_PAGE state and so the SessionEnd lambda should be called straight away instead of rendering the debug page.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1367](https://govukverify.atlassian.net/browse/PYIC-1367)

