### PR TITLE
PYIC-1376 - Rewrite request header's x-forwarded-proto

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "express-async-errors": "3.1.1",
     "express-session": "^1.17.3",
     "govuk-frontend": "4.0.1",
-    "hmpo-app": "2.2.1",
+    "hmpo-app": "2.3.0",
     "hmpo-components": "5.3.0",
     "hmpo-config": "2.2.0",
     "hmpo-form-wizard": "12.0.3",

--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,12 @@ const { router } = setup({
   },
   publicDirs: ["../dist/public"],
   dev: true,
+  middlewareSetupFn: (app) => {
+    app.use(function (req, res, next) {
+      req.headers["x-forwarded-proto"] = "https";
+      next();
+    });
+  },
 });
 
 router.use("/oauth2", require("./app/oauth2/router"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,10 +1889,15 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hmpo-app@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/hmpo-app/-/hmpo-app-2.2.1.tgz#e5839fb49f550aeec531f5a1b9851471b67c59d8"
-  integrity sha512-XBe8/KCiMqrvFWTqqFGxoJ5WnihBpiEA8uRekidGKXj9ev7cOrO7R6iSNkzZfVUwyGzOISNqlJ9oZYybNoRZyg==
+helmet@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-5.1.0.tgz#e98a5d4bf89ab8119c856018a3bcc82addadcd47"
+  integrity sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g==
+
+hmpo-app@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hmpo-app/-/hmpo-app-2.3.0.tgz#9ac43f50bbe1d22acdbb0df0e0775dc76496bd6a"
+  integrity sha512-okBETJEmTQyQNZ0HaYQtpiKdWcwqBaokmGU1wqZ1KfMRxuXxbIuc/5t9g7f7khG4RbMLuaJ8e+H7ZyVIVdO78A==
   dependencies:
     async "^3.2.4"
     body-parser "^1.20.0"
@@ -1904,6 +1909,7 @@ hmpo-app@2.2.1:
     express-session "^1.17.3"
     fakeredis "^2.0.0"
     frameguard "^4.0.0"
+    helmet "5.1.0"
     nocache "^3.0.4"
     on-finished "^2.4.1"
     redis "4.0.x"


### PR DESCRIPTION
### What changed

Added middleware setup to rewrite the incoming request header value `x-forwarded-proto` to be https
Updated HMPO-App to 2.3.0 to have the ability to inject custom middleware

### Why did it change

The existing infrastructure configuration is causing the Load Balancer to forward the incorrect header `value x-fowarded-proto`.  Infrastructure cannot overwrite the value due to where the TLS termination ends and requires the app to explicitly trust that the original request is secure. 

<!-- Describe the reason these changes were made - the "why" -->
- [PYIC-1376](https://govukverify.atlassian.net/browse/PYIC-1376)
