### PR TITLE
PYIC-1416 and cookie banner: temporarily remove cookie banner

### DIFF
--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -34,12 +34,17 @@
 <!-- End Google Tag Manager -->
 {% endblock %}
 
+<!-- temporarily remove the cookie banner -->
+{% block cookieBanner %}
+{% endblock %}
+
 {% block bodyStart %}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TK92W68"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endblock %}
+
 
 
 {% block pageTitle %}
@@ -54,7 +59,7 @@
 {% block govukHeader %}
     {# to remediate accessibility issues the header does not include the service name #}
     {# this overrides the behaviour in hmpo-template.njk and calls the 'minimal' GOV.UK header #}
-    {{ govukHeader({}) }}
+    {{ govukHeader({homepageUrl:"https://www.gov.uk"}) }}
 {% endblock %}
 
 {# the BETA banner is added to all pages using this template by default #}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This update temporarily removes the cookie banner and permanently adds the correct URL for the header link to the GOV.UK homepage.

### What changed

<!-- Describe the changes in detail - the "what"-->

Nunjucks block overrides the cookie banner code; attribute added to the header to feed in a `homepageUrl`.

### Why did it change

To meet user needs and remove the display of unnecessary text.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1416](https://govukverify.atlassian.net/browse/PYIC-1416) and https://gds.slack.com/archives/C0222KXB6RM/p1656070344007499

