### PR TITLE
PYIC-2047 - replace hmpo-logger with pino logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "yarn": "1.22.x"
   },
   "scripts": {
-    "start": "node src/app.js  | pino-pretty",
+    "start": "node src/app.js",
+    "start-dev": "node src/app.js | pino-pretty",
     "dev": "nodemon --inspect=0.0.0.0:9228 src/app.js",
     "build": "yarn minfiy-build-front-end-gov-js && yarn build-sass && yarn copy-locales",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "yarn": "1.22.x"
   },
   "scripts": {
-    "start": "node src/app.js",
+    "start": "node src/app.js  | pino-pretty",
     "dev": "nodemon --inspect=0.0.0.0:9228 src/app.js",
     "build": "yarn minfiy-build-front-end-gov-js && yarn build-sass && yarn copy-locales",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
@@ -40,6 +40,7 @@
     "lint-staged": "13.0.3",
     "mocha": "10.0.0",
     "nodemon": "2.0.19",
+    "pino-pretty": "9.1.1",
     "prettier": "2.7.1",
     "proxyquire": "2.1.3",
     "sass": "1.54.9",
@@ -68,6 +69,8 @@
     "hmpo-logger": "6.1.1",
     "jsonwebtoken": "8.5.1",
     "nunjucks": "3.2.3",
-    "nyc": "15.1.0"
+    "nyc": "15.1.0",
+    "pino": "8.6.1",
+    "pino-http": "8.2.1"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -58,6 +58,7 @@ router.use((req, res, next) => {
   req.log = logger.child({
     requestId: req.id,
     ipvSessionId: req.session?.ipvSessionId,
+    sessionId: req.session?.id,
   });
   next();
 });

--- a/src/app.js
+++ b/src/app.js
@@ -8,12 +8,6 @@ const { PORT, SESSION_SECRET, SESSION_TABLE_NAME } = require("./lib/config");
 const { setup } = require("hmpo-app");
 const { getGTM } = require("./lib/locals");
 const { loggerMiddleware, logger } = require("./lib/logger");
-const { randomUUID } = require("node:crypto");
-const { logCoreBackCall } = require("./app/shared/loggerHelper");
-const {
-  LOG_COMMUNICATION_TYPE_REQUEST,
-  LOG_TYPE_JOURNEY,
-} = require("./app/shared/loggerConstants");
 
 let sessionStore;
 
@@ -56,24 +50,13 @@ const { router } = setup({
       req.headers["x-forwarded-proto"] = "https";
       next();
     });
-
-    //generate request id for logging correlation
-    app.use(function (req, res, next) {
-      let id = req.get("x-request-id");
-      if (!id) {
-        id = randomUUID();
-      }
-      req.requestId = id;
-      next();
-    });
-
     app.use(loggerMiddleware);
   },
 });
 
-// due to the sequencing
 router.use((req, res, next) => {
   req.log = logger.child({
+    requestId: req.id,
     ipvSessionId: req.session?.ipvSessionId,
   });
   next();

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const DynamoDBStore = require("connect-dynamodb")(session);
 const { PORT, SESSION_SECRET, SESSION_TABLE_NAME } = require("./lib/config");
 const { setup } = require("hmpo-app");
 const { getGTM } = require("./lib/locals");
+const { loggerMiddleware } = require("./lib/logger");
 
 let sessionStore;
 
@@ -22,18 +23,6 @@ if (process.env.NODE_ENV !== "local") {
   });
 }
 
