### PR TITLE
PYIC-1489: App logs and config

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,7 @@ const loggerConfig = {
     ipvSessionId: "session.ipvSessionId",
   },
   meta: {
-    ipvSessionId: "req.session.ipvSessionId",
+    ipvSessionId: "session.ipvSessionId",
   },
 };
 

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -5,6 +5,7 @@ const {
   EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
 const { generateAxiosConfig } = require("../shared/axiosHelper");
+const logger = require("hmpo-logger").get();
 
 module.exports = {
   addCallbackParamsToRequest: async (req, _res, next) => {
@@ -28,6 +29,7 @@ module.exports = {
     ]);
 
     try {
+      logger.info("calling cri return lambda", { req, res });
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_RETURN_PATH}`,
         evidenceParam,
@@ -37,6 +39,7 @@ module.exports = {
 
       res.redirect(`/ipv${apiResponse.data?.journey}`);
     } catch (error) {
+      logger.error("error calling cri return lambda", { req, res, error });
       if (error?.response?.status === 404) {
         res.status = error.response.status;
       } else {
@@ -50,6 +53,10 @@ module.exports = {
       const { error, error_description, id } = req.query;
 
       if (error || error_description) {
+        logger.error("error or error_description received in callback", {
+          req,
+          res,
+        });
         const errorParams = new URLSearchParams([
           ["error", error],
           ["error_description", error_description],
@@ -66,6 +73,7 @@ module.exports = {
 
       return next();
     } catch (error) {
+      logger.error("error calling cri error lambda", { req, res, error });
       return next(error);
     }
   },

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -4,16 +4,19 @@ const {
   API_REQUEST_CONFIG_PATH,
   API_ISSUED_CREDENTIALS_PATH,
 } = require("../../lib/config");
+const logger = require("hmpo-logger").get();
 
 module.exports = {
   setCriConfig: async (req, res, next) => {
     if (!req.session.criConfig) {
       try {
+        logger.info("calling cri config lambda", { req, res });
         const apiResponse = await axios.get(
           `${API_BASE_URL}${API_REQUEST_CONFIG_PATH}`
         );
         req.session.criConfig = apiResponse.data;
       } catch (error) {
+        logger.error("error calling cri config lambda", { req, res, error });
         res.error = error.name;
         return next(error);
       }
@@ -23,6 +26,7 @@ module.exports = {
 
   getIssuedCredentials: async (req, res, next) => {
     try {
+      logger.info("calling issued credentials lambda", { req, res });
       const apiResponse = await axios.get(
         `${API_BASE_URL}${API_ISSUED_CREDENTIALS_PATH}`,
         {
@@ -39,6 +43,7 @@ module.exports = {
 
       req.issuedCredentials = parsedResponse;
     } catch (error) {
+      logger.error("error fetching issued credentials", { req, res, error });
       res.error = error.name;
       return next(error);
     }

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,12 +1,14 @@
 const axios = require("axios");
 const { API_BASE_URL } = require("../../lib/config");
+const logger = require("hmpo-logger").get();
 
 module.exports = {
   redirectToJourney: async (_req, res) => {
     res.redirect("/ipv/journey/next");
   },
 
-  setDebugJourneyType: (req, _res, next) => {
+  setDebugJourneyType: (req, res, next) => {
+    logger.info("starting debug journey", { req, res });
     req.session.isDebugJourney = true;
     next();
   },
@@ -35,12 +37,14 @@ module.exports = {
         return next(new Error("Client ID Missing"));
       }
 
+      logger.info("calling session start lambda", { req, res });
       const response = await axios.post(
         `${API_BASE_URL}/session/start`,
         authParams
       );
       req.session.ipvSessionId = response?.data?.ipvSessionId;
     } catch (error) {
+      logger.error("error calling session start lambda", { req, res, error });
       res.error = error.name;
       return next(error);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adjust app log config and add a smattering of app logs

### Why did it change

[PYIC-1484: Adjust app log](https://github.com/alphagov/di-ipv-core-front/commit/a17681b3d8abe1070924b36337a115dc0e8faa37) 

We've configured the app logs to log the ipvSessionId by pulling it from
the session. To do this we need to pass the request object to any
application logs we generate. For example:

        `logger.info('hello world', {req})`

Once the logger has the request object, it just needs to call,
`session.ipvSessionId` on it, without the `req` prefix we originally
included in the config. This has been tested in the passport front.
  
[PYIC-1489: App app logs](https://github.com/alphagov/di-ipv-core-front/commit/4f32f921312ec95354ce573e7b80bae31ab6b747) 

This adds a few app logs throughout the various middleware, mostly
surrounding calls to the backend. This will help us track journeys
through the system.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1489](https://govukverify.atlassian.net/browse/PYIC-1489)

