### PR TITLE
BAU: Adjust app log config

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,7 @@ const loggerConfig = {
     ipvSessionId: "session.ipvSessionId",
   },
   meta: {
-    ipvSessionId: "req.session.ipvSessionId",
+    ipvSessionId: "session.ipvSessionId",
   },
 };
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adjust app log config

### Why did it change

We've configured the app logs to log the ipvSessionId by pulling it from
the session. To do this we need to pass the request object to any
application logs we generate. For example:

        `logger.info('hello world', {req})`

Once the logger has the request object, it just needs to call,
`session.ipvSessionId` on it, without the `req` prefix we originally
included in the config. This has been tested in the passport front.
