### PR TITLE
PYIC-1281 Fix Bucket Policy Dependency

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -96,7 +96,6 @@ Resources:
       SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
 
   AccessLogsBucket:
-    Condition: IsNotDevelopment
     Type: AWS::S3::Bucket
     #checkov:skip=CKV_AWS_18: This is the bucket where our access logs go and AWS advise not sending a bucket's access logs to itself.
     Properties:
@@ -115,7 +114,6 @@ Resources:
               SSEAlgorithm: AES256
 
   CoreFrontAccessLogsBucketPolicy:
-    Condition: IsNotDevelopment
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref AccessLogsBucket
@@ -167,6 +165,7 @@ Resources:
           - Key: access_logs.s3.prefix
             Value: !Sub core-front-${Environment}
           - !Ref AWS::NoValue
+    DependsOn: CoreFrontAccessLogsBucketPolicy
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
The access logs bucket policy must be applied before the ALB is created
which needs access to the bucket to send its access logs to. Previously
we were only creating the access logs bucket and its policy in
non-development environments. Unfortunately the CFN `DependsOn` does not
support `!If` conditions. Therefore it is necessary to create the bucket
and its policy in all environments, however we can continue to only send
ALB access logs to it in non-development environments.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1281](https://govukverify.atlassian.net/browse/PYIC-1281)
