### PR TITLE
BAU: Validate that page requests are from a set list

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -86,8 +86,17 @@ module.exports = {
       switch (pageId) {
         case "page-ipv-debug":
           return res.redirect("/debug");
-        default:
+        case "page-ipv-error":
+        case "page-ipv-identity-start":
+        case "page-ipv-success":
+        case "page-pre-kbv-transition":
+        case "pyi-kbv-fail":
+        case "pyi-no-match":
+        case "pyi-technical":
+        case "pyi-technical-unrecoverable":
           return res.render(`ipv/${pageId}`);
+        default:
+          return res.render(`ipv/pyi-technical`);
       }
     } catch (error) {
       res.error = error.name;

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -132,13 +132,22 @@ describe("journey middleware", () => {
       expect(res.redirect).to.have.been.calledWith("/debug");
     });
 
-    it("should render default case when given valid pageId", async () => {
+    it("should render page case when given valid pageId", async () => {
       req = {
-        query: { pageId: "page-cri-start" },
+        query: { pageId: "page-ipv-identity-start" },
       };
 
       await middleware.handleJourneyPage(req, res);
-      expect(res.render).to.have.been.calledWith("ipv/page-cri-start");
+      expect(res.render).to.have.been.calledWith("ipv/page-ipv-identity-start");
+    });
+
+    it("should render technical error page when given invalid pageId", async () => {
+      req = {
+        query: { pageId: "../debug/page-ipv-debug" },
+      };
+
+      await middleware.handleJourneyPage(req, res);
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical");
     });
 
     it("should raise an error when missing pageId", async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a set of case statements for all the valid pages, rendering those value and defaulting to an error page.

### Why did it change

We need to avoid the possibility of a traversal attack on our input pageid. We are likely to rework how we handle page loading, but we need to put a fix in place quickly.

