### PR TITLE
PYIC-1078 Added back security group rules to s3 and dynamodb prefix list

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,6 +59,10 @@ Mappings:
       desiredTaskCount: 2
     "075701497069": # Production
       desiredTaskCount: 2
+  SecurityGroups:
+    PrefixListIds:
+      dynamodb: "pl-b3a742da"
+      s3: "pl-7ca54015"
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -95,6 +99,16 @@ Resources:
       GroupDescription: >-
         Core Front ECS Security Group outbound permissions ruleset
       SecurityGroupEgress:
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, dynamodb]
+          Description: Allow outbound traffic to dynamodb vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, s3]
+          Description: Allow outbound traffic to s3 vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
         - DestinationSecurityGroupId: !If
             - IsNotDevelopment
             - Fn::ImportValue:  !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-1078 Added back security group rules to s3 and dynamodb prefix list
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-1078 Added back security group rules to s3 and dynamodb prefix list.

For future reference, these are managed aws prefix lists created by aws: https://docs.aws.amazon.com/vpc/latest/userguide/working-with-aws-managed-prefix-lists.html

For gateway endpoints they work on a CIDR range where AWS provide some "prefix list ids" which act as references to the CIDR range, you'll also see these in the route table routes for the gateway endpoints. For these the ECS security group will need a rule that references the "prefix list id" for that particular service for example permit TCP on port 443 for "pl-b3a7422da" (prefix list id for dynamodb)
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1078](https://govukverify.atlassian.net/browse/PYIC-1078)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
