### PR TITLE
PYIC-2045 Call validate-callback for both oauth success and error

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -28,6 +28,13 @@ module.exports = {
       ["state", req.credentialIssuer.state],
     ]);
 
+    if (req.query?.error) {
+      evidenceParam.append("error", req.query.error);
+      if (req.query.error_description) {
+        evidenceParam.append("error_description", req.query.error_description);
+      }
+    }
+
     try {
       logger.info("calling validate-callback lambda", { req, res });
       const apiResponse = await axios.post(
@@ -64,6 +71,13 @@ module.exports = {
       ["state", req.credentialIssuer.state],
     ]);
 
+    if (req.query?.error) {
+      evidenceParam.append("error", req.query.error);
+      if (req.query.error_description) {
+        evidenceParam.append("error_description", req.query.error_description);
+      }
+    }
+
     try {
       logger.info("calling validate-callback lambda", { req, res });
       const apiResponse = await axios.post(
@@ -86,38 +100,6 @@ module.exports = {
         res.error = error.name;
       }
       next(error);
-    }
-  },
-  tryHandleRedirectError: async (req, res, next) => {
-    try {
-      const { error, error_description, id } = req.query;
-
-      const criId = req.params.criId || id;
-
-      if (error || error_description) {
-        logger.error("error or error_description received in callback", {
-          req,
-          res,
-        });
-
-        const errorParams = new URLSearchParams([
-          ["error", error],
-          ["error_description", error_description],
-          ["credential_issuer_id", criId],
-        ]);
-
-        const journeyResponse = await axios.post(
-          `${API_BASE_URL}/journey/cri/error`,
-          errorParams,
-          generateAxiosConfig(req.session.ipvSessionId)
-        );
-        return handleJourneyResponse(req, res, journeyResponse.data?.journey);
-      }
-
-      return next();
-    } catch (error) {
-      logger.error("error calling cri error lambda", { req, res, error });
-      return next(error);
     }
   },
 };

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -82,34 +82,65 @@ describe("credential issuer middleware", () => {
       };
     });
 
