### PR TITLE
PYIC-1493 Add a healthcheck endpoint

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -184,8 +184,9 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckPath: /healthcheck
       Matcher:
-        HttpCode: 200-499
+        HttpCode: 200
       Port: 80
       Protocol: HTTP
       TargetType: ip


### PR DESCRIPTION
Adds a basic health check endpoint to confirm the server is running. This
is then used by the Application Load Balancer Target Group where it
expects a 200 http status code.

This change removes the noisy 404 http status codes in the app logs. The
request to the health check and its 200 response are not logged in the
application logs as per feedback from the team. The Target Group metrics
show the healthy host count and can be used to investigate.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
Added a `/healthcheck`
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Remove the noise from `404` healthcheck requests to the root of the app. This also enables us to implement Route53 healthcheck on the HZ and improve our Amazon Shield Advanced protection.


This has been run into my dev environment and the ECS task becomes stable as expected.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1493](https://govukverify.atlassian.net/browse/PYIC-1493)

