### PR TITLE
BAU: Refactor handleJourneyResponse method

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -5,7 +5,7 @@ const {
   EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
 const { generateAxiosConfig } = require("../shared/axiosHelper");
-const { handleJourneyResponse } = require("../ipv/middleware");
+const { handleBackendResponse } = require("../ipv/middleware");
 const { transformError } = require("../shared/loggerHelper");
 const logger = require("hmpo-logger").get();
 
@@ -45,7 +45,7 @@ module.exports = {
       );
       res.status = apiResponse?.status;
 
-      return handleJourneyResponse(req, res, apiResponse.data?.journey);
+      return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
       transformError(error, "error calling validate-callback lambda");
       next(error);
@@ -79,7 +79,7 @@ module.exports = {
       );
       res.status = apiResponse?.status;
 
-      return handleJourneyResponse(req, res, apiResponse.data?.journey);
+      return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
       transformError(error, "error calling validate-callback lambda");
       next(error);

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -56,7 +56,7 @@ describe("credential issuer middleware", () => {
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
 
-      ipvMiddlewareStub.handleJourneyResponse = sinon.fake();
+      ipvMiddlewareStub.handleBackendResponse = sinon.fake();
 
       middleware = proxyquire("./middleware", {
         axios: axiosStub,
@@ -161,7 +161,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(ipvMiddlewareStub.handleJourneyResponse.lastArg).to.equal(
+      expect(ipvMiddlewareStub.handleBackendResponse.lastArg.journey).to.equal(
         "journey/next"
       );
     });
@@ -195,7 +195,7 @@ describe("credential issuer middleware", () => {
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
 
-      ipvMiddlewareStub.handleJourneyResponse = sinon.fake();
+      ipvMiddlewareStub.handleBackendResponse = sinon.fake();
 
       middleware = proxyquire("./middleware", {
         axios: axiosStub,
@@ -300,7 +300,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(ipvMiddlewareStub.handleJourneyResponse.lastArg).to.equal(
+      expect(ipvMiddlewareStub.handleBackendResponse.lastArg.journey).to.equal(
         "journey/next"
       );
     });


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactor handleJourneyResponse method

### Why did it change

This splits the `handleJourneyResponse` method in two. This allows the routing logic for backend responses to be used without having to call the backend.

This has been done in preparation for the credential-issuer middleware to be able to receive more than a journey response. A page response, for example, in the case that there is an error in one of the CRI response lambdas.

This is needed as there is a piece of work to run the CRI response lambdas in a step function, rather than bouncing back to the frontend. The step function may return a page response, and so the credential-issuer middleware has to be able to handle it.
