### PR TITLE
[PYIC-1867] Add Welsh translation yaml files

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -1,0 +1,47 @@
+buttons:
+  authorizeAndReturn: Awdurdodi a Dychwelyd
+  next: Parhau
+  cancel: Canslo
+  credentialIssuer: Cyhoeddwr Cymhwyster
+  govUkHomepage: Ewch i hafan GOV.UK
+govuk:
+  serviceName: " "
+  backLink: Yn ôl
+  errorSummaryTitle: Mae problem
+  error: Gwall
+  warning: Rhybudd
+  skipLink: Neidio i’r prif gynnwys
+  betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: beta
+    betaBannerContentHTML: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.'
+  cookie:
+    cookieBanner:
+      title: Cwcis ar gyfrif GOV.UK
+      heading: Cwcis ar gyfrif GOV.UK
+      paragraph1: Rydym yn defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.
+      paragraph2: Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut rydych yn defnyddio’r gwasanaeth a gwneud gwelliannau.
+      changeCookiePreferencesLink: newid eich gosodiadau cwcis
+      cookieBannerAccept:
+        paragraph1: "Rydych wedi derbyn cwcis ychwanegol. Gallwch "
+        paragraph2: " unrhyw bryd."
+      cookieBannerReject:
+        paragraph1: "Rydych wedi gwrthod cwcis ychwanegol. Gallwch "
+        paragraph2: " unrhyw bryd."
+      buttonAcceptText: Derbyn cwcis dadansoddi
+      buttonRejectText: Gwrthod cwcis dadansoddi
+      linkViewCookies: Gweld cwcis
+      cookieBannerHideLink: Cuddio'r neges yma
+  footerNavItems:
+    meta:
+      items:
+        - href: "https://signin.account.gov.uk/accessibility-statement"
+          text: "Datganiad hygyrchedd"
+        - href: "https://signin.account.gov.uk/cookies"
+          text: "Cwcis"
+        - href: "https://signin.account.gov.uk/terms-and-conditions"
+          text: "Telerau ac amodau"
+        - href: "https://signin.account.gov.uk/privacy-notice"
+          text: "Hysbysiad preifatrwydd"
+        - href: "https://signin.account.gov.uk/contact-us"
+          text: "Cymorth"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -1,0 +1,23 @@
+error:
+  title: Mae'n ddrwg gennym, mae problem
+  serviceNameRequired: true
+  content:
+    - Ni allwn brofi pwy ydych chi ar hyn o bryd.
+    - "## Beth allwch chi ei wneud"
+    - Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
+
+pageNotFound:
+  title: Tudalen heb ei darganfod
+  serviceNameRequired: true
+  content:
+    - Os ydych wedi teipio’r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.
+    - Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan.
+    - Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
+
+sessionEnded:
+  title: Sesiwn wedi dod i ben
+  contactAccountTeamHTML: <p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a></p>

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -55,7 +55,7 @@ pageIpvIdentityStart:
   title: Rydych wedi mewngofnodi i’ch cyfrif GOV.UK
   serviceNameRequired: true
   content:
-     - Gallwch nawr barhau i brofi pwy ydych chi.
+    - Gallwch nawr barhau i brofi pwy ydych chi.
 
 pagePreKbvTransition:
   title: Ateb cwestiynau diogelwc
@@ -66,7 +66,7 @@ pagePreKbvTransition:
   warningTextContent: Ceisiwch ateb y cwestiynau hyn mor gywir ag y gallwch. Ni fyddwch yn gallu newid eich atebion os gwnewch gamgymeriad.
   warningTextFallback: Rhybudd
   contentAddition:
-     - Ni fyddwn yn cadw eich atebion.
+    - Ni fyddwn yn cadw eich atebion.
   summaryText:
     - Sut rydym yn gwybod pa gwestiynau i’w gofyn i chi
   summaryHtml:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,0 +1,80 @@
