### PR TITLE
PYIC-1785: Update content for kbv thin file error page

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -46,10 +46,8 @@ pyiKbvThinFile:
   content:
     - Mae ein cwestiynau diogelwch yn seiliedig ar wybodaeth sy’n cael ei gadw gan sefydliad arall. Nid oes gan y sefydliad hwn lawer o wybodaeth amdanoch chi.
     - Mae hyn yn golygu na allwn ofyn i chi’r nifer o gwestiynau y byddai angen i ni fod yn sicr mai chi yw pwy rydych yn ei ddweud ydych chi.
-    - "## Beth allwch chi ei wneud"
+    - "## Beth hoffech chi ei wneud?"
     - Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill o brofi pwy ydych chi.
-    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
-    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>
 
 pageIpvIdentityStart:
   title: Rydych wedi mewngofnodi i’ch cyfrif GOV.UK

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -42,14 +42,12 @@ pyiKbvFail:
 
 pyiKbvThinFile:
   title: Sorry, we cannot prove your identity right now
-  serviceNameRequired: false
+  serviceNameRequired: true
   content:
     - Our security questions are based on information held by another organisation. This organisation does not have much information about you.
     - This means we cannot ask you the number of questions that we’d need to be sure that you are who you say you are.
-    - "## What you can do"
+    - "## What would you like to do?"
     - Continue to the service you were trying to use and look for other ways to prove your identity.
-    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">{{ translate("buttons.govUkHomepage") }}</a>
-    - <a target="_blank" rel="noopener noreferrer" href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 pageIpvIdentityStart:
   title: You’ve signed in to your GOV.UK account

--- a/src/views/ipv/pyi-kbv-thin-file.html
+++ b/src/views/ipv/pyi-kbv-thin-file.html
@@ -1,10 +1,8 @@
 {% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "pyiKbvThinFile" %}
-{% set hmpoPageTitle = "pages."+hmpoThinFile+".title" %}
+
 
 {% block cta %}
-  {# unsure if this is required: page is still under development
   {% include 'shared/journey-next-form.njk' %}
   {{ translate("pages.errors.contactAccountTeamHTML") | safe }}
-  #}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

Updated kbv thin file error page content to be anligned with the content on the mural board 

<img width="500" alt="Screenshot 2022-10-11 at 09 43 34" src="https://user-images.githubusercontent.com/24409958/195044333-9ec9da0f-c204-4367-ab7f-ab211c55c7fa.png">

<img width="500" alt="Screenshot 2022-10-11 at 09 48 15" src="https://user-images.githubusercontent.com/24409958/195044292-9b724028-8bc7-4e90-9d00-b0460236a30d.png">


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1785](https://govukverify.atlassian.net/browse/PYIC-1785)

