### PR TITLE
Added new alarm for External Gateway

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
         args: [ --allow-missing-credentials ]
     -   id: detect-private-key
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.61.0 # The version of cfn-lint to use
+    rev: v0.68.1 # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
         files: .template\.yaml$
 - repo: https://github.com/bridgecrewio/checkov.git
-  rev: '2.0.1211'
+  rev: '2.1.294'
   hooks:
   - id: checkov
     verbose: true

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -61,15 +61,30 @@ Mappings:
       desiredTaskCount: 2
   EnvironmentConfiguration:
     "130355686670": # Development
-      gw500ErrorLimit: 1
+      lb500ErrorLimit: 1
+      lb500ErrorWindow: 300
+      tg500ErrorLimit: 10
+      tg500ErrorWindow: 300
     "457601271792": # Build
-      gw500ErrorLimit: 1
+      lb500ErrorLimit: 1
+      lb500ErrorWindow: 300
+      tg500ErrorLimit: 10
+      tg500ErrorWindow: 300
     "335257547869": # Staging
-      gw500ErrorLimit: 1
+      lb500ErrorLimit: 1
+      lb500ErrorWindow: 300
+      tg500ErrorLimit: 10
+      tg500ErrorWindow: 300
     "991138514218": # Integration
-      gw500ErrorLimit: 1
+      lb500ErrorLimit: 1
+      lb500ErrorWindow: 300
+      tg500ErrorLimit: 10
+      tg500ErrorWindow: 300
     "075701497069": # Production
-      gw500ErrorLimit: 1
+      lb500ErrorLimit: 2
+      lb500ErrorWindow: 300
+      tg500ErrorLimit: 30
+      tg500ErrorWindow: 300
   SecurityGroups:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
@@ -604,20 +619,20 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
-  CoreApiGw5xxErrors:
+  FrontLoadBalancer5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: ExternalApiGateWay5xxAlarm
+      AlarmName: FrontLoadBalancer5xxAlarm
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue sns-topics-AlarmTopic
       OKActions:
         - !ImportValue sns-topics-AlarmTopic
       InsufficientDataActions: []
-      EvaluationPeriods: 3
-      DatapointsToAlarm: 3
-      Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, gw500ErrorLimit ]
-      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lb500ErrorLimit ]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:
         - Id: e1
@@ -628,12 +643,44 @@ Resources:
           ReturnData: false
           MetricStat:
             Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 5XXError
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_5XX_Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub IPV Core External API Gateway ${Environment}
-            Period: 300
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+            Period: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lb500ErrorWindow ]
+            Stat: Sum
+
+  FrontTargetGroup5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: FrontTargetGroup5xxAlarm
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue sns-topics-AlarmTopic
+      OKActions:
+        - !ImportValue sns-topics-AlarmTopic
+      InsufficientDataActions: [ ]
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorLimit ]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: Sum-of-5xx-Errors
+          ReturnData: true
+          Expression: SUM(METRICS())
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_Target_5XX_Count
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+            Period: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorWindow ]
             Stat: Sum
 
 Outputs:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,6 +59,17 @@ Mappings:
       desiredTaskCount: 2
     "075701497069": # Production
       desiredTaskCount: 2
+  EnvironmentConfiguration:
+    "130355686670": # Development
+      gw500ErrorLimit: 1
+    "457601271792": # Build
+      gw500ErrorLimit: 1
+    "335257547869": # Staging
+      gw500ErrorLimit: 1
+    "991138514218": # Integration
+      gw500ErrorLimit: 1
+    "075701497069": # Production
+      gw500ErrorLimit: 1
   SecurityGroups:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
@@ -592,6 +603,38 @@ Resources:
         # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
         SSEEnabled: true
         SSEType: KMS
+
+  CoreApiGw5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ExternalApiGateWay5xxAlarm
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue sns-topics-AlarmTopic
+      OKActions:
+        - !ImportValue sns-topics-AlarmTopic
+      InsufficientDataActions: []
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, gw500ErrorLimit ]
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: Sum-of-5xx-Errors
+          ReturnData: true
+          Expression: SUM(METRICS())
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub IPV Core External API Gateway ${Environment}
+            Period: 300
+            Stat: Sum
 
 Outputs:
   CoreFrontUrl:


### PR DESCRIPTION
Added cloudwatch alarms  for load balancer and target group 5xx errors

## Proposed changes
This add a new cloudwatch alarm to trigger if there are load balancer, or ttarget group 5xx errors. This is configured per environment in a mapping

https://govukverify.atlassian.net/browse/PYIC-2091
