### PR TITLE
PYIC-1460 Update core-front utils script

### DIFF
--- a/utils/deploy_to_dev_env.sh
+++ b/utils/deploy_to_dev_env.sh
@@ -27,7 +27,12 @@ DEV_IMAGE_TAG="${ENVIRONMENT}-$(date +%s)"
 if ! aws cloudformation describe-stacks \
     --stack-name "$STACK_NAME" \
     --region eu-west-2 > /dev/null 2>&1 ; then
-  echo "The stack 'core-front-${ENVIRONMENT}' does not exist. Ask in ipv-tech for help"
+  echo "The stack 'core-front-${ENVIRONMENT}' has not been found."
+  echo " - check the script has been run with the required permissions, e.g. aws-vault exec <profile> -- $0"
+  echo " - check you are on the VPN"
+  echo " - check whether your stack exists via the console or cli, if not you may need to: "
+  echo "    - Run your developer pipeline in Concourse to create it"
+  echo "    - if you do not have a developer pipeline then ask a team member to update di-ipv-config/core/ci/core-developer-pipelines"
   exit 1
 fi
 
@@ -70,7 +75,6 @@ aws cloudformation update-stack \
                ParameterKey=Environment,UsePreviousValue=true \
                ParameterKey=SubnetIds,UsePreviousValue=true \
                ParameterKey=VpcId,UsePreviousValue=true \
-               ParameterKey=DesiredTaskCount,UsePreviousValue=true \
   --capabilities CAPABILITY_IAM \
   --region eu-west-2
 


### PR DESCRIPTION
No longer pass the desired task count when deploying core front and
improve the help message when a developers' task cannot be found.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
No need to pass the task desired count when deploying core front because this is set via the mappings section in the template.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The help text when a stack cannot be found now read:

```
Enter your developer environment prefix, for example 'dev-danw'
dev-danw
The stack 'core-front-dev-danw' has not been found.
 - check the script has been run with the required permissions, e.g. aws-vault exec <profile> -- ./deploy_to_dev_env.sh
 - check you are on the VPN
 - check whether your stack exists via the console or cli, if not you may need to:
    - Run your developer pipeline in Concourse to create it
    - if you do not have a developer pipeline then ask a team member to update di-ipv-config/core/ci/core-developer-pipelines

```
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1460](https://govukverify.atlassian.net/browse/PYIC-1460)