-const loggerConfig = {
-  console: true,
-  consoleJSON: true,
-  app: false,
-  requestMeta: {
-    ipvSessionId: "session.ipvSessionId",
-  },
-  meta: {
-    ipvSessionId: "session.ipvSessionId",
-  },
-};
-
 const sessionConfig = {
   cookieName: "ipv_core_service_session",
   secret: SESSION_SECRET,
@@ -43,7 +32,7 @@ const sessionConfig = {
 const { router } = setup({
   config: { APP_ROOT: __dirname },
   port: PORT,
-  logs: loggerConfig,
+  logs: false,
   session: sessionConfig,
   redis: !sessionStore,
   urls: {
@@ -61,6 +50,8 @@ const { router } = setup({
       req.headers["x-forwarded-proto"] = "https";
       next();
     });
+
+    app.use(loggerMiddleware);
   },
 });
 

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -6,7 +6,7 @@ const {
 } = require("../../lib/config");
 const { generateJsonAxiosConfig } = require("../shared/axiosHelper");
 const { handleBackendResponse } = require("../ipv/middleware");
-const { logError, logCoreBackCall } = require("../shared/loggerHelper");
+const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 
 module.exports = {
@@ -41,7 +41,7 @@ module.exports = {
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      logError(req, error, "error calling validate-callback lambda");
+      transformError(error, "error calling validate-callback lambda");
       next(error);
     }
   },
@@ -79,7 +79,7 @@ module.exports = {
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      logError(req, error, "error calling validate-callback lambda");
+      transformError(error, "error calling validate-callback lambda");
       next(error);
     }
   },

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -6,8 +6,8 @@ const {
 } = require("../../lib/config");
 const { generateJsonAxiosConfig } = require("../shared/axiosHelper");
 const { handleBackendResponse } = require("../ipv/middleware");
-const { transformError } = require("../shared/loggerHelper");
-const logger = require("hmpo-logger").get();
+const { logError, logCoreBackCall } = require("../shared/loggerHelper");
+const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -27,7 +27,11 @@ module.exports = {
     }
 
     try {
-      logger.info("calling CRI callback step function", { req, res });
+      logCoreBackCall(req, {
+        logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
+        path: API_CRI_CALLBACK,
+      });
+
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
@@ -37,7 +41,7 @@ module.exports = {
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      transformError(error, "error calling CRI callback step function");
+      logError(req, error, "error calling validate-callback lambda");
       next(error);
     }
   },
@@ -61,7 +65,11 @@ module.exports = {
     }
 
     try {
-      logger.info("calling CRI callback step function", { req, res });
+      logCoreBackCall(req, {
+        logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
+        path: API_CRI_CALLBACK,
+      });
+
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
@@ -71,7 +79,7 @@ module.exports = {
 
       return handleBackendResponse(req, res, apiResponse.data);
     } catch (error) {
-      transformError(error, "error calling CRI callback step function");
+      logError(req, error, "error calling validate-callback lambda");
       next(error);
     }
   },

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -35,11 +35,11 @@ module.exports = {
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
-        generateJsonAxiosConfig(req.session.ipvSessionId)
+        generateJsonAxiosConfig(req)
       );
       res.status = apiResponse?.status;
 
-      return handleBackendResponse(req, res, apiResponse.data);
+      return handleBackendResponse(req, res, apiResponse?.data);
     } catch (error) {
       transformError(error, "error calling validate-callback lambda");
       next(error);
@@ -73,7 +73,7 @@ module.exports = {
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
-        generateJsonAxiosConfig(req.session.ipvSessionId)
+        generateJsonAxiosConfig(req)
       );
       res.status = apiResponse?.status;
 

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const proxyquire = require("proxyquire");
+const sinon = require("sinon");
 
 describe("credential issuer middleware", () => {
   describe("sendParamsToAPI", function () {
@@ -27,6 +28,7 @@ describe("credential issuer middleware", () => {
         "../ipv/middleware": ipvMiddlewareStub,
       });
       req = {
+        id: "1",
         params: {},
         session: { ipvSessionId: "ipv-session-id" },
         query: {
@@ -34,6 +36,7 @@ describe("credential issuer middleware", () => {
           code: "authorize-code-issued",
           state: "oauth-state",
         },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
       res = {
         status: sinon.fake(),
@@ -65,6 +68,7 @@ describe("credential issuer middleware", () => {
           headers: {
             "ipv-session-id": "abadcafe",
             "Content-Type": "application/json",
+            "x-request-id": "1",
           },
         })
       );
@@ -93,6 +97,7 @@ describe("credential issuer middleware", () => {
         expectedBody,
         sinon.match({
           headers: {
+            "x-request-id": "1",
             "ipv-session-id": "abadcafe",
             "Content-Type": "application/json",
           },
@@ -160,12 +165,14 @@ describe("credential issuer middleware", () => {
         "../ipv/middleware": ipvMiddlewareStub,
       });
       req = {
+        id: "1",
         params: { criId: "PassportIssuer" },
         session: { ipvSessionId: "ipv-session-id" },
         query: {
           code: "authorize-code-issued",
           state: "oauth-state",
         },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
       res = {
         status: sinon.fake(),
@@ -197,6 +204,7 @@ describe("credential issuer middleware", () => {
           headers: {
             "ipv-session-id": "abadcafe",
             "Content-Type": "application/json",
+            "x-request-id": "1",
           },
         })
       );
@@ -225,6 +233,7 @@ describe("credential issuer middleware", () => {
         expectedBody,
         sinon.match({
           headers: {
+            "x-request-id": "1",
             "ipv-session-id": "abadcafe",
             "Content-Type": "application/json",
           },

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -4,19 +4,18 @@ const {
   API_REQUEST_CONFIG_PATH,
   API_BUILD_DEBUG_CREDENTIAL_DATA_PATH,
 } = require("../../lib/config");
-const logger = require("hmpo-logger").get();
 
 module.exports = {
   setCriConfig: async (req, res, next) => {
     if (!req.session.criConfig) {
       try {
-        logger.info("calling cri config lambda", { req, res });
+        req.log.info("calling cri config lambda", { req, res });
         const apiResponse = await axios.get(
           `${API_BASE_URL}${API_REQUEST_CONFIG_PATH}`
         );
         req.session.criConfig = apiResponse.data;
       } catch (error) {
-        logger.error("error calling cri config lambda", { req, res, error });
+        req.log.error("error calling cri config lambda", { req, res, error });
         res.error = error.name;
         return next(error);
       }
@@ -26,7 +25,7 @@ module.exports = {
 
   getIssuedCredentials: async (req, res, next) => {
     try {
-      logger.info("calling build-debug-credential-data lambda", { req, res });
+      req.log.info("calling build-debug-credential-data lambda", { req, res });
       const apiResponse = await axios.get(
         `${API_BASE_URL}${API_BUILD_DEBUG_CREDENTIAL_DATA_PATH}`,
         {
@@ -43,7 +42,11 @@ module.exports = {
 
       req.issuedCredentials = parsedResponse;
     } catch (error) {
-      logger.error("error fetching debug credential data", { req, res, error });
+      req.log.error("error fetching debug credential data", {
+        req,
+        res,
+        error,
+      });
       res.error = error.name;
       return next(error);
     }

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -25,7 +25,7 @@ module.exports = {
 
   getIssuedCredentials: async (req, res, next) => {
     try {
-      req.log.info("calling build-debug-credential-data lambda", { req, res });
+      req.log.info("calling build-debug-credential-data lambda");
       const apiResponse = await axios.get(
         `${API_BASE_URL}${API_BUILD_DEBUG_CREDENTIAL_DATA_PATH}`,
         {

--- a/src/app/debug/middleware.js
+++ b/src/app/debug/middleware.js
@@ -4,6 +4,7 @@ const {
   API_REQUEST_CONFIG_PATH,
   API_BUILD_DEBUG_CREDENTIAL_DATA_PATH,
 } = require("../../lib/config");
+const { transformError } = require("../shared/loggerHelper");
 
 module.exports = {
   setCriConfig: async (req, res, next) => {
@@ -15,8 +16,7 @@ module.exports = {
         );
         req.session.criConfig = apiResponse.data;
       } catch (error) {
-        req.log.error("error calling cri config lambda", { req, res, error });
-        res.error = error.name;
+        transformError(error, "error calling cri config lambda");
         return next(error);
       }
     }
@@ -42,12 +42,7 @@ module.exports = {
 
       req.issuedCredentials = parsedResponse;
     } catch (error) {
-      req.log.error("error fetching debug credential data", {
-        req,
-        res,
-        error,
-      });
-      res.error = error.name;
+      transformError(error, "error fetching debug credential data");
       return next(error);
     }
     next();

--- a/src/app/debug/middleware.test.js
+++ b/src/app/debug/middleware.test.js
@@ -1,5 +1,4 @@
 const proxyquire = require("proxyquire");
-
 const axiosStub = {};
 
 const configStub = {
@@ -25,6 +24,11 @@ describe("debug middleware", () => {
       render: sinon.fake(),
     };
 
+    req = {
+      session: {},
+      log: { info: sinon.fake(), error: sinon.fake() },
+    };
+
     next = sinon.fake();
   });
 
@@ -34,6 +38,7 @@ describe("debug middleware", () => {
       beforeEach(() => {
         req = {
           session: {},
+          log: { info: sinon.fake(), error: sinon.fake() },
         };
         axiosResponse = {
           data: [
@@ -87,7 +92,7 @@ describe("debug middleware", () => {
 
           await middleware.setCriConfig(req, res, next);
 
-          expect(res.error).to.be.eql("Error");
+          expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
         });
       });
     });
@@ -135,6 +140,7 @@ describe("debug middleware", () => {
     beforeEach(() => {
       req = {
         session: {},
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
     });
 
@@ -164,7 +170,7 @@ describe("debug middleware", () => {
 
         await middleware.getIssuedCredentials(req, res, next);
 
-        expect(res.error).to.be.eql("Error");
+        expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
       });
     });
   });
@@ -172,7 +178,6 @@ describe("debug middleware", () => {
   describe("renderDebugPage", () => {
     it("should render debug page", () => {
       middleware.renderDebugPage(req, res);
-
       expect(res.render).to.have.been.calledWith("debug/page-ipv-debug");
     });
   });

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -114,19 +114,42 @@ module.exports = {
         return next(new Error("Debug operation not available"));
       }
 
-      const action = req.url;
-      //valid list of allowed actions for route
       const allowedActions = [
-        /^\/journey\/(next|error|fail)$/,
-        /^\/journey\/cri\/build-oauth-request\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv|activityHistory|stubActivityHistory|dcmaw|stubDcmaw|debugAddress)$/,
-        /^\/journey\/build-client-oauth-response$/,
-        /^\/journey\/cri\/validate\/(ukPassport|stubUkPassport|fraud|stubFraud|address|stubAddress|kbv|stubKbv|dcmaw|stubDcmaw)$/,
+        "/journey/next",
+        "/journey/error",
+        "/journey/fail",
+        "/journey/cri/build-oauth-request/ukPassport",
+        "/journey/cri/build-oauth-request/stubUkPassport",
+        "/journey/cri/build-oauth-request/fraud",
+        "/journey/cri/build-oauth-request/stubFraud",
+        "/journey/cri/build-oauth-request/address",
+        "/journey/cri/build-oauth-request/stubAddress",
+        "/journey/cri/build-oauth-request/kbv",
+        "/journey/cri/build-oauth-request/stubKbv",
+        "/journey/cri/build-oauth-request/activityHistory",
+        "/journey/cri/build-oauth-request/stubActivityHistory",
+        "/journey/cri/build-oauth-request/dcmaw",
+        "/journey/cri/build-oauth-request/stubDcmaw",
+        "/journey/cri/build-oauth-request/debugAddress",
+        "/journey/build-client-oauth-response",
+        "/journey/cri/validate/ukPassport",
+        "/journey/cri/validate/stubUkPassport",
+        "/journey/cri/validate/fraud",
+        "/journey/cri/validate/stubFraud",
+        "/journey/cri/validate/address",
+        "/journey/cri/validate/stubAddress",
+        "/journey/cri/validate/kbv",
+        "/journey/cri/validate/stubKbv",
+        "/journey/cri/validate/dcmaw",
+        "/journey/cri/validate/stubDcmaw",
       ];
 
-      if (allowedActions.some((actionRegex) => actionRegex.test(action))) {
+      const action = allowedActions.find((x) => x === req.url);
+
+      if (action) {
         await handleJourneyResponse(req, res, action);
       } else {
-        next(new Error(`Action ${action} not valid`));
+        next(new Error(`Action ${req.url} not valid`));
       }
     } catch (error) {
       next(error);

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -5,9 +5,12 @@ const {
   redirectToAuthorize,
 } = require("../shared/criHelper");
 
-
 const { generateAxiosConfig } = require("../shared/axiosHelper");
-const { logError, logCoreBackCall } = require("../shared/loggerHelper");
+const {
+  logError,
+  logCoreBackCall,
+  transformError,
+} = require("../shared/loggerHelper");
 const {
   LOG_COMMUNICATION_TYPE_REQUEST,
   LOG_TYPE_JOURNEY,
@@ -168,7 +171,7 @@ module.exports = {
           return res.render(`ipv/pyi-technical`);
       }
     } catch (error) {
-      logError(req, error, `error handling journey page: ${req.params}`);
+      transformError(error, `error handling journey page: ${req.params}`);
       next(error);
     }
   },
@@ -180,7 +183,7 @@ module.exports = {
         await handleJourneyResponse(req, res, "journey/next");
       }
     } catch (error) {
-      logError(req, error, "error invoking handleJourneyAction");
+      transformError(error, "error invoking handleJourneyAction");
       next(error);
     }
   },

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -30,16 +30,26 @@ describe("journey middleware", () => {
       redirect: sinon.fake(),
       send: sinon.fake(),
       render: sinon.fake(),
+      log: { info: sinon.fake(), error: sinon.fake() },
     };
     req = {
       session: { ipvSessionId: "ipv-session-id" },
       csrfToken: sinon.fake(),
+      log: { info: sinon.fake(), error: sinon.fake() },
     };
     next = sinon.fake();
     axiosStub.post.reset();
   });
 
   context("from a sequence of events that ends with a page response", () => {
+    beforeEach(() => {
+      req = {
+        id: "1",
+        session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+    });
+
     it("should have called the network in the correct sequence", async function () {
       const pageId = "pageTransition";
       const eventResponses = [
@@ -65,14 +75,9 @@ describe("journey middleware", () => {
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
           "ipv-session-id": "ipv-session-id",
+          "x-request-id": "1",
         },
       };
-
-      beforeEach(() => {
-        req = {
-          session: { ipvSessionId: "ipv-session-id" },
-        };
-      });
 
       await middleware.handleJourneyResponse(req, res, "/journey/next");
       expect(axiosStub.post.getCall(0)).to.have.been.calledWith(
@@ -98,16 +103,20 @@ describe("journey middleware", () => {
   context("calling the journeyPage endpoint", () => {
     beforeEach(() => {
       req = {
+        id: "1",
         url: "/ipv/page",
         session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
     });
 
     it("should render debug page when page-ipv-debug", async () => {
       req = {
+        id: "1",
         params: { pageId: "page-ipv-debug" },
         csrfToken: sinon.fake(),
         session: { currentPage: "page-ipv-debug" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       await middleware.handleJourneyPage(req, res);
@@ -116,9 +125,11 @@ describe("journey middleware", () => {
 
     it("should render page case when given valid pageId", async () => {
       req = {
+        id: "1",
         params: { pageId: "page-ipv-identity-start" },
         csrfToken: sinon.fake(),
         session: { currentPage: "page-ipv-identity-start" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       await middleware.handleJourneyPage(req, res);
@@ -127,8 +138,10 @@ describe("journey middleware", () => {
 
     it("should render technical error page when given invalid pageId", async () => {
       req = {
+        id: "1",
         params: { pageId: "../debug/page-ipv-debug" },
         session: { currentPage: "../debug/page-ipv-debug" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       await middleware.handleJourneyPage(req, res);
@@ -137,8 +150,10 @@ describe("journey middleware", () => {
 
     it("should render unrecoverable technical error page when current page is not equal to pageId", async () => {
       req = {
+        id: "1",
         params: { pageId: "invalid-page-id" },
         session: { currentPage: "../debug/page-ipv-debug" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       await middleware.handleJourneyPage(req, res);
@@ -192,8 +207,10 @@ describe("journey middleware", () => {
         },
       ];
       req = {
+        id: "1",
         url: "/journey/next",
         session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       const callBack = sinon.stub();
@@ -229,7 +246,9 @@ describe("journey middleware", () => {
         },
       ];
       req = {
+        id: "1",
         session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
       await middleware.handleJourneyResponse(
         req,
@@ -259,7 +278,9 @@ describe("journey middleware", () => {
           },
         ];
         req = {
+          id: "1",
           session: { ipvSessionId: "ipv-session-id" },
+          log: { info: sinon.fake(), error: sinon.fake() },
         };
 
         const callBack = sinon.stub();
@@ -292,7 +313,9 @@ describe("journey middleware", () => {
       });
 
       req = {
+        id: "1",
         session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
     });
 
@@ -318,8 +341,10 @@ describe("journey middleware", () => {
       ];
 
       req = {
+        id: "1",
         url: "/journey/next",
         session: { ipvSessionId: "ipv-session-id" },
+        log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       const callBack = sinon.stub();
@@ -343,8 +368,10 @@ describe("journey middleware", () => {
     () => {
       it("should post with journey/end", async function () {
         req = {
+          id: "1",
           body: { journey: "end" },
           session: { ipvSessionId: "ipv-session-id" },
+          log: { info: sinon.fake(), error: sinon.fake() },
         };
 
         await middleware.handleJourneyAction(req, res, next);

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const { API_BASE_URL, API_SESSION_INITIALISE } = require("../../lib/config");
-const { logError, logCoreBackCall } = require("../shared/loggerHelper");
+const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 
 module.exports = {
@@ -46,7 +46,7 @@ module.exports = {
 
       req.session.ipvSessionId = response?.data?.ipvSessionId;
     } catch (error) {
-      logError(req, error, "error calling initialise-ipv-session lambda");
+      transformError(error, `error handling journey page: ${req.params}`);
       return next(error);
     }
 

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -10,7 +10,7 @@ module.exports = {
   },
 
   setRealJourneyType: (req, res, next) => {
-    req.log.info("starting real journey", { req, res });
+    req.log.info("starting real journey");
     req.session.isDebugJourney = false;
     next();
   },

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
-const { API_BASE_URL } = require("../../lib/config");
-const { transformError } = require("../shared/loggerHelper");
-const logger = require("hmpo-logger").get();
+const { API_BASE_URL, API_SESSION_INITIALISE } = require("../../lib/config");
+const { logError, logCoreBackCall } = require("../shared/loggerHelper");
+const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 
 module.exports = {
   setDebugJourneyType: (req, _res, next) => {
@@ -10,7 +10,7 @@ module.exports = {
   },
 
   setRealJourneyType: (req, res, next) => {
-    logger.info("starting real journey", { req, res });
+    req.log.info("starting real journey", { req, res });
     req.session.isDebugJourney = false;
     next();
   },
@@ -34,14 +34,19 @@ module.exports = {
         return next(new Error("Client ID Missing"));
       }
 
-      logger.info("calling initialise-ipv-session lambda", { req, res });
+      logCoreBackCall(req, {
+        logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
+        path: API_SESSION_INITIALISE,
+      });
+
       const response = await axios.post(
-        `${API_BASE_URL}/session/initialise`,
+        `${API_BASE_URL}${API_SESSION_INITIALISE}`,
         authParams
       );
+
       req.session.ipvSessionId = response?.data?.ipvSessionId;
     } catch (error) {
-      transformError(error, "error calling initialise-ipv-session lambda");
+      logError(req, error, "error calling initialise-ipv-session lambda");
       return next(error);
     }
 

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -18,6 +18,7 @@ describe("oauth middleware", () => {
   beforeEach(() => {
     req = {
       session: {},
+      log: { info: sinon.fake(), error: sinon.fake() },
     };
 
     res = {

--- a/src/app/shared/axiosHelper.js
+++ b/src/app/shared/axiosHelper.js
@@ -4,15 +4,16 @@ module.exports = {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         "ipv-session-id": req.session.ipvSessionId,
-        "x-request-Id": req.id,
+        "x-request-id": req.id,
       },
     };
   },
-  generateJsonAxiosConfig: (sessionId) => {
+  generateJsonAxiosConfig: (req) => {
     return {
       headers: {
         "Content-Type": "application/json",
-        "ipv-session-id": sessionId,
+        "ipv-session-id": req.session.ipvSessionId,
+        "x-request-id": req.id,
       },
     };
   },

--- a/src/app/shared/axiosHelper.js
+++ b/src/app/shared/axiosHelper.js
@@ -1,9 +1,10 @@
 module.exports = {
-  generateAxiosConfig: (sessionId) => {
+  generateAxiosConfig: (req) => {
     return {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": sessionId,
+        "ipv-session-id": req.session.ipvSessionId,
+        "x-request-Id": req.requestId,
       },
     };
   },

--- a/src/app/shared/axiosHelper.js
+++ b/src/app/shared/axiosHelper.js
@@ -4,7 +4,7 @@ module.exports = {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         "ipv-session-id": req.session.ipvSessionId,
-        "x-request-Id": req.requestId,
+        "x-request-Id": req.id,
       },
     };
   },

--- a/src/app/shared/loggerConstants.js
+++ b/src/app/shared/loggerConstants.js
@@ -1,0 +1,14 @@
+const LOG_COMMUNICATION_TYPE_REQUEST = "request";
+const LOG_COMMUNICATION_TYPE_RESPONSE = "response";
+const LOG_TYPE_JOURNEY = "journey";
+const LOG_TYPE_PAGE = "page";
+const LOG_TYPE_CRI = "cri";
+const LOG_TYPE_CLIENT = "client";
+module.exports = {
+  LOG_COMMUNICATION_TYPE_REQUEST,
+  LOG_COMMUNICATION_TYPE_RESPONSE,
+  LOG_TYPE_JOURNEY,
+  LOG_TYPE_PAGE,
+  LOG_TYPE_CRI,
+  LOG_TYPE_CLIENT,
+};

--- a/src/app/shared/loggerHelper.js
+++ b/src/app/shared/loggerHelper.js
@@ -20,7 +20,7 @@ module.exports = {
         errorMessage: error.message,
       },
       level: "ERROR",
-      requestId: req.requestId,
+      requestId: req.id,
     });
   },
   logCoreBackCall: (req, { logCommunicationType, type, path, info }) => {
@@ -32,6 +32,6 @@ module.exports = {
     if (type) {
       message.type = type;
     }
-    req.log.info({ message, level: "INFO", requestId: req.requestId });
+    req.log.info({ message, level: "INFO", requestId: req.id });
   },
 };

--- a/src/app/shared/loggerHelper.js
+++ b/src/app/shared/loggerHelper.js
@@ -1,4 +1,13 @@
 module.exports = {
+  transformError: (error, messageContext) => {
+    if (error?.response?.status) {
+      error.status = error?.response?.status;
+    }
+
+    if (messageContext) {
+      error.messageContext = messageContext;
+    }
+  },
   logError: (req, error, messageContext) => {
     if (error?.response?.status) {
       error.status = error?.response?.status;

--- a/src/app/shared/loggerHelper.js
+++ b/src/app/shared/loggerHelper.js
@@ -1,11 +1,28 @@
 module.exports = {
-  transformError: (error, messageContext) => {
+  logError: (req, error, messageContext) => {
     if (error?.response?.status) {
       error.status = error?.response?.status;
     }
 
-    if (messageContext) {
-      error.messageContext = messageContext;
+    req.log.error({
+      error,
+      message: {
+        errorMessageContext: messageContext,
+        errorMessage: error.message,
+      },
+      level: "ERROR",
+      requestId: req.requestId,
+    });
+  },
+  logCoreBackCall: (req, { logCommunicationType, type, path, info }) => {
+    const message = {
+      logCommunicationType,
+      path,
+      info,
+    };
+    if (type) {
+      message.type = type;
     }
+    req.log.info({ message, level: "INFO", requestId: req.requestId });
   },
 };

--- a/src/app/shared/loggerHelper.test.js
+++ b/src/app/shared/loggerHelper.test.js
@@ -1,13 +1,12 @@
 const { expect } = require("chai");
-const { logError } = require("./loggerHelper");
+const { transformError } = require("./loggerHelper");
 
 describe("logger helper", () => {
-  beforeEach();
   describe("when error.response.status has a value", () => {
     it("should error.response.status to error.status for logging consistency", () => {
       const error = new Error("Some error");
       error.response = { status: 400 };
-      logError(error);
+      transformError(error);
       expect(error.status).to.equal(400);
     });
   });
@@ -16,7 +15,7 @@ describe("logger helper", () => {
     it("should append to error object", () => {
       const extraMessage = "some message";
       const error = new Error("Some error");
-      logError(error, extraMessage);
+      transformError(error, extraMessage);
       expect(error.messageContext).to.equal(extraMessage);
     });
   });

--- a/src/app/shared/loggerHelper.test.js
+++ b/src/app/shared/loggerHelper.test.js
@@ -1,12 +1,12 @@
 const { expect } = require("chai");
-const { transformError } = require("./loggerHelper");
+const { logError } = require("./loggerHelper");
 
 describe("logger helper", () => {
   describe("when error.response.status has a value", () => {
     it("should error.response.status to error.status for logging consistency", () => {
       const error = new Error("Some error");
       error.response = { status: 400 };
-      transformError(error);
+      logError(error);
       expect(error.status).to.equal(400);
     });
   });
@@ -15,7 +15,7 @@ describe("logger helper", () => {
     it("should append to error object", () => {
       const extraMessage = "some message";
       const error = new Error("Some error");
-      transformError(error, extraMessage);
+      logError(error, extraMessage);
       expect(error.messageContext).to.equal(extraMessage);
     });
   });

--- a/src/app/shared/loggerHelper.test.js
+++ b/src/app/shared/loggerHelper.test.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 const { logError } = require("./loggerHelper");
 
 describe("logger helper", () => {
+  beforeEach();
   describe("when error.response.status has a value", () => {
     it("should error.response.status to error.status for logging consistency", () => {
       const error = new Error("Some error");

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -13,6 +13,7 @@ module.exports = {
   API_BUILD_DEBUG_CREDENTIAL_DATA_PATH: "/debug-credential-data",
   API_REQUEST_CONFIG_PATH: "/request-config",
   API_CRI_CALLBACK: "/journey/cri/callback",
+  API_SESSION_INITIALISE: "/session/initialise",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -7,11 +7,8 @@ const logger = pino({
   serializers: {
     req: (req) => {
       return {
-        requestId: req.id,
         method: req.method,
         url: req.url,
-        ipvSessionId: req.session?.ipvSessionId,
-        sessionId: req.sessionId,
       };
     },
     res: (res) => {
@@ -55,7 +52,7 @@ const loggerMiddleware = require("pino-http")({
   },
   // Define a custom receive message
   customReceivedMessage: function (req) {
-    return "request received: " + req.method;
+    return "REQUEST RECEIVED: " + req.method;
   },
   customReceivedObject: function (req, res, val) {
     return {
@@ -66,7 +63,7 @@ const loggerMiddleware = require("pino-http")({
     };
   },
   customErrorMessage: function (error, req, res) {
-    return "request errored with status code: " + res.statusCode;
+    return "REQUEST ERRORED WITH STATUS CODE: " + res.status;
   },
   customErrorObject: (req, res, error, val) => {
     return {
@@ -78,9 +75,9 @@ const loggerMiddleware = require("pino-http")({
   },
   customSuccessMessage: function (req, res) {
     if (res.statusCode === 404) {
-      return "resource not found";
+      return "RESOURCE NOT FOUND";
     }
-    return `request completed with status code of:${res.statusCode}`;
+    return `REQUEST COMPLETED WITH STATUS CODE OF :${res.statusCode}`;
   },
   customSuccessObject: function (req, res, val) {
     return {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -29,7 +29,7 @@ const loggerMiddleware = require("pino-http")({
   // Reuse an existing logger instance
   logger,
 
-  // Define a custom request id function
+  // Define a custom request id function, this will be assigned to req.id
   genReqId: function (req, res) {
     if (req.id) return req.id;
     let id = req.get("x-request-id");
@@ -64,7 +64,7 @@ const loggerMiddleware = require("pino-http")({
       ...val,
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
-      sessionId: req.sessionId,
+      sessionId: req.session?.id,
     };
   },
   customErrorMessage: function (error, req, res) {
@@ -75,7 +75,7 @@ const loggerMiddleware = require("pino-http")({
       ...val,
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
-      sessionId: req.sessionId,
+      sessionId: req.session?.id,
     };
   },
   customSuccessMessage: function (req, res) {
@@ -89,7 +89,7 @@ const loggerMiddleware = require("pino-http")({
       ...val,
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
-      sessionId: req.sessionId,
+      sessionId: req.session?.id,
     };
   },
   customAttributeKeys: {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,66 +1,83 @@
 const pino = require("pino");
+const { randomUUID } = require("node:crypto");
+const logger = pino({
+  name: "di-ipv-core",
+  level: process.env.LOGS_LEVEL || "debug",
+  serializers: {
+    req: (req) => {
+      return {
+        id: req.id,
+        method: req.method,
+        url: req.url,
+      };
+    },
+    res: (res) => {
+      return {
+        status: res.statusCode,
+        sessionId: res.locals.sessionId,
+        clientSessionId: res.locals.clientSessionId,
+        persistentSessionId: res.locals.persistentSessionId,
+        languageFromCookie: res.locals.language?.toUpperCase(),
+      };
+    },
+  },
+});
+
 const loggerMiddleware = require("pino-http")({
   // Reuse an existing logger instance
-  logger: pino(),
+  logger,
 
-  // Define custom serializers
-  serializers: {
-    err: pino.stdSerializers.err,
-    req: pino.stdSerializers.req,
-    res: pino.stdSerializers.res,
+  // Define a custom request id function
+  genReqId: function (req, res) {
+    if (req.requestId) return req.requestId;
+    let id = req.get("x-request-id");
+    if (id) return id;
+    id = randomUUID();
+    res.header("x-request-id", id);
+    return id;
   },
 
   // Set to `false` to prevent standard serializers from being wrapped.
   wrapSerializers: true,
-
-  // Define a custom logger level
-  customLogLevel: function (req, res, err) {
-    if (res.statusCode >= 400 && res.statusCode < 500) {
-      return "warn";
-    } else if (res.statusCode >= 500 || err) {
-      return "error";
-    } else if (res.statusCode >= 300 && res.statusCode < 400) {
-      return "silent";
-    }
-    return "info";
+  quietReqLogger: true,
+  autoLogging: {
+    ignorePaths: [
+      "/public/scripts/cookies.js",
+      "/public/scripts/all.js",
+      "/public/style.css",
+      "/public/scripts",
+      "/public/scripts/application.js",
+      "/assets/images/govuk-crest-2x.png",
+      "/assets/fonts/bold-b542beb274-v2.woff2",
+      "/assets/fonts/bold-b542beb274-v2.woff2",
+      "/assets/images/favicon.ico",
+      "/assets/fonts/light-94a07e06a1-v2.woff2",
+    ],
   },
-
-  // Define a custom success message
-  customSuccessMessage: function (req, res) {
+  customErrorMessage: function (error, res) {
+    return "request errored with status code: " + res.statusCode;
+  },
+  customSuccessMessage: function (res) {
     if (res.statusCode === 404) {
       return "resource not found";
     }
-    return `${req.method} completed`;
+    return `request completed with status code of:${res.statusCode}`;
   },
-
-  // Define a custom receive message
-  customReceivedMessage: function (req) {
-    return "request received: " + req.method;
-  },
-
-  // Define a custom error message
-  customErrorMessage: function (req, res) {
-    return "request errored with status code: " + res.statusCode;
-  },
-
-  // Override attribute keys for the log object
   customAttributeKeys: {
-    req: "request",
-    res: "response",
-    err: "error",
     responseTime: "timeTaken",
-  },
-
-  // Define additional custom request properties
-  customProps: function (req, res) {
-    return {
-      customProp: req.customProp,
-      // user request-scoped data is in res.locals for express applications
-      customProp2: res.locals.myCustomData,
-    };
   },
 });
 
+function handle(req, res, next) {
+  logger.child({
+    requestId: req.requestId,
+  });
+
+  loggerMiddleware(req, res);
+  next();
+}
+
 module.exports = {
-  loggerMiddleware,
+  loggerMiddleware: handle,
+  logger,
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,66 @@
+const pino = require("pino");
+const loggerMiddleware = require("pino-http")({
+  // Reuse an existing logger instance
+  logger: pino(),
+
+  // Define custom serializers
+  serializers: {
+    err: pino.stdSerializers.err,
+    req: pino.stdSerializers.req,
+    res: pino.stdSerializers.res,
+  },
+
+  // Set to `false` to prevent standard serializers from being wrapped.
+  wrapSerializers: true,
+
+  // Define a custom logger level
+  customLogLevel: function (req, res, err) {
+    if (res.statusCode >= 400 && res.statusCode < 500) {
+      return "warn";
+    } else if (res.statusCode >= 500 || err) {
+      return "error";
+    } else if (res.statusCode >= 300 && res.statusCode < 400) {
+      return "silent";
+    }
+    return "info";
+  },
+
+  // Define a custom success message
+  customSuccessMessage: function (req, res) {
+    if (res.statusCode === 404) {
+      return "resource not found";
+    }
+    return `${req.method} completed`;
+  },
+
+  // Define a custom receive message
+  customReceivedMessage: function (req) {
+    return "request received: " + req.method;
+  },
+
+  // Define a custom error message
+  customErrorMessage: function (req, res) {
+    return "request errored with status code: " + res.statusCode;
+  },
+
+  // Override attribute keys for the log object
+  customAttributeKeys: {
+    req: "request",
+    res: "response",
+    err: "error",
+    responseTime: "timeTaken",
+  },
+
+  // Define additional custom request properties
+  customProps: function (req, res) {
+    return {
+      customProp: req.customProp,
+      // user request-scoped data is in res.locals for express applications
+      customProp2: res.locals.myCustomData,
+    };
+  },
+});
+
+module.exports = {
+  loggerMiddleware,
+};

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,9 +1,14 @@
 const pino = require("pino");
 const { randomUUID } = require("node:crypto");
 const logger = pino({
-  name: "di-ipv-core",
+  name: "di-ipv-core-front",
   level: process.env.LOGS_LEVEL || "debug",
-  messageKey: "message", // rename default msg property to message
+  messageKey: "message", // rename default msg property to message,
+  formatters: {
+    level(label) {
+      return { level: label.toUpperCase() };
+    },
+  },
   serializers: {
     req: (req) => {
       return {
@@ -89,6 +94,13 @@ const loggerMiddleware = require("pino-http")({
   },
   customAttributeKeys: {
     responseTime: "timeTaken",
+  },
+  // Define a custom logger level
+  customLogLevel: function (req, res, err) {
+    if (res.statusCode >= 400 || err) {
+      return "error";
+    }
+    return "info";
   },
 });
 


### PR DESCRIPTION
## Proposed changes

Core front log tidy up required, hmpo-logger does not allow for structured objects in the message property and this was needed for consistency with core-back logs.

Removed unnecessary hmpo internal logging that was adding noise.  

### What changed

example log that is now created, 
{
    "level": "INFO",
    "time": 1666605503149,
    "pid": 35,
    "hostname": "ip-10-120-8-188.eu-west-2.compute.internal",
    "name": "di-ipv-core-front",
    "requestId": "1d4ea12b-53eb-4506-8573-f48b753c3b1b",
    "ipvSessionId": "l1MhwEgfwinZqNsinpxDWsPM6ze4B1oKcKonCtNfGOw",
    "sessionId": "Bg-fyPJYq2PiftKhIIaPs_uCqFP7NwaX",
    "message": {
        "logCommunicationType": "request",
        "path": "journey/next",
        "type": "journey"
    }
}

- [PYIC-2047](https://govukverify.atlassian.net/browse/PYIC-2047)
- [PYIC-2048](https://govukverify.atlassian.net/browse/PYIC-2048)
