### PR TITLE
PYIC-1435 - removed redundant ipv routes

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -70,26 +70,6 @@ function tryValidateClientResponse(client) {
 }
 
 module.exports = {
-  updateJourneyState: async (req, res, next) => {
-    try {
-      const action = req.url;
-      //valid list of allowed actions for route
-      const allowedActions = [
-        /^\/journey\/(next|error|fail)$/,
-        /^\/journey\/cri\/start\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv|activityHistory|stubActivityHistory|debugAddress)$/,
-        /^\/journey\/session\/end$/,
-        /^\/journey\/cri\/validate\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv)$/,
-      ];
-
-      if (allowedActions.some((actionRegex) => actionRegex.test(action))) {
-        await handleJourneyResponse(req, res, action);
-      } else {
-        next(new Error(`Action ${action} not valid`));
-      }
-    } catch (error) {
-      next(error);
-    }
-  },
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -3,17 +3,12 @@ const csrf = require("csurf");
 const bodyParser = require("body-parser");
 const router = express.Router();
 
-const {
-  updateJourneyState,
-  handleJourneyPage,
-  handleJourneyNext,
-} = require("./middleware");
+const { handleJourneyPage, handleJourneyNext } = require("./middleware");
 
 const csrfProtection = csrf({});
 const parseForm = bodyParser.urlencoded({ extended: false });
 
 router.get("/page/:pageId", csrfProtection, handleJourneyPage);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyNext);
-router.get("/*", updateJourneyState);
 
 module.exports = router;


### PR DESCRIPTION
### What changed
Removed redundant IPV routes now that journey engine is called internally

### Why did it change

To reduce the exposed routes and not allow user to affect the journey by manually entering journey routes in the browser.

- [PYIC-1435](https://govukverify.atlassian.net/browse/PYIC-1435)
