### PR TITLE
BAU: Fix sonar coverage

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -5,9 +5,8 @@ include:
 exclude:
   - "**/*.test.js"
   - "**/*router.js"
-  - "src/assets/javascripts/*.js"
-  - "src/assets/javascript/*.js"
-  - "src/lib/config.js"
+  - "src/assets/*"
+  - "src/lib/*"
   - "src/app.js"
 report-dir: coverage
 statements: 80

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=alphagov_di-ipv-core-front
 sonar.organization=alphagov
 
 sonar.sources=src/
-sonar.exclusions=**/*.test.js
+sonar.exclusions=**/assets/**,**/*.test.js,**/service-unavailable-s3/**
 
 sonar.tests=src/
 sonar.test.inclusions=**/*.test.js

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -134,9 +134,40 @@ describe("journey middleware", () => {
       expect(res.render).to.have.been.calledWith("ipv/pyi-technical");
     });
 
+    it("should render unrecoverable technical error page when current page is not equal to pageId", async () => {
+      req = {
+        params: { pageId: "invalid-page-id" },
+        session: { currentPage: "../debug/page-ipv-debug" },
+      };
+
+      await middleware.handleJourneyPage(req, res);
+      expect(res.redirect).to.have.been.calledWith(
+        "pyi-technical-unrecoverable"
+      );
+    });
+
     it("should raise an error when missing pageId", async () => {
       await middleware.handleJourneyPage(req, res, next);
       expect(res.status).to.have.been.calledWith(500);
+    });
+  });
+
+  context("calling the updateJourneyState", () => {
+    it("should raise an error when debug is set to false", async () => {
+      req.session.isDebugJourney = false;
+      await middleware.updateJourneyState(req, res, next);
+      expect(next).to.have.been.calledWith(
+        sinon.match.has("message", "Debug operation not available")
+      );
+    });
+
+    it("should raise an error when given an invalid action", async () => {
+      req.session.isDebugJourney = true;
+      req.url = "/invalidCri";
+      await middleware.updateJourneyState(req, res, next);
+      expect(next).to.have.been.calledWith(
+        sinon.match.has("message", "Action /invalidCri not valid")
+      );
     });
   });
 


### PR DESCRIPTION
## Proposed changes

### What changed

Fixed sonarcloud codesmells by ignoring the assets directory and the one of s3error page we have
Increased coverage by adding tests around a function we previously had no tests for
I excluded the lib directory so that is no longer included in the coverage report

### Why did it change

Important to keep our coverage high and accurate