### PR TITLE
PYIC-1870: Update core-front to have new callback endpoint with criId as a url path parameter

### DIFF
--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -13,6 +13,7 @@ describe("credential issuer middleware", () => {
         query: {
           code: "xyz",
         },
+        params: {},
         session: {},
       };
       configStub = {};
@@ -67,6 +68,7 @@ describe("credential issuer middleware", () => {
           code: "authorize-code-issued",
           state: "oauth-state",
         },
+        params: {},
         session: { ipvSessionId: "ipv-session-id" },
         query: { id: "PassportIssuer" },
       };
@@ -178,6 +180,7 @@ describe("credential issuer middleware", () => {
       req = {
         url: `/callback`,
         query: { error, error_description, id },
+        params: {},
         session: { ipvSessionId: "ipv-session-id" },
       };
 
@@ -239,6 +242,7 @@ describe("credential issuer middleware", () => {
       req = {
         url: `/callback`,
         query: { error_description, id },
+        params: {},
         session: { ipvSessionId: "ipv-session-id" },
       };
 

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -15,4 +15,11 @@ router.get(
   sendParamsToAPI
 );
 
+router.get(
+  "/callback/:criId",
+  tryHandleRedirectError,
+  addCallbackParamsToRequest,
+  sendParamsToAPI
+);
+
 module.exports = router;

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const {
   addCallbackParamsToRequest,
   sendParamsToAPI,
+  sendParamsToAPIV2,
   tryHandleRedirectError,
 } = require("./middleware");
 
@@ -19,7 +20,7 @@ router.get(
   "/callback/:criId",
   tryHandleRedirectError,
   addCallbackParamsToRequest,
-  sendParamsToAPI
+  sendParamsToAPIV2
 );
 
 module.exports = router;


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Setup a new callback endpoint for returning from a CRI that uses a URL path parameter for the criId instead of a query parameter.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This new endpoint will be used to handle the redirect back from the app system. We have found that using a query param for the criId makes it slightly more complicated for a CRI to construct the redirect uri, so using a URL path parameter is a better alternative.

There will be future work to migrate the other CRI's to use this new endpoint as well.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1870](https://govukverify.atlassian.net/browse/PYIC-1870)

