### PR TITLE
PYIC-1867 Update Welsh and English content after content audit

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -46,6 +46,6 @@ govuk:
         - href: "https://signin.account.gov.uk/contact-us"
           text: "Cymorth"
     contentLicence:
-      text: "Mae’r holl gynnwys ar gael o dan Trwydded Llywodraeth Agored v3.0, oni nodir yn wahanol"
+      html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
     copyright:
       text: "© Hawlfraint y goron"

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -31,7 +31,7 @@ govuk:
       buttonAcceptText: Derbyn cwcis dadansoddi
       buttonRejectText: Gwrthod cwcis dadansoddi
       linkViewCookies: Gweld cwcis
-      cookieBannerHideLink: Cuddio'r neges yma
+      cookieBannerHideLink: Cuddio’r neges yma
   footerNavItems:
     meta:
       items:

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -45,3 +45,7 @@ govuk:
           text: "Hysbysiad preifatrwydd"
         - href: "https://signin.account.gov.uk/contact-us"
           text: "Cymorth"
+    contentLicence:
+      text: "Mae’r holl gynnwys ar gael o dan Trwydded Llywodraeth Agored v3.0, oni nodir yn wahanol"
+    copyright:
+      text: "© Hawlfraint y goron"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -1,10 +1,10 @@
 error:
-  title: Mae'n ddrwg gennym, mae problem
+  title: Mae’n ddrwg gennym, mae problem
   serviceNameRequired: true
   content:
     - Ni allwn brofi pwy ydych chi ar hyn o bryd.
     - "## Beth allwch chi ei wneud"
-    - Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
+    - Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
     - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
 
@@ -20,4 +20,5 @@ pageNotFound:
 
 sessionEnded:
   title: Sesiwn wedi dod i ben
-  contactAccountTeamHTML: <p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a></p>
+
+contactAccountTeamHTML: <p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a></p>

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -14,11 +14,11 @@ criRedirectionError:
   title: Cri Redirection error
 
 pyiNoMatch:
-  title: Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
+  title: Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
   serviceNameRequired: true
   content:
-    - Efallai bod hyn oherwydd nad oeddem yn gallu gyfateb paru eich manylion i wybodaeth o gronfa ddata arall.
-    - Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddangos pa un o'ch manylion y cawsom drafferth ei baru.
+    - Efallai bod hyn oherwydd nad oeddem yn gallu paru eich manylion i wybodaeth o gronfa ddata arall.
+    - Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddangos pa un o’ch manylion y cawsom drafferth ei baru.
     - Gallai hyn hefyd fod oherwydd eich bod yn aflwyddiannus pan rydych wedi ceisio profi pwy ydych chi ar-lein yn y gorffennol.
     - "## Beth allwch chi ei wneud"
     - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
@@ -32,10 +32,10 @@ pyiTechnical:
     - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
 
 pyiKbvFail:
-  title: Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
+  title: Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd
   serviceNameRequired: true
   content:
-    - Efallai mai'r rheswm am hyn yw eich bod wedi rhoi'r ateb anghywir i rai o'r cwestiynau diogelwch.
+    - Efallai mai’r rheswm am hyn yw eich bod wedi rhoi’r ateb anghywir i rai o’r cwestiynau diogelwch.
     - Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddangos pa gwestiynau yr ateboch yn anghywir.
     - "## Beth allwch chi ei wneud"
     - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
@@ -45,9 +45,9 @@ pyiKbvThinFile:
   serviceNameRequired: false
   content:
     - Mae ein cwestiynau diogelwch yn seiliedig ar wybodaeth sy’n cael ei gadw gan sefydliad arall. Nid oes gan y sefydliad hwn lawer o wybodaeth amdanoch chi.
-    - Mae hyn yn golygu na allwn ofyn i chi'r nifer o gwestiynau y byddai angen i ni fod yn sicr mai chi yw pwy rydych yn ei ddweud ydych chi.
+    - Mae hyn yn golygu na allwn ofyn i chi’r nifer o gwestiynau y byddai angen i ni fod yn sicr mai chi yw pwy rydych yn ei ddweud ydych chi.
     - "## Beth allwch chi ei wneud"
