### PR TITLE
PYIC-1290 Permit S3 logging to Access Bucket

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -100,6 +100,7 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ipv-core-${Environment}-access-logs
+      AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: "Enabled"
       PublicAccessBlockConfiguration:
@@ -111,6 +112,23 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+
+  AccessLoggingBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Condition: IsNotDevelopment
+      Properties:
+        Bucket: !Ref AccessLogsBucket
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: logging.s3.amazonaws.com
+              Action: s3:PutObject
+              Resource: !Sub "arn:aws:s3:::${AccessLogsBucket}/*"
+              Condition:
+                StringEquals:
+                  'aws:SourceAccount': !Sub "${AWS::AccountId}"
 
   CoreFrontAccessLogsBucketPolicy:
     Condition: IsNotDevelopment


### PR DESCRIPTION
Update the Access Logs Bucket's policy to permit S3 access logs to be
written into it. Also update the buckets ACL policy to permit log
delivery write.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
So we can send bucket access logs to this bucket.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1290](https://govukverify.atlassian.net/browse/PYIC-1290)

