### PR TITLE
BAU: Remove authorize route from CRI router

### DIFF
--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -8,10 +8,6 @@ const {
   tryHandleRedirectError
 } = require("./middleware");
 
-const { buildCredentialIssuerRedirectURL, redirectToAuthorize } = require('../shared/criHelper');
-
-router.get("/authorize", buildCredentialIssuerRedirectURL, redirectToAuthorize);
-
 router.get(
   "/callback",
   tryHandleRedirectError,


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove authorize route from CRI router

### Why did it change

Building the URL to send a user to a CRI is handled in the
handleJourneyResponse method of the ipv middleware. We never use this
authorize route so should remove it.
