### PR TITLE
PYIC-1768 refactor code to manage all content in yaml files

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -12,6 +12,9 @@ govuk:
   warning: Warning
   skipLink: Skip to main content
   betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: beta
+    betaBannerContentHTML: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
   cookie:
     cookieBanner:
       title: Cookies on GOV.UK account

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -23,3 +23,7 @@ pageNotFound:
 
 sessionEnded:
   title: Session expired
+
+# used on pyi-technical.html, pyi-no-match.html, pyi-thin-file.html
+
+contactAccountTeamHTML: '<p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a></p>'

--- a/src/views/ipv/pyi-no-match.html
+++ b/src/views/ipv/pyi-no-match.html
@@ -2,9 +2,6 @@
 {% set hmpoPageKey = "pyiNoMatch" %}
 
 {% block cta %}
-  {% include 'shared/journey-next-form.njk' %}
-  <p>
-    <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
-  </p>
-{% endblock%}
-
+{% include 'shared/journey-next-form.njk' %}
+{{ translate("pages.errors.contactAccountTeamHTML") | safe }}
+{% endblock %}

--- a/src/views/ipv/pyi-technical-unrecoverable.html
+++ b/src/views/ipv/pyi-technical-unrecoverable.html
@@ -1,3 +1,2 @@
 {% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "errors.error" %}
-

--- a/src/views/ipv/pyi-technical.html
+++ b/src/views/ipv/pyi-technical.html
@@ -4,7 +4,5 @@
 
 {% block cta %}
   {% include 'shared/journey-next-form.njk' %}
-  <p>
-    <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
-  </p>
-{% endblock%}
+  {{ translate("pages.errors.contactAccountTeamHTML") | safe }}
+{% endblock %}

--- a/src/views/shared/banner.njk
+++ b/src/views/shared/banner.njk
@@ -11,11 +11,17 @@
 {% endset %}
 
 {% set acceptHtml %}
-    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a
+                class="govuk-link"
+                href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}
+    </p>
 {% endset %}
 
 {% set rejectedHtml %}
-    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a class="govuk-link" href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a
+                class="govuk-link"
+                href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}
+    </p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -78,7 +84,7 @@
                 classes:"cookie-hide-button",
                 attributes: {
                 "aria-label": 'govuk.cookie.cookieBanner.cookieBannerHideLink' | translate
-                }
+            }
             }
         ],
             hidden: true

--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -33,8 +33,8 @@
 {# the BETA banner is added to all pages using this template by default #}
 {% block beforeContent %}
     {{ govukPhaseBanner({
-    tag: { text: "beta" },
-    html: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
+    tag: { text: translate("govuk.betaBannerContent.betaBannerContentLabel") },
+    html: translate("govuk.betaBannerContent.betaBannerContentHTML")
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR ensures that all translatable content in the user interface is managed in the files in `locales/en` for translation into other languages

### What changed

English text present in nunjucks or html files have been shifted into the relevant `yaml` file.

### Why did it change

So the `yaml` file holds all the content for the UI, making it easier to manage translations.

### Issue tracking

- [PYIC-1768](https://govukverify.atlassian.net/browse/PYIC-1768)


