### PR TITLE
PYIC-1575 add classes for google analytics

### DIFF
--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -38,6 +38,13 @@
     }) }}
 {% endblock %}
 
+{# add the correct classes to the h1 tag #}
+{% block mainContent %}
+<h1 class="govuk-heading-l" id="header" data-page="{{hmpoPageKey}}">{{ translate("pages." + hmpoPageKey + ".h1", { default: hmpoTitle }) | safe }}</h1>
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+{{ hmpoHtml(translate("pages." + hmpoPageKey + ".content", { default: [] })) }}
+{% endblock %}
+
 {# generate the specific footer items required for the PYI flows #}
 
 {% set footerNavItems = translate("govuk.footerNavItems") %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This adds a class to the `<h1>` tag to help describe the page contents for google analytics.

### What changed

<!-- Describe the changes in detail - the "what"-->

The `mainContent` block is overridden from `hmpo-template.njk` so the class can be added to the attributes on the `<h1>` tag.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Requested by the GA team.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1575](https://govukverify.atlassian.net/browse/PYIC-1575)


