### PR TITLE
BAU: Fix core-front session dyanamoDB policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -340,6 +340,18 @@ Resources:
                 Resource:
                   - !GetAtt "ECSAccessLogsGroup.Arn"
                   - !Sub "${ECSAccessLogsGroup.Arn}:*"
+
+  ECSTaskRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      Policies:
         - PolicyName: CoreFrontDynamoDBSessionAccess
           PolicyDocument:
             Version: "2012-10-17"
@@ -357,17 +369,6 @@ Resources:
                   - "dynamodb:PutItem"
                 Resource:
                   - !GetAtt CoreFrontSessionsTable.Arn
-
-  ECSTaskRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: "sts:AssumeRole"
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: 2012-10-17
 
   # Create the VPC Link to join the API Gateway to the
   # private Load Balancer in front of Core Front ECS

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -63,6 +63,7 @@ Resources:
     Properties:
       GroupDescription: >-
         Core Front LoadBalancer Security Group
+      # checkov:skip=CKV_AWS_260: Security group rules to be reviewed in JIRA PYIC-1464
       SecurityGroupIngress:
         - CidrIp: 0.0.0.0/0
           Description: Allow from anyone on port 80


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Move the policy that allows DynamoDB read/write access to the new core-front table to the ECSTaskRole role.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The policy had previously been added to the ECSTaskExecutionRole which was incorrect. The policy needed to be added to the ECSTaskRole instead.
<!-- Describe the reason these changes were made - the "why" -->

