### PR TITLE
PYIC-1830: cleanup core front tests and validation message

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -53,7 +53,7 @@ async function handleJourneyResponse(req, res, action) {
 
 function tryValidateCriResponse(criResponse) {
   if (!criResponse?.redirectUrl) {
-    throw new Error(`CRI response AuthorizeUrl is missing`);
+    throw new Error(`CRI response RedirectUrl is missing`);
   }
 
   return true;

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -141,7 +141,7 @@ describe("journey middleware", () => {
   });
 
   context("handling CRI event response", async () => {
-    const authorizeUrl = "https://someurl.com";
+    const redirectUrl = "https://someurl.com";
     let eventResponses = [];
     let clientId = "test-client-id";
     let request =
@@ -154,10 +154,7 @@ describe("journey middleware", () => {
           data: {
             cri: {
               id: "someid",
-              authorizeUrl: authorizeUrl,
-              ipvClientId: clientId,
-              request: request,
-              redirectUrl: `${authorizeUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
+              redirectUrl: `${redirectUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
             },
           },
         },
@@ -193,10 +190,7 @@ describe("journey middleware", () => {
             redirect: {
               cri: {
                 id: "PassportIssuer",
-                authorizeUrl: authorizeUrl,
-                request: "req",
-                ipvClientId: clientId,
-                redirectUrl: `${authorizeUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
+                redirectUrl: `${redirectUrl}?client_id=${clientId}&request=${request}&response_type=${responseType}`,
               },
             },
           },
@@ -217,7 +211,7 @@ describe("journey middleware", () => {
   });
 
   context(
-    "handling CRI event response that has missing authorizeUrl",
+    "handling CRI event response that has missing redirectUrl",
     async () => {
       let eventResponses = [];
 
@@ -227,10 +221,7 @@ describe("journey middleware", () => {
             data: {
               cri: {
                 id: "someid3",
-                authorizeUrl: "",
-                ipvClientId: "clientId",
-                request:
-                  "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJkYXRlT2ZCaXJ0aHMiOltdLCJhZGRyZXNzZXMiOltdLCJuYW1lcyI6W10sImFkZHJlc3NIaXN0b3J5IjpbXX0.DwQQOldmOYQ1Lv6OJETzks7xv1fM7VzW0O01H3-uQqQ_rSkCZrd2KwQHHzo0Ddw2K_LreePy-tEr-tiPgi8Yl604n3rwQy6xBat8mb4lTtNnOxsUOYviYQxC5aamsvBAS27G43wFejearXHWzEqhJhIFdGE4zJkgZAKpLGzvOXLvX4NZM4aI4c6jMgpktkvvFey-O0rI5ePh5RU4BjbG_hvByKNlLr7pzIlsS-Q8KuIPawqFJxN2e3xfj1Ogr8zO0hOeDCA5dLDie78sPd8ph0l5LOOcGZskd-WD74TM6XeinVpyTfN7esYBnIZL-p-qULr9CUVIPCMxn-8VTj3SOw==",
+                redirectUrl: "",
               },
             },
           },
@@ -250,7 +241,7 @@ describe("journey middleware", () => {
       it("should raise an error ", async () => {
         await middleware.handleJourneyNext(req, res, next);
         expect(next).to.have.been.calledWith(
-          sinon.match.has("message", "CRI response AuthorizeUrl is missing")
+          sinon.match.has("message", "CRI response RedirectUrl is missing")
         );
       });
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Cleanup PR to remove the old cri response params from the unit test. Also updated the error message for missing redirect url param.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The cri redirect url has been refactored to be stored under the new param of `redirectUrl` so most of the other params are not being used. This PR just cleans up the tests to act in the same way.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1830](https://govukverify.atlassian.net/browse/PYIC-1830)

