### PR TITLE
PYIC-1523 - use onSubmit to disable submit input and to prevent subse…

### DIFF
--- a/src/views/shared/journey-next-form.njk
+++ b/src/views/shared/journey-next-form.njk
@@ -1,9 +1,18 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<form action="/ipv/page/{{pageId}}" method="POST">
+<form id="nextForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return nextFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-
-    <button class="govuk-button" data-module="govuk-button" onclick="this.disabled=true;this.form.submit();">
-        {{translate("buttons.next")}}
-    </button>
+    <input id="nextSubmit" type="submit" class="govuk-button" value="{{translate("buttons.next")}}">
 </form>
+
+<script>
+    let disableSubmit = false;
+    function nextFormSubmit() {
+      if(!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('nextSubmit').disabled = true;
+        return true
+      }
+      return false;
+    }
+</script>


### PR DESCRIPTION
### What changed

Use onSubmit to disable submit input and to prevent subsequent form submissions

### Why did it change

Previously used the click event of the button to disable the button to prevent multiple clicks but this did not account for edge cases where user is not using a mouse.

- [PYIC-1523](https://govukverify.atlassian.net/browse/PYIC-1523)