-    context("add-evidence request", () => {
-      it("should call axios with correct parameters", async () => {
-        req.session.ipvSessionId = "abadcafe";
-        axiosStub.post = sinon.fake();
+    it("should call axios with correct parameters", async () => {
+      req.session.ipvSessionId = "abadcafe";
+      axiosStub.post = sinon.fake();
 
-        const searchParams = new URLSearchParams([
-          ["authorization_code", req.credentialIssuer.code],
-          ["credential_issuer_id", req.query.id],
-          [
-            "redirect_uri",
-            `http://example.com/credential-issuer/callback?id=${req.query.id}`,
-          ],
-          ["state", req.credentialIssuer.state],
-        ]);
+      const searchParams = new URLSearchParams([
+        ["authorization_code", req.credentialIssuer.code],
+        ["credential_issuer_id", req.query.id],
+        [
+          "redirect_uri",
+          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
+        ],
+        ["state", req.credentialIssuer.state],
+      ]);
 
-        await middleware.sendParamsToAPI(req, res, next);
+      await middleware.sendParamsToAPI(req, res, next);
 
-        expect(axiosStub.post).to.have.been.calledWith(
-          "https://example.net/path/journey/cri/validate-callback",
-          searchParams,
-          sinon.match({
-            headers: {
-              "ipv-session-id": "abadcafe",
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
-          })
-        );
-      });
+      expect(axiosStub.post).to.have.been.calledWith(
+        "https://example.net/path/journey/cri/validate-callback",
+        searchParams,
+        sinon.match({
+          headers: {
+            "ipv-session-id": "abadcafe",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+      );
+    });
+
+    it("should add error parameters if they exist", async () => {
+      req.session.ipvSessionId = "abadcafe";
+      axiosStub.post = sinon.fake();
+
+      req.query.error = "access_denied";
+      req.query.error_description = "Access was denied!";
+
+      const searchParams = new URLSearchParams([
+        ["authorization_code", req.credentialIssuer.code],
+        ["credential_issuer_id", req.query.id],
+        [
+          "redirect_uri",
+          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
+        ],
+        ["state", req.credentialIssuer.state],
+        ["error", req.query.error],
+        ["error_description", req.query.error_description],
+      ]);
+
+      await middleware.sendParamsToAPI(req, res, next);
+
+      expect(axiosStub.post).to.have.been.calledWith(
+        "https://example.net/path/journey/cri/validate-callback",
+        searchParams,
+        sinon.match({
+          headers: {
+            "ipv-session-id": "abadcafe",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+      );
     });
 
     it("should send code to core backend and return with 200 response", async () => {
@@ -186,6 +217,7 @@ describe("credential issuer middleware", () => {
         },
         params: { criId: "PassportIssuer" },
         session: { ipvSessionId: "ipv-session-id" },
+        query: {},
       };
       res = {
         status: sinon.fake(),
@@ -197,34 +229,65 @@ describe("credential issuer middleware", () => {
       };
     });
 
-    context("add-evidence request", () => {
-      it("should call axios with correct parameters", async () => {
-        req.session.ipvSessionId = "abadcafe";
-        axiosStub.post = sinon.fake();
+    it("should call axios with correct parameters", async () => {
+      req.session.ipvSessionId = "abadcafe";
+      axiosStub.post = sinon.fake();
 
-        const searchParams = new URLSearchParams([
-          ["authorization_code", req.credentialIssuer.code],
-          ["credential_issuer_id", req.params.criId],
-          [
-            "redirect_uri",
-            `http://example.com/credential-issuer/callback/${req.params.criId}`,
-          ],
-          ["state", req.credentialIssuer.state],
-        ]);
+      const searchParams = new URLSearchParams([
+        ["authorization_code", req.credentialIssuer.code],
+        ["credential_issuer_id", req.params.criId],
+        [
+          "redirect_uri",
+          `http://example.com/credential-issuer/callback/${req.params.criId}`,
+        ],
+        ["state", req.credentialIssuer.state],
+      ]);
 
-        await middleware.sendParamsToAPIV2(req, res, next);
+      await middleware.sendParamsToAPIV2(req, res, next);
 
-        expect(axiosStub.post).to.have.been.calledWith(
-          "https://example.net/path/journey/cri/validate-callback",
-          searchParams,
-          sinon.match({
-            headers: {
-              "ipv-session-id": "abadcafe",
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
-          })
-        );
-      });
+      expect(axiosStub.post).to.have.been.calledWith(
+        "https://example.net/path/journey/cri/validate-callback",
+        searchParams,
+        sinon.match({
+          headers: {
+            "ipv-session-id": "abadcafe",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+      );
+    });
+
+    it("should add error parameters if they exist", async () => {
+      req.session.ipvSessionId = "abadcafe";
+      axiosStub.post = sinon.fake();
+
+      req.query.error = "access_denied";
+      req.query.error_description = "Access was denied!";
+
+      const searchParams = new URLSearchParams([
+        ["authorization_code", req.credentialIssuer.code],
+        ["credential_issuer_id", req.query.id],
+        [
+          "redirect_uri",
+          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
+        ],
+        ["state", req.credentialIssuer.state],
+        ["error", req.query.error],
+        ["error_description", req.query.error_description],
+      ]);
+
+      await middleware.sendParamsToAPI(req, res, next);
+
+      expect(axiosStub.post).to.have.been.calledWith(
+        "https://example.net/path/journey/cri/validate-callback",
+        searchParams,
+        sinon.match({
+          headers: {
+            "ipv-session-id": "abadcafe",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+      );
     });
 
     it("should send code to core backend and return with 200 response", async () => {
@@ -267,144 +330,6 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(res.error).to.be.eql("Error");
-    });
-  });
-
-  describe("tryHandleRedirectError", async function () {
-    let req;
-    let res;
-    let next;
-    let axiosStub = {};
-    let configStub = {};
-    let middleware;
-    let ipvMiddlewareStub = {};
-
-    const error = "access_denied";
-    const error_description = "restart ";
-    const id = "ukPassport";
-
-    beforeEach(() => {
-      configStub.API_BASE_URL = "https://example.net/path";
-      ipvMiddlewareStub.handleJourneyResponse = sinon.fake();
-
-      middleware = proxyquire("./middleware", {
-        axios: axiosStub,
-        "../../lib/config": configStub,
-        "../ipv/middleware": ipvMiddlewareStub,
-      });
-
-      req = {
-        url: `/callback`,
-        query: { error, error_description, id },
-        params: {},
-        session: { ipvSessionId: "ipv-session-id" },
-      };
-
-      res = {
-        status: sinon.fake(),
-        render: sinon.fake(),
-        redirect: sinon.fake(),
-      };
-      next = sinon.fake();
-    });
-
-    it("should report error to journey api and redirect using response's journey value", async () => {
-      const axiosResponse = {};
-
-      axiosResponse.data = {
-        journey: "journey/cri/error",
-      };
-      axiosStub.post = sinon.fake.returns(axiosResponse);
-
-      const errorParams = new URLSearchParams([
-        ["error", error],
-        ["error_description", error_description],
-        ["credential_issuer_id", "ukPassport"],
-      ]);
-
-      await middleware.tryHandleRedirectError(req, res, next);
-
-      expect(axiosStub.post).to.have.been.calledWith(
-        `${configStub.API_BASE_URL}/journey/cri/error`,
-        errorParams,
-        sinon.match({
-          headers: {
-            "ipv-session-id": "ipv-session-id",
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-        })
-      );
-
-      expect(ipvMiddlewareStub.handleJourneyResponse.lastArg).to.equal(
-        "journey/cri/error"
-      );
-    });
-
-    it("should report error to journey api and redirect to journey value when only error description is present", async () => {
-      const axiosResponse = {};
-
-      axiosResponse.data = {
-        journey: "journey/cri/error",
-      };
-
-      axiosStub.post = sinon.fake.returns(axiosResponse);
-
-      const errorParams = new URLSearchParams([
-        ["error", "undefined"],
-        ["error_description", error_description],
-        ["credential_issuer_id", "ukPassport"],
-      ]);
-
-      req = {
-        url: `/callback`,
-        query: { error_description, id },
-        params: {},
-        session: { ipvSessionId: "ipv-session-id" },
-      };
-
-      await middleware.tryHandleRedirectError(req, res, next);
-
-      expect(axiosStub.post).to.have.been.calledWith(
-        `${configStub.API_BASE_URL}/journey/cri/error`,
-        errorParams,
-        sinon.match({
-          headers: {
-            "ipv-session-id": "ipv-session-id",
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-        })
-      );
-
-      expect(ipvMiddlewareStub.handleJourneyResponse.lastArg).to.equal(
-        "journey/cri/error"
-      );
-    });
-
-    it("should call next if no error and error_description is present in the query string", async () => {
-      req = {
-        url: `/callback`,
-        query: {},
-        session: { ipvSessionId: "ipv-session-id" },
-      };
-      axiosStub.post = sinon.fake.returns({});
-
-      await middleware.tryHandleRedirectError(req, res, next);
-
-      expect(next).to.have.been.calledOnce;
-    });
-
-    it("should call next with error if api call errors", async () => {
-      let axiosResponse = {};
-      axiosResponse.status = 404;
-      const axiosError = new Error("api error");
-      axiosError.response = axiosResponse;
-      axiosStub.post = sinon.fake.throws(axiosError);
-      await middleware.tryHandleRedirectError(req, res, next);
-
-      expect(next).to.have.been.calledWith(
-        sinon.match.has("message", "api error")
-      );
-      expect(next).to.have.been.calledOnce;
     });
   });
 });

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -6,21 +6,10 @@ const {
   addCallbackParamsToRequest,
   sendParamsToAPI,
   sendParamsToAPIV2,
-  tryHandleRedirectError,
 } = require("./middleware");
 
-router.get(
-  "/callback",
-  tryHandleRedirectError,
-  addCallbackParamsToRequest,
-  sendParamsToAPI
-);
+router.get("/callback", addCallbackParamsToRequest, sendParamsToAPI);
 
-router.get(
-  "/callback/:criId",
-  tryHandleRedirectError,
-  addCallbackParamsToRequest,
-  sendParamsToAPIV2
-);
+router.get("/callback/:criId", addCallbackParamsToRequest, sendParamsToAPIV2);
 
 module.exports = router;


### PR DESCRIPTION
## Proposed changes

### What changed

Call validate-callback endpoint with callback error params if they are present. Remove old call to cri-error endpoint

### Why did it change

In the backend the cri-error lambda is being removed, with the validate-callback lambda now responsible for handling both success and error oauth callbacks and deciding what to do

### Issue tracking
- [PYIC-2045](https://govukverify.atlassian.net/browse/PYIC-2045)