+index:
+  title: di-ipv-core-front
+
+pageIpvError:
+  title: Tudalen gwall
+  serviceNameRequired: true
+  content:
+    - Mae gwall wedi digwydd.
+
+pageIpvEnd:
+  title: Tudalen diwedd
+
+criRedirectionError:
+  title: Cri Redirection error
+
+pyiNoMatch:
+  title: Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
+  serviceNameRequired: true
+  content:
+    - Efallai bod hyn oherwydd nad oeddem yn gallu gyfateb paru eich manylion i wybodaeth o gronfa ddata arall.
+    - Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddangos pa un o'ch manylion y cawsom drafferth ei baru.
+    - Gallai hyn hefyd fod oherwydd eich bod yn aflwyddiannus pan rydych wedi ceisio profi pwy ydych chi ar-lein yn y gorffennol.
+    - "## Beth allwch chi ei wneud"
+    - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
+
+pyiTechnical:
+  title: Mae’n ddrwg gennym, mae problem
+  serviceNameRequired: true
+  content:
+    - Ni allwn brofi pwy ydych chi ar hyn o bryd.
+    - "## Beth allwch chi ei wneud"
+    - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
+
+pyiKbvFail:
+  title: Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
+  serviceNameRequired: true
+  content:
+    - Efallai mai'r rheswm am hyn yw eich bod wedi rhoi'r ateb anghywir i rai o'r cwestiynau diogelwch.
+    - Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddangos pa gwestiynau yr ateboch yn anghywir.
+    - "## Beth allwch chi ei wneud"
+    - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
+
+pyiKbvThinFile:
+  title: Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
+  serviceNameRequired: false
+  content:
+    - Mae ein cwestiynau diogelwch yn seiliedig ar wybodaeth sy’n cael ei gadw gan sefydliad arall. Nid oes gan y sefydliad hwn lawer o wybodaeth amdanoch chi.
+    - Mae hyn yn golygu na allwn ofyn i chi'r nifer o gwestiynau y byddai angen i ni fod yn sicr mai chi yw pwy rydych yn ei ddweud ydych chi.
+    - "## Beth allwch chi ei wneud"
+    - Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
+    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
+
+pageIpvIdentityStart:
+  title: Rydych wedi mewngofnodi i’ch cyfrif GOV.UK
+  serviceNameRequired: true
+  content:
+     - Gallwch nawr barhau i brofi pwy ydych chi.
+
+pagePreKbvTransition:
+  title: Ateb cwestiynau diogelwc
+  serviceNameRequired: true
+  content:
+    - Byddwn yn gofyn rhai cwestiynau diogelwch i chi mai dim ond chi ddylai wybod yr atebion iddynt. Bydd hyn yn ein helpu i atal unrhyw un arall a allai fod â’ch manylion rhag esgus bod yn chi.
+    - Bydd y cwestiynau’n ymwneud â phethau fel eich contract ffôn symudol, cyfrif banc, ac unrhyw gardiau credyd, benthyciadau neu forgeisi sydd gennych.
+  warningTextContent: Ceisiwch ateb y cwestiynau hyn mor gywir ag y gallwch. Ni fyddwch yn gallu newid eich atebion os gwnewch gamgymeriad.
+  warningTextFallback: Rhybudd
+  contentAddition:
+     - Ni fyddwn yn cadw eich atebion.
+  summaryText:
+    - Sut rydym yn gwybod pa gwestiynau i’w gofyn i chi
+  summaryHtml:
+    - <p>Byddwn yn gweithio gyda <a target="_blank" rel="noopener noreferrer" href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services">Experian (agor mewn tab newydd)</a>  i wneud yn siwr ein bod yn gofyn cwestiynau i chi mai dim ond chi sy'n gallu eu hateb. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at lawer o wybodaeth y gallwn wirio'ch atebion yn eu herbyn.<p><p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/privacy-statement">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>
+
+pageIpvSuccess:
+  title: Rydych wedi profi pwy ydych chi yn llwyddiannus
+  serviceNameRequired: true
+  content:
+    - Nawr ewch yn eich blaen i ddefnyddio'r gwasanaeth <strong>Gwneud cais am DBS sylfaenol</strong>.
+    - Efallai bydd rhywfaint o’r wybodaeth rydych eisoes wedi ei rhannu pan wnaethoch brofi pwy ydych chi yn cael ei defnyddio i lenwi ffurflenni o fewn y gwasanaeth yn awtomatig.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR adds the Welsh translation of the English user interface content, ready for checking in early September.

### What changed

<!-- Describe the changes in detail - the "what"-->
Welsh versions of the yaml files in `locales/en` were added to `locales/cy`. Pages can be viewed in Welsh by adding `?lang=cy` to the end of the URI.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Welsh translation is required for the system to pass service evaluation.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1867](https://govukverify.atlassian.net/browse/PYIC-1867)

## Checklists

### Other considerations

- [ ] Content will be reviewed in early September
- [ ] A variable will need to be added to sessions so the system is aware of the language the user has chosen earlier in the journey ([see RFC0002](https://github.com/alphagov/digital-identity-architecture/blob/785811fce3686677ddd20f4b5f3ccf39a25326ed/rfc/0002-crossteam-oidc-profile.md))
