### PR TITLE
PYIC-1972 PYIC-1965 Add Welsh translations for pageDcmawApp and pagePassportDocCheck

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -93,7 +93,6 @@ pagePassportDocCheck:
     otherWayButtonText: Profi pwy ydych chi mewn ffordd arall
     otherWayButtonHint: Gallwch brofi pwy ydych chi ar-lein gyda GOV.UK Verify neu gymryd eich dogfennau hunaniaeth i’w gwirio’n bersonol.
 
-
 pageIpvSuccess:
   title: Rydych wedi profi pwy ydych chi yn llwyddiannus
   serviceNameRequired: true

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -72,6 +72,28 @@ pagePreKbvTransition:
   summaryHtml:
     - <p>Byddwn yn gweithio gyda <a target="_blank" rel="noopener noreferrer" href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services">Experian (agor mewn tab newydd)</a>  i wneud yn siwr ein bod yn gofyn cwestiynau i chi mai dim ond chi sy’n gallu eu hateb. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at lawer o wybodaeth y gallwn wirio’ch atebion yn eu herbyn.<p><p><a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/privacy-statement">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>
 
+pageDcmawApp:
+  title: Rydym wedi llwyddo i’ch paru chi â’r ID gyda llun
+  serviceNameRequired: true
+  content:
+    - Byddwch angen rhoi eich cyfeiriad cartref presennol (a’ch cyfeiriad blaenorol, os ydych chi wedi symud yn ddiweddar) pan fyddwch yn parhau.
+
+pagePassportDocCheck:
+  title: Rhowch fanylion eich pasbort ac atebwch y cwestiynau diogelwch
+  serviceNameRequired: true
+  content:
+    - "I brofi pwy ydych chi yn y ffordd hyn, byddwch angen:"
+    - - manylion eich pasbort y DU (gan gynnwys eich enw, rhif pasbort a’r dyddiad mae eich pasbort yn dod i ben)
+      - cyfeiriad eich cartref presennol (efallai y byddwch hefyd angen eich cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)
+      - ateb rhai cwestiynau mai dim ond chi ddylai wybod yr atebion iddynt
+    - "## Beth hoffech chi ei wneud?"
+  formRadioButtons:
+    continueButtonText: Parhau i brofi pwy ydych chi yn y ffordd hyn
+    continueButtonHint: Byddwch angen pasbort y DU
+    otherWayButtonText: Profi pwy ydych chi mewn ffordd arall
+    otherWayButtonHint: Gallwch brofi pwy ydych chi ar-lein gyda GOV.UK Verify neu gymryd eich dogfennau hunaniaeth i’w gwirio’n bersonol.
+
+
 pageIpvSuccess:
   title: Rydych wedi profi pwy ydych chi yn llwyddiannus
   serviceNameRequired: true

--- a/src/views/ipv/pyi-kbv-fail.html
+++ b/src/views/ipv/pyi-kbv-fail.html
@@ -4,7 +4,5 @@
 
 {% block cta %}
   {% include 'shared/journey-next-form.njk' %}
-  <p>
-    <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
-  </p>
+  {{ translate("pages.errors.contactAccountTeamHTML") | safe }}
 {% endblock%}

--- a/src/views/ipv/pyi-kbv-thin-file.html
+++ b/src/views/ipv/pyi-kbv-thin-file.html
@@ -3,6 +3,8 @@
 {% set hmpoPageTitle = "pages."+hmpoThinFile+".title" %}
 
 {% block cta %}
+  {# unsure if this is required: page is still under development
   {% include 'shared/journey-next-form.njk' %}
   {{ translate("pages.errors.contactAccountTeamHTML") | safe }}
+  #}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR adds Welsh translations for two pages of the core journey required to support users who have taken the app route.

### What changed

<!-- Describe the changes in detail - the "what"-->
The Welsh `/locales/cy/pages.yml` file has been updated with translated content and two html pages have had small changes to ensure the correct content in the right languages is shown.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To improve the Welsh user experience

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1965](https://govukverify.atlassian.net/browse/PYIC-1965)
- [PYIC-1972](https://govukverify.atlassian.net/browse/PYIC-1972)

