### PR TITLE
PYIC-1974: Add retrieve-cri-credential to the allowedActions regex

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -83,6 +83,7 @@ module.exports = {
         /^\/journey\/(next|error|fail)$/,
         /^\/journey\/cri\/build-oauth-request\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv|activityHistory|stubActivityHistory|dcmaw|stubDcmaw|debugAddress)$/,
         /^\/journey\/build-client-oauth-response$/,
+        /^\/journey\/retrieve-cri-credential$/,
         /^\/journey\/cri\/validate\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv|dcmaw|stubDcmaw)$/,
       ];
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add retrieve-cri-credential to the allowedActions regex

<!-- Describe the changes in detail - the "what"-->

### Why did it change
So that the frontend can call the new /journey/retrieve-cri-credential lambda (via the Journey Engine)

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1974](https://govukverify.atlassian.net/browse/PYIC-1974)