### PR TITLE
Pyic 1519 log response latency

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -440,7 +440,8 @@ Resources:
           "routeKey":"$context.routeKey",
           "status":"$context.status",
           "protocol":"$context.protocol",
-          "responseLength":"$context.responseLength"
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency"
           }
 
   APIGWAccessLogsGroup:

--- a/utils/deploy_to_dev_env.sh
+++ b/utils/deploy_to_dev_env.sh
@@ -75,7 +75,7 @@ function check_connection() {
 }
 
 function init() {
-  region=$(aws configure get region)
+  region='eu-west-2'
   account_id=$(aws sts get-caller-identity --query Account --output text)
   STACK_NAME="core-front-${ENVIRONMENT}"
   DEV_IMAGE_TAG="${ENVIRONMENT}-$(date +%s)"
@@ -113,7 +113,7 @@ function build_image() {
 function isStackUpdateComplete() {
   status="$(aws cloudformation describe-stacks \
     --stack-name "$STACK_NAME" \
-    --region eu-west-2 \
+    --region "${region}" \
     | jq '.Stacks[].StackStatus' -r )"
 
   echo "Current status is: ${status}"
@@ -133,7 +133,7 @@ function update_stack() {
                  ParameterKey=SubnetIds,UsePreviousValue=true \
                  ParameterKey=VpcId,UsePreviousValue=true \
     --capabilities CAPABILITY_IAM \
-    --region eu-west-2
+    --region "${region}"
 
   while ! isStackUpdateComplete
   do


### PR DESCRIPTION
BAU Add Response Latency To Frontend API Logs

Log the response latency in the Core Front API Gateway logs. This will be useful in Splunk.


## Proposed changes
As above

### What changed
Additional structured field in the Core front API Gateway access logs. I have deployed this into my dev environment and the logs now contain the expected field
```
GDS11321:~ dan.worth$ aws-vault exec di-ipv-dev -- awslogs get /aws/apigateway/core-front-dev-danw-CoreFront-API-GW-AccessLogs --aws-region eu-west-2 -S -G | jq '.'
{
  "requestId": "UieGvippLPEEPvQ=",
  "ip": "213.86.153.237",
  "requestTime": "30/Jun/2022:13:50:34 +0000",
  "httpMethod": "GET",
  "path": "/oauth2/debug-authorize",
  "routeKey": "ANY /{proxy+}",
  "status": "302",
  "protocol": "HTTP/1.1",
  "responseLength": "78",
  "responseLatency": "4766"
}
```

Also a minor change to the deploy core front script for those using `aws-vault` and without a default profile configured in their `~/.aws/config` file (`aws configure` does not consider env var `AWS_REGION` which is set by `aws-vault exec`). This means the script failed for me because the ecr registry arn was malformed. Also update so its use is consistent within the script. `eu-west-2` is only ever used.

### Why did it change
Having the response latency in the logs will be useful in Splunk.
<!-- Describe the reason these changes were made - the "why" -->
