### PR TITLE
BAU: harmonise query string field name with cookie name for localisation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,7 @@ const { router } = setup({
     allowedLangs: ["en", "cy"],
     fallbackLang: ["en"],
     cookie: { name: "lng" },
+    query: "lng",
   },
   dev: true,
   middlewareSetupFn: (app) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR harmonises the query string field name to `lng`, which matches the cookie name `lng` to control the language of the user interface’s content.

### What changed

<!-- Describe the changes in detail - the "what"-->
`app.js` has a new key added in the translation object.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
In the current state of the app, the language can be changed using the `lang` query string field name, which is different to the cookie name, `lng`. Using the same name reduces confusion and will make documenting this feature easier.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- This will be discussed further at the #di-frontend meeting

## Checklists

### Other considerations

- [ ] This behaviour should be documented as part of the Welsh translation work
