### PR TITLE
PYIC-1433 - Journey responses now handled on the serverside and not r…

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -145,4 +145,5 @@ module.exports = {
       next(error);
     }
   },
+  handleJourneyResponse,
 };


### PR DESCRIPTION
### What changed
Journey responses now handled on the server side and not response redirects.


### Why did it change

To reduce the exposed routes and not allow user to affect the journey by manually entering journey routes in the browser.

- [PYIC-1433](https://govukverify.atlassian.net/browse/PYIC-1433)
