### PR TITLE
PYIC-1719: update core-front to use new renamed lambdas

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const {
   API_BASE_URL,
-  API_CRI_RETURN_PATH,
+  API_CRI_ACCESS_TOKEN_PATH,
   EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
 const { generateAxiosConfig } = require("../shared/axiosHelper");
@@ -31,7 +31,7 @@ module.exports = {
     try {
       logger.info("calling cri return lambda", { req, res });
       const apiResponse = await axios.post(
-        `${API_BASE_URL}${API_CRI_RETURN_PATH}`,
+        `${API_BASE_URL}${API_CRI_ACCESS_TOKEN_PATH}`,
         evidenceParam,
         generateAxiosConfig(req.session.ipvSessionId)
       );

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -29,7 +29,7 @@ module.exports = {
     ]);
 
     try {
-      logger.info("calling cri return lambda", { req, res });
+      logger.info("calling build-cri-oauth-access-token lambda", { req, res });
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_ACCESS_TOKEN_PATH}`,
         evidenceParam,
@@ -39,7 +39,11 @@ module.exports = {
 
       return handleJourneyResponse(req, res, apiResponse.data?.journey);
     } catch (error) {
-      logger.error("error calling cri return lambda", { req, res, error });
+      logger.error("error calling  build-cri-oauth-access-token lambda", {
+        req,
+        res,
+        error,
+      });
       if (error?.response?.status === 404) {
         res.status = error.response.status;
       } else {

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -50,7 +50,7 @@ describe("credential issuer middleware", () => {
     let ipvMiddlewareStub = {};
 
     beforeEach(() => {
-      configStub.API_CRI_RETURN_PATH = "/ADD-EVIDENCE";
+      configStub.API_CRI_ACCESS_TOKEN_PATH = "/access-token";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
@@ -98,7 +98,7 @@ describe("credential issuer middleware", () => {
         await middleware.sendParamsToAPI(req, res, next);
 
         expect(axiosStub.post).to.have.been.calledWith(
-          "https://example.net/path/ADD-EVIDENCE",
+          "https://example.net/path/access-token",
           searchParams,
           sinon.match({
             headers: {

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -2,7 +2,7 @@ const axios = require("axios");
 const {
   API_BASE_URL,
   API_REQUEST_CONFIG_PATH,
-  API_ISSUED_CREDENTIALS_PATH,
+  API_BUILD_DEBUG_CREDENTIAL_DATA_PATH,
 } = require("../../lib/config");
 const logger = require("hmpo-logger").get();
 
@@ -28,7 +28,7 @@ module.exports = {
     try {
       logger.info("calling issued credentials lambda", { req, res });
       const apiResponse = await axios.get(
-        `${API_BASE_URL}${API_ISSUED_CREDENTIALS_PATH}`,
+        `${API_BASE_URL}${API_BUILD_DEBUG_CREDENTIAL_DATA_PATH}`,
         {
           headers: {
             "ipv-session-id": req.session.ipvSessionId,

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -26,7 +26,7 @@ module.exports = {
 
   getIssuedCredentials: async (req, res, next) => {
     try {
-      logger.info("calling issued credentials lambda", { req, res });
+      logger.info("calling build-debug-credential-data lambda", { req, res });
       const apiResponse = await axios.get(
         `${API_BASE_URL}${API_BUILD_DEBUG_CREDENTIAL_DATA_PATH}`,
         {
@@ -43,7 +43,7 @@ module.exports = {
 
       req.issuedCredentials = parsedResponse;
     } catch (error) {
-      logger.error("error fetching issued credentials", { req, res, error });
+      logger.error("error fetching debug credential data", { req, res, error });
       res.error = error.name;
       return next(error);
     }

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -33,14 +33,18 @@ module.exports = {
         return next(new Error("Client ID Missing"));
       }
 
-      logger.info("calling session start lambda", { req, res });
+      logger.info("calling initialise-ipv-session lambda", { req, res });
       const response = await axios.post(
         `${API_BASE_URL}/session/initialise`,
         authParams
       );
       req.session.ipvSessionId = response?.data?.ipvSessionId;
     } catch (error) {
-      logger.error("error calling session start lambda", { req, res, error });
+      logger.error("error calling initialise-ipv-session lambda", {
+        req,
+        res,
+        error,
+      });
       res.error = error.name;
       return next(error);
     }

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -35,7 +35,7 @@ module.exports = {
 
       logger.info("calling session start lambda", { req, res });
       const response = await axios.post(
-        `${API_BASE_URL}/session/start`,
+        `${API_BASE_URL}/session/initialise`,
         authParams
       );
       req.session.ipvSessionId = response?.data?.ipvSessionId;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,9 +10,9 @@ if (!appEnv.isLocal) {
 
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
-  API_ISSUED_CREDENTIALS_PATH: "/issued-credentials",
+  API_BUILD_DEBUG_CREDENTIAL_DATA_PATH: "/debug-credential-data",
   API_REQUEST_CONFIG_PATH: "/request-config",
-  API_CRI_RETURN_PATH: "/journey/cri/return",
+  API_CRI_ACCESS_TOKEN_PATH: "/journey/cri/access-token",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update core-front to use some of the renamed lambda endpoints.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
A lot of the core-back lambdas have been renamed with some getting new api endpoint paths. For these ones they were deployed as an additional copy of the lambda under the new path, while keeping a version accessible on the old api gateway path. This PR is part of the changes to move over to the new renamed lambdas allowing the old ones to be deleted.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1719](https://govukverify.atlassian.net/browse/PYIC-1719)

