### PR TITLE
BAU: Set trust proxy on express app

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,7 @@ const sessionConfig = {
   secret: SESSION_SECRET,
 };
 
-const { router } = setup({
+const { app, router } = setup({
   config: { APP_ROOT: __dirname },
   port: PORT,
   logs: loggerConfig,
@@ -26,6 +26,8 @@ const { router } = setup({
   publicDirs: ["../dist/public"],
   dev: true,
 });
+
+app.set('trust proxy', 2)
 
 router.use("/oauth2", require("./app/oauth2/router"));
 router.use("/credential-issuer", require("./app/credential-issuer/router"));


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set trust proxy on express app

### Why did it change

Currently the frontends session cookies are not being set with the
Secure attribute, which they probably should be.

The hmpo-app framework we're using is setting the session cookie option
to `secure: 'auto'` which means it checks the `x-forwarded-proto` header
to determine if the original request was https (the TLS gets terminated
at the API gateway for us)

Express won't trust or use the `X-Forwarded` headers unless you tell it
to: https://expressjs.com/en/guide/behind-proxies.html

This sets up the app to trust at most a reverse proxy two hops away.
API Gateway -> ALB -> Express
