### PR TITLE
PYIC-1828: use new fully constructed URL being returned from core-back

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -143,6 +143,10 @@ describe("journey middleware", () => {
   context("handling CRI event response", async () => {
     const authorizeUrl = "https://someurl.com";
     let eventResponses = [];
+    let clientId = "test-client-id";
+    let request =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw==";
+    let responseType = "code";
 
     beforeEach(() => {
       eventResponses = [
@@ -151,9 +155,9 @@ describe("journey middleware", () => {
             cri: {
               id: "someid",
               authorizeUrl: authorizeUrl,
-              ipvClientId: "clientId",
-              request:
-                "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw==",
+              ipvClientId: clientId,
+              request: request,
+              redirectUrl: `${authorizeUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
             },
           },
         },
@@ -178,7 +182,7 @@ describe("journey middleware", () => {
     it("should be redirected to a valid redirectURL", async function () {
       await middleware.handleJourneyResponse(req, res, "/journey/next");
       expect(req.redirectURL.toString()).to.equal(
-        "https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D"
+        "https://someurl.com/?client_id=test-client-id&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw==&response_type=code"
       );
     });
 
@@ -191,7 +195,8 @@ describe("journey middleware", () => {
                 id: "PassportIssuer",
                 authorizeUrl: authorizeUrl,
                 request: "req",
-                ipvClientId: "clientId",
+                ipvClientId: clientId,
+                redirectUrl: `${authorizeUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
               },
             },
           },
@@ -206,7 +211,7 @@ describe("journey middleware", () => {
         "/journey/cri/start/ukPassport"
       );
       expect(req.redirectURL.toString()).to.equal(
-        "https://someurl.com/?client_id=clientId&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw%3D%3D"
+        "https://someurl.com/?client_id=test-client-id&request=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw==&response_type=code"
       );
     });
   });

--- a/src/app/shared/criHelper.js
+++ b/src/app/shared/criHelper.js
@@ -10,10 +10,7 @@ module.exports = {
       res.status(500);
       return res.send("Could not find configured CRI");
     }
-
-    req.redirectURL = new URL(cri.authorizeUrl);
-    req.redirectURL.searchParams.append("client_id", cri.ipvClientId);
-    req.redirectURL.searchParams.append("request", cri.request);
+    req.redirectURL = new URL(cri.redirectUrl);
 
     if (next) {
       next();

--- a/src/app/shared/criHelper.test.js
+++ b/src/app/shared/criHelper.test.js
@@ -19,6 +19,8 @@ describe("cri Helper", () => {
               tokenUrl: "http://passport-stub-1/token",
               credentialUrl: "http://passport-stub-1/credential",
               ipvClientId: "test-ipv-client",
+              redirectUrl:
+                "http://passport-stub-1/authorize?client_id=test-ipv-client&request=test-request",
             },
             {
               id: "FraudIssuer",
@@ -27,6 +29,8 @@ describe("cri Helper", () => {
               tokenUrl: "http://fraud-stub-1/token",
               credentialUrl: "http://fraud-stub-1/credential",
               ipvClientId: "test-ipv-client",
+              redirectUrl:
+                "http://fraud-stub-1/authorize?client_id=test-ipv-client&request=test-request",
             },
             {
               id: "AddressIssuer",
@@ -35,6 +39,8 @@ describe("cri Helper", () => {
               tokenUrl: "http://address-stub-1/token",
               credentialUrl: "http://address-stub-1/credential",
               ipvClientId: "test-ipv-client",
+              redirectUrl:
+                "http://address-stub-1/authorize?client_id=test-ipv-client&request=test-request",
             },
           ],
         },
@@ -59,7 +65,7 @@ describe("cri Helper", () => {
       await buildCredentialIssuerRedirectURL(req, res, next);
 
       expect(req.redirectURL.toString()).to.equal(
-        "http://passport-stub-1/authorize?client_id=test-ipv-client&request=undefined"
+        "http://passport-stub-1/authorize?client_id=test-ipv-client&request=test-request"
       );
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update core-front to use the new "redirectUrl" param being returned from core-back
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Core-back now fully constructs the whole redirectUri, this PR ensures that core-front uses this new value instead of trying to construct the url itself.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1828](https://govukverify.atlassian.net/browse/PYIC-1828)

Core-back PR - https://github.com/alphagov/di-ipv-core-back/pull/405

