### PR TITLE
PYIC-1460 Increase Desired Task Count in Production

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,8 +34,11 @@ Parameters:
     Type: String
   DesiredTaskCount:
     Description: >-
-      The number of core front ecs tasks to run.
+      This is being replaced by the desiredTaskCount with the Mapping section. Its removal
+      must be coordinated with changes to our CI configuration to avoid breaking
+      deployments in the interim.
     Type: Number
+    Default: 1
 
 Conditions:
   IsNotDevelopment: !Or
@@ -43,6 +46,22 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+
+# The AWS Account Id is used in the following mapping section because we have
+# multiple developer environments and it is undesirable to have to keep this
+# mapping up to date with each developer environment.
+Mappings:
+  EcsConfiguration:
+    "130355686670": # Development
+      desiredTaskCount: 1
+    "457601271792": # Build
+      desiredTaskCount: 1
+    "335257547869": # Staging
+      desiredTaskCount: 1
+    "991138514218": # Integration
+      desiredTaskCount: 1
+    "075701497069": # Production
+      desiredTaskCount: 2
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -214,7 +233,10 @@ Resources:
           Rollback: true
       DeploymentController:
         Type: ECS
-      DesiredCount: !Ref DesiredTaskCount
+      DesiredCount: !FindInMap
+        - EcsConfiguration
+        - !Ref AWS::AccountId
+        - desiredTaskCount
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE


### PR DESCRIPTION
This is necessary for increased resilience by running across two
availability zones. No other changes should be necessary since Fargate's
default deployment strategy is to spread across AZs.

Update the template so that the task desired count is defined within the
template rather than passing from CI configuration. This should make it
simpler to amend and find in future and simplify the roll-out of such
changes.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
In preparation for going live we ensuring our system is running across at least 2 AZ. We may likely have to make further adjustments to desired task count (and memory) once we've done some performance testing but this meets the requirements whilst balancing cost.

### Notes
This has been applied into my dev environment and works as expected.

CFN `Mappings` section does not support defaults. All of the possible values passed to the `Environments` param are unknown since the developer environments are numerous and change with onboarding/offboarding. I tried different ways of making the `!FindInMap` work with the `Environment` parameters which I think is more readable than the account ID but unfortunately we are restricted by CFN functionality. Even making the `!FindInMap` conditional does work because the validation of the template still fails.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1460](https://govukverify.atlassian.net/browse/PYIC-1460)


