### PR TITLE
PYIC-1724: create page and content for thin file error

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -116,6 +116,7 @@ module.exports = {
         case "page-ipv-success":
         case "page-pre-kbv-transition":
         case "pyi-kbv-fail":
+        case "pyi-kbv-thin-file":
         case "pyi-no-match":
         case "pyi-technical":
         case "pyi-technical-unrecoverable":

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -24,6 +24,6 @@ pageNotFound:
 sessionEnded:
   title: Session expired
 
-# used on pyi-technical.html, pyi-no-match.html, pyi-thin-file.html
+# used on pyi-technical.html, pyi-no-match.html, pyi-kbv-thin-file.html
 
 contactAccountTeamHTML: '<p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a></p>'

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -40,6 +40,17 @@ pyiKbvFail:
     - "## What you can do"
     - Continue to the service you were trying to use and look for other ways to prove your identity.
 
+pyiKbvThinFile:
+  title: Sorry, we cannot prove your identity right now
+  serviceNameRequired: false
+  content:
+    - Our security questions are based on information held by another organisation. This organisation does not have much information about you.
+    - This means we cannot ask you the number of questions that we'd need to be sure that you are who you say you are.
+    - "## What you can do"
+    - Continue to the service you were trying to use and look for other ways to prove your identity.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+
 pageIpvIdentityStart:
   title: You’ve signed in to your GOV.UK account
   serviceNameRequired: true

--- a/src/views/ipv/pyi-kbv-thin-file.html
+++ b/src/views/ipv/pyi-kbv-thin-file.html
@@ -1,0 +1,8 @@
+{% extends "shared/ipv-template.html" %}
+{% set hmpoPageKey = "pyiKbvThinFile" %}
+{% set hmpoPageTitle = "pages."+hmpoThinFile+".title" %}
+
+{% block cta %}
+  {% include 'shared/journey-next-form.njk' %}
+  {{ translate("pages.errors.contactAccountTeamHTML") | safe }}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR creates a thin file error page when there are not enough questions for the user to be able to complete KBVs. **There will still be core-back backend work required** to allow the front-end to show this page for the correct user journey states.

### What changed

A html file was created and yaml filed updated. **Don’t merge these changes before the Welsh translation updates, PYIC-1768** are merged**

### Why did it change

This page more correctly describes errors users are seeing, which we hope will reduce the number of support requests.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1724](https://govukverify.atlassian.net/browse/PYIC-1724)

