### PR TITLE
PYIC-1460 Remove DesiredTaskCount param

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -32,13 +32,6 @@ Parameters:
       The VPC id in which to create the components.
       Example "vpc-123"
     Type: String
-  DesiredTaskCount:
-    Description: >-
-      This is being replaced by the desiredTaskCount with the Mapping section. Its removal
-      must be coordinated with changes to our CI configuration to avoid breaking
-      deployments in the interim.
-    Type: Number
-    Default: 1
 
 Conditions:
   IsNotDevelopment: !Or


### PR DESCRIPTION
This is now set in the mappings section and has been removed from the
Concourse CI configuration. It is safe to remove.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->


### What changed
This is to be merged after https://github.com/alphagov/di-ipv-config/pull/739