### PR TITLE
[PYIC-1420] Remove empty link from GOV.UK header

### DIFF
--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -48,11 +48,18 @@
     {% endif %}
 {% endblock %}
 
+
+{% block govukHeader %}
+    {# to remediate accessibility issues the header does not include the service name #}
+    {# this overrides the behaviour in hmpo-template.njk and calls the 'minimal' GOV.UK header #}
+    {{ govukHeader({}) }}
+{% endblock %}
+
 {# the BETA banner is added to all pages using this template by default #}
 {% block beforeContent %}
     {{ govukPhaseBanner({
     tag: { text: "beta" },
-    html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a>  will help us to improve it.'
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change modifies the global core template to remove the option to add a service name. The empty hyperlink in the source code created when the service name was set to an empty string causes accessibility issues with tabbing through the document and using a screen reader.

### What changed

<!-- Describe the changes in detail - the "what"-->
The `{% block govukHeader %}` is set to use a simple call to `{{ govukHeader({}) }}` with no attributes.


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

To allow the service to meet WCAG 2.1 accessibility standards.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1420](https://govukverify.atlassian.net/browse/PYIC-1420)
