### PR TITLE
PYIC-1456: create core-front dynamoDB table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -315,19 +315,17 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "dynamodb:BatchGet*"
-                  - "dynamodb:DescribeStream"
+                  - "dynamodb:BatchGetItem"
                   - "dynamodb:DescribeTable"
-                  - "dynamodb:Get*"
+                  - "dynamodb:GetItem"
                   - "dynamodb:Query"
                   - "dynamodb:Scan"
-                  - "dynamodb:BatchWrite*"
-                  - "dynamodb:CreateTable"
-                  - "dynamodb:Delete*"
-                  - "dynamodb:Update*"
+                  - "dynamodb:BatchWriteItem"
+                  - "dynamodb:DeleteItem"
+                  - "dynamodb:UpdateItem"
                   - "dynamodb:PutItem"
                 Resource:
-                  - "arn:aws:dynamodb:*:*:table/core-front-sessions-*"
+                  - !GetAtt CoreFrontSessionsTable.Arn
 
   ECSTaskRole:
     Type: 'AWS::IAM::Role'

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -309,6 +309,26 @@ Resources:
                 Resource:
                   - !GetAtt "ECSAccessLogsGroup.Arn"
                   - !Sub "${ECSAccessLogsGroup.Arn}:*"
+        - PolicyName: CoreFrontDynamoDBSessionAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "dynamodb:BatchGet*"
+                  - "dynamodb:DescribeStream"
+                  - "dynamodb:DescribeTable"
+                  - "dynamodb:Get*"
+                  - "dynamodb:Query"
+                  - "dynamodb:Scan"
+                  - "dynamodb:BatchWrite*"
+                  - "dynamodb:CreateTable"
+                  - "dynamodb:Delete*"
+                  - "dynamodb:Update*"
+                  - "dynamodb:PutItem"
+                Resource:
+                  - "arn:aws:dynamodb:*:*:table/core-front-sessions-*"
+
   ECSTaskRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -418,6 +438,26 @@ Resources:
               Condition:
                 ArnLike:
                   "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  CoreFrontSessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
+      TableName: !Sub "core-front-sessions-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "expires"
+        Enabled: true
+      SSESpecification:
+        # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
+        SSEEnabled: true
+        SSEType: KMS
 
 Outputs:
   CoreFrontUrl:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create a new DynamoDB table to be used by core front to hold our front-end session data. 

The table has an "id" partition key with ttl enabled based off the "expires" field.

Also added a new policy to the core-front execution IAM role to allow access to the table from the ECS instance.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We are using DynamoDB as our persistent data storage of the front-end session data. We are using an npm package to handle the connection to and reading from the dynamoDB table which expects to use an "id" param to read from the table.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1456](https://govukverify.atlassian.net/browse/PYIC-1456)

