### PR TITLE
BAU: Call new backend endpoint for CRI return state machine

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -4,73 +4,74 @@ const {
   API_CRI_CALLBACK,
   EXTERNAL_WEBSITE_HOST,
 } = require("../../lib/config");
-const { generateAxiosConfig } = require("../shared/axiosHelper");
+const { generateJsonAxiosConfig } = require("../shared/axiosHelper");
 const { handleBackendResponse } = require("../ipv/middleware");
 const { transformError } = require("../shared/loggerHelper");
 const logger = require("hmpo-logger").get();
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
-    const oauthParams = {
+    const body = {
       authorizationCode: req.query?.code,
       credentialIssuerId: req.query.id,
       redirectUri: `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback?id=${req.query.id}`,
       state: req.query?.state,
     };
 
+    const errorDetails = {};
     if (req.query?.error) {
-      evidenceParam.append("error", req.query.error);
+      errorDetails.error = req.query.error;
       if (req.query.error_description) {
-        evidenceParam.append("error_description", req.query.error_description);
+        errorDetails.errorDescription = req.query.error_description;
       }
     }
 
     try {
-      logger.info("calling validate-callback lambda", { req, res });
+      logger.info("calling CRI callback step function", { req, res });
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
-        evidenceParam,
-        generateAxiosConfig(req.session.ipvSessionId)
+        { ...body, ...errorDetails },
+        generateJsonAxiosConfig(req.session.ipvSessionId)
       );
       res.status = apiResponse?.status;
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      transformError(error, "error calling validate-callback lambda");
+      transformError(error, "error calling CRI callback step function");
       next(error);
     }
   },
   // Temporary - this will replace the above method once all CRI's have been migrated across to use the new endpoint
   sendParamsToAPIV2: async (req, res, next) => {
     const criId = req.params.criId;
-    const redirectUri = `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback/${req.params.criId}`;
 
-    const evidenceParam = new URLSearchParams([
-      ["authorization_code", req.query?.code],
-      ["credential_issuer_id", criId],
-      ["redirect_uri", redirectUri],
-      ["state", req.query?.state],
-    ]);
+    const body = {
+      authorizationCode: req.query?.code,
+      credentialIssuerId: criId,
+      redirectUri: `${EXTERNAL_WEBSITE_HOST}/credential-issuer/callback/${criId}`,
+      state: req.query?.state,
+    };
 
+    const errorDetails = {};
     if (req.query?.error) {
-      evidenceParam.append("error", req.query.error);
+      errorDetails.error = req.query.error;
       if (req.query.error_description) {
-        evidenceParam.append("error_description", req.query.error_description);
+        errorDetails.errorDescription = req.query.error_description;
       }
     }
 
     try {
-      logger.info("calling validate-callback lambda", { req, res });
+      logger.info("calling CRI callback step function", { req, res });
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
-        evidenceParam,
-        generateAxiosConfig(req.session.ipvSessionId)
+        { ...body, ...errorDetails },
+        generateJsonAxiosConfig(req.session.ipvSessionId)
       );
       res.status = apiResponse?.status;
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      transformError(error, "error calling validate-callback lambda");
+      transformError(error, "error calling CRI callback step function");
       next(error);
     }
   },

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -2,43 +2,6 @@ const { expect } = require("chai");
 const proxyquire = require("proxyquire");
 
 describe("credential issuer middleware", () => {
-  describe("addCallbackParamsToRequest", () => {
-    let req;
-    let res;
-    let next;
-    let configStub;
-
-    beforeEach(() => {
-      req = {
-        query: {
-          code: "xyz",
-        },
-        params: {},
-        session: {},
-      };
-      configStub = {};
-      next = sinon.fake();
-    });
-
-    it("should save code to request", async function () {
-      const { addCallbackParamsToRequest } = proxyquire("./middleware", {
-        "../../lib/config": configStub,
-      });
-      await addCallbackParamsToRequest(req, res, next);
-
-      expect(req.credentialIssuer.code).to.equal(req.query.code);
-    });
-
-    it("should call next", async function () {
-      const { addCallbackParamsToRequest } = proxyquire("./middleware", {
-        "../../lib/config": configStub,
-      });
-
-      await addCallbackParamsToRequest(req, res, next);
-
-      expect(next).to.have.been.called;
-    });
-  });
   describe("sendParamsToAPI", function () {
     let req;
     let res;

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -14,7 +14,7 @@ describe("credential issuer middleware", () => {
     let ipvMiddlewareStub = {};
 
     beforeEach(() => {
-      configStub.API_CRI_VALIDATE_CALLBACK = "/journey/cri/validate-callback";
+      configStub.API_CRI_CALLBACK = "/journey/cri/callback";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
@@ -27,13 +27,13 @@ describe("credential issuer middleware", () => {
         "../ipv/middleware": ipvMiddlewareStub,
       });
       req = {
-        credentialIssuer: {
+        params: {},
+        session: { ipvSessionId: "ipv-session-id" },
+        query: {
+          id: "PassportIssuer",
           code: "authorize-code-issued",
           state: "oauth-state",
         },
-        params: {},
-        session: { ipvSessionId: "ipv-session-id" },
-        query: { id: "PassportIssuer" },
       };
       res = {
         status: sinon.fake(),
@@ -49,25 +49,22 @@ describe("credential issuer middleware", () => {
       req.session.ipvSessionId = "abadcafe";
       axiosStub.post = sinon.fake();
 
-      const searchParams = new URLSearchParams([
-        ["authorization_code", req.credentialIssuer.code],
-        ["credential_issuer_id", req.query.id],
-        [
-          "redirect_uri",
-          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
-        ],
-        ["state", req.credentialIssuer.state],
-      ]);
+      const expectedBody = {
+        authorizationCode: req.query.code,
+        credentialIssuerId: req.query.id,
+        redirectUri: `http://example.com/credential-issuer/callback?id=${req.query.id}`,
+        state: req.query.state,
+      };
 
       await middleware.sendParamsToAPI(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/validate-callback",
-        searchParams,
+        "https://example.net/path/journey/cri/callback",
+        expectedBody,
         sinon.match({
           headers: {
             "ipv-session-id": "abadcafe",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
           },
         })
       );
@@ -80,27 +77,24 @@ describe("credential issuer middleware", () => {
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
 
-      const searchParams = new URLSearchParams([
-        ["authorization_code", req.credentialIssuer.code],
-        ["credential_issuer_id", req.query.id],
-        [
-          "redirect_uri",
-          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
-        ],
-        ["state", req.credentialIssuer.state],
-        ["error", req.query.error],
-        ["error_description", req.query.error_description],
-      ]);
+      const expectedBody = {
+        authorizationCode: req.query.code,
+        credentialIssuerId: req.query.id,
+        redirectUri: `http://example.com/credential-issuer/callback?id=${req.query.id}`,
+        state: req.query.state,
+        error: req.query.error,
+        errorDescription: req.query.error_description,
+      };
 
       await middleware.sendParamsToAPI(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/validate-callback",
-        searchParams,
+        "https://example.net/path/journey/cri/callback",
+        expectedBody,
         sinon.match({
           headers: {
             "ipv-session-id": "abadcafe",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
           },
         })
       );
@@ -153,7 +147,7 @@ describe("credential issuer middleware", () => {
     let ipvMiddlewareStub = {};
 
     beforeEach(() => {
-      configStub.API_CRI_VALIDATE_CALLBACK = "/journey/cri/validate-callback";
+      configStub.API_CRI_CALLBACK = "/journey/cri/callback";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
@@ -166,13 +160,12 @@ describe("credential issuer middleware", () => {
         "../ipv/middleware": ipvMiddlewareStub,
       });
       req = {
-        credentialIssuer: {
+        params: { criId: "PassportIssuer" },
+        session: { ipvSessionId: "ipv-session-id" },
+        query: {
           code: "authorize-code-issued",
           state: "oauth-state",
         },
-        params: { criId: "PassportIssuer" },
-        session: { ipvSessionId: "ipv-session-id" },
-        query: {},
       };
       res = {
         status: sinon.fake(),
@@ -188,25 +181,22 @@ describe("credential issuer middleware", () => {
       req.session.ipvSessionId = "abadcafe";
       axiosStub.post = sinon.fake();
 
-      const searchParams = new URLSearchParams([
-        ["authorization_code", req.credentialIssuer.code],
-        ["credential_issuer_id", req.params.criId],
-        [
-          "redirect_uri",
-          `http://example.com/credential-issuer/callback/${req.params.criId}`,
-        ],
-        ["state", req.credentialIssuer.state],
-      ]);
+      const expectedBody = {
+        authorizationCode: req.query.code,
+        credentialIssuerId: req.params.criId,
+        redirectUri: `http://example.com/credential-issuer/callback/${req.params.criId}`,
+        state: req.query.state,
+      };
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/validate-callback",
-        searchParams,
+        "https://example.net/path/journey/cri/callback",
+        expectedBody,
         sinon.match({
           headers: {
             "ipv-session-id": "abadcafe",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
           },
         })
       );
@@ -219,27 +209,24 @@ describe("credential issuer middleware", () => {
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
 
-      const searchParams = new URLSearchParams([
-        ["authorization_code", req.credentialIssuer.code],
-        ["credential_issuer_id", req.query.id],
-        [
-          "redirect_uri",
-          `http://example.com/credential-issuer/callback?id=${req.query.id}`,
-        ],
-        ["state", req.credentialIssuer.state],
-        ["error", req.query.error],
-        ["error_description", req.query.error_description],
-      ]);
+      const expectedBody = {
+        authorizationCode: req.query.code,
+        credentialIssuerId: req.params.criId,
+        redirectUri: `http://example.com/credential-issuer/callback/${req.params.criId}`,
+        state: req.query.state,
+        error: req.query.error,
+        errorDescription: req.query.error_description,
+      };
 
-      await middleware.sendParamsToAPI(req, res, next);
+      await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/validate-callback",
-        searchParams,
+        "https://example.net/path/journey/cri/callback",
+        expectedBody,
         sinon.match({
           headers: {
             "ipv-session-id": "abadcafe",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
           },
         })
       );

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -2,14 +2,10 @@ const express = require("express");
 
 const router = express.Router();
 
-const {
-  addCallbackParamsToRequest,
-  sendParamsToAPI,
-  sendParamsToAPIV2,
-} = require("./middleware");
+const { sendParamsToAPI, sendParamsToAPIV2 } = require("./middleware");
 
-router.get("/callback", addCallbackParamsToRequest, sendParamsToAPI);
+router.get("/callback", sendParamsToAPI);
 
-router.get("/callback/:criId", addCallbackParamsToRequest, sendParamsToAPIV2);
+router.get("/callback/:criId", sendParamsToAPIV2);
 
 module.exports = router;

--- a/src/app/shared/axiosHelper.js
+++ b/src/app/shared/axiosHelper.js
@@ -7,4 +7,12 @@ module.exports = {
       },
     };
   },
+  generateJsonAxiosConfig: (sessionId) => {
+    return {
+      headers: {
+        "Content-Type": "application/json",
+        "ipv-session-id": sessionId,
+      },
+    };
+  },
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -12,7 +12,7 @@ module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_BUILD_DEBUG_CREDENTIAL_DATA_PATH: "/debug-credential-data",
   API_REQUEST_CONFIG_PATH: "/request-config",
-  API_CRI_VALIDATE_CALLBACK: "/journey/cri/validate-callback",
+  API_CRI_CALLBACK: "/journey/cri/callback",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,


### PR DESCRIPTION
**Not to be merged before https://github.com/alphagov/di-ipv-core-back/pull/528**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Call new backend endpoint for CRI return state machine

### Why did it change

[BAU: Remove addCallbackParamsToRequest middleware](https://github.com/alphagov/di-ipv-core-front/commit/d0ca82ddda0c2fd804ea20678254f9a36c2e9d56) 

The logic in this middleware seems pretty redundant. The
`credentialIssuer` object stored on the request is only used in the next
middleware, and is only used to retrieve the data stored in this
middleware. It's effectively a proxy for the request object.
  
[BAU: Use new /cri/callback backend endpoint](https://github.com/alphagov/di-ipv-core-front/commit/72a695d8d2f5f9d621cd58a447d82559beacfd36) 

The new backend endpoint hooks into the CRI return step function. This
is a more appropriate endpoint that `/cri/validate-callback`.

This also switches the request content type to `application/json`. We're
dealing with JSON in the backend lambdas so it makes sense to keep
things simple. This change will also allow us to directly deserialize
the incoming data in the validate-callback lambda, rather than using an
input stream and having to read it.
