### PR TITLE
PYIC-1078 split out ecs security groups and fixed vpc calls

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -90,7 +90,7 @@ Resources:
       Description: >-
         Egress between the Core Front load balancer and
         the core front ECS security group
-      DestinationSecurityGroupId: !GetAtt ECSSecurityGroup.GroupId
+      DestinationSecurityGroupId: !GetAtt CoreFrontECSSecurityGroup.GroupId
       FromPort: 8080
       ToPort: 8080
 
@@ -109,7 +109,7 @@ Resources:
           IpProtocol: tcp
           ToPort: 80
       VpcId:
-        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+        Fn::ImportValue: !Sub networking-${Environment}-VpcId
 
   # Deprecated will be removed once migrated to new vpc
   LoadBalancerSGEgressToECSSecurityGroup:
@@ -124,7 +124,7 @@ Resources:
       FromPort: 8080
       ToPort: 8080
 
-  ECSSecurityGroup:
+  CoreFrontECSSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
@@ -151,6 +151,45 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub ${VpcStackName}-VpcId
 
+  CoreFrontECSSecurityGroupIngressFromLoadBalancer:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      IpProtocol: tcp
+      Description: >-
+        Core Front ECS permits inbound from the Core Front
+        load balancer.
+      FromPort: 8080
+      ToPort: 8080
+      GroupId: !GetAtt CoreFrontECSSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt PrivateLoadBalancerSG.GroupId
+
+
+  # Deprecated will be removed when vpc migration is complete
+  ECSSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: >-
+        Core Front ECS Security Group outbound permissions ruleset
+      SecurityGroupEgress:
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, dynamodb]
+          Description: Allow outbound traffic to dynamodb vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, s3]
+          Description: Allow outbound traffic to s3 vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - DestinationSecurityGroupId: !ImportValue InterfaceVpcEndpointSecurityGroupId
+          Description: Allow outbound traffic to Interface vpc endpoint security group
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+      VpcId:
+        Fn::ImportValue: !Sub networking-${Environment}-VpcId
+
+  # Deprecated will be removed when vpc migration is complete
   ECSSecurityGroupIngressFromLoadBalancer:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
@@ -161,7 +200,7 @@ Resources:
       FromPort: 8080
       ToPort: 8080
       GroupId: !GetAtt ECSSecurityGroup.GroupId
-      SourceSecurityGroupId: !GetAtt PrivateLoadBalancerSG.GroupId
+      SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
 
   AccessLogsBucket:
     Type: AWS::S3::Bucket
@@ -382,7 +421,7 @@ Resources:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
           SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
+            - !GetAtt CoreFrontECSSecurityGroup.GroupId
           Subnets:
             - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
             - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-1078 split out ecs security groups and fixed vpc calls
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-1078 split out ecs security groups and fixed vpc calls

The vpc for the deprecated security group was pointing to new vpc - this is now fixed. 
Also noticed the same issue would arise for the ecs security groups so they have also been duplicated / renamed for the new vpc and settings adjusted for the deprecated to link to the deprecated security groups and vpc. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1078](https://govukverify.atlassian.net/browse/PYIC-1078)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