-    - Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
+    - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
     - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
 
@@ -58,7 +58,7 @@ pageIpvIdentityStart:
     - Gallwch nawr barhau i brofi pwy ydych chi.
 
 pagePreKbvTransition:
-  title: Ateb cwestiynau diogelwc
+  title: Ateb cwestiynau diogelwch
   serviceNameRequired: true
   content:
     - Byddwn yn gofyn rhai cwestiynau diogelwch i chi mai dim ond chi ddylai wybod yr atebion iddynt. Bydd hyn yn ein helpu i atal unrhyw un arall a allai fod â’ch manylion rhag esgus bod yn chi.
@@ -70,11 +70,11 @@ pagePreKbvTransition:
   summaryText:
     - Sut rydym yn gwybod pa gwestiynau i’w gofyn i chi
   summaryHtml:
-    - <p>Byddwn yn gweithio gyda <a target="_blank" rel="noopener noreferrer" href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services">Experian (agor mewn tab newydd)</a>  i wneud yn siwr ein bod yn gofyn cwestiynau i chi mai dim ond chi sy'n gallu eu hateb. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at lawer o wybodaeth y gallwn wirio'ch atebion yn eu herbyn.<p><p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/privacy-statement">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>
+    - <p>Byddwn yn gweithio gyda <a target="_blank" rel="noopener noreferrer" href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services">Experian (agor mewn tab newydd)</a>  i wneud yn siwr ein bod yn gofyn cwestiynau i chi mai dim ond chi sy’n gallu eu hateb. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at lawer o wybodaeth y gallwn wirio’ch atebion yn eu herbyn.<p><p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/privacy-statement">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>
 
 pageIpvSuccess:
   title: Rydych wedi profi pwy ydych chi yn llwyddiannus
   serviceNameRequired: true
   content:
-    - Nawr ewch yn eich blaen i ddefnyddio'r gwasanaeth <strong>Gwneud cais am DBS sylfaenol</strong>.
+    - Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth <strong>Gwneud cais am DBS sylfaenol</strong>.
     - Efallai bydd rhywfaint o’r wybodaeth rydych eisoes wedi ei rhannu pan wnaethoch brofi pwy ydych chi yn cael ei defnyddio i lenwi ffurflenni o fewn y gwasanaeth yn awtomatig.

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -19,7 +19,7 @@ pyiNoMatch:
   content:
     - This might be because we could not match your details to information from another database.
     - To keep your information safe, we cannot show which of your details we had trouble finding a match for.
-    - This could also be because you were unsuccessful when you've previously tried to prove your identity online.
+    - This could also be because you were unsuccessful when you’ve previously tried to prove your identity online.
     - "## What you can do"
     - Continue to the service you were trying to use and look for other ways to prove your identity.
 
@@ -45,7 +45,7 @@ pyiKbvThinFile:
   serviceNameRequired: false
   content:
     - Our security questions are based on information held by another organisation. This organisation does not have much information about you.
-    - This means we cannot ask you the number of questions that we'd need to be sure that you are who you say you are.
+    - This means we cannot ask you the number of questions that we’d need to be sure that you are who you say you are.
     - "## What you can do"
     - Continue to the service you were trying to use and look for other ways to prove your identity.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Content in the English and Welsh yaml files are updated to improve the user experience

### What changed

<!-- Describe the changes in detail - the "what"-->
Welsh content is corrected and typographically correct apostrophes are added where necessary to English and Welsh content.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Updates were prompted by the review of the Welsh content by the DWP Welsh content team.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1867](https://govukverify.atlassian.net/browse/PYIC-1867)

## Checklists

### Other considerations

- [ ] These updates do not change currently visible content except for the typographically correct apostrophes in `pages.yaml`.
