### PR TITLE
PYIC-2076 Create new version of page-passport-doc-check to include multiple forms of ID

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -185,6 +185,7 @@ module.exports = {
         case "page-pre-kbv-transition":
         case "page-dcmaw-success":
         case "page-passport-doc-check":
+        case "page-multiple-doc-check":
         case "pyi-kbv-fail":
         case "pyi-kbv-thin-file":
         case "pyi-no-match":

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -178,8 +178,24 @@
         "formRadioButtons": {
           "continueButtonText": "Parhau i brofi pwy ydych chi yn y ffordd hyn",
           "continueButtonHint": "Byddwch angen pasbort y DU",
-          "otherWayButtonText": "Profi pwy ydych chi mewn ffordd arall",
-          "otherWayButtonHint": "Gallwch brofi pwy ydych chi ar-lein gyda GOV.UK Verify neu gymryd eich dogfennau hunaniaeth i’w gwirio’n bersonol."
+          "otherWayButtonText": "Profi pwy ydych chi mewn ffordd arall"
+        }
+      }
+    },
+    "pageMultipleDocCheck": {
+      "title": "Rhowch y manylion o’ch ID gyda llun ac ateb cwestiynau diogelwch",
+      "header": "Rhowch y manylion o’ch ID gyda llun ac ateb cwestiynau diogelwch",
+      "content": {
+        "paragraph1": "I brofi pwy ydych, bydd angen i chi:",
+        "bullet1": "rhoi’r manylion o’ch trwydded yrru y DU neu basbort y DU (efallai y byddwch yn ei chael hi’n haws i wneud hyn os oes gennych ID gyda llun rydych am ei ddefnyddio gyda chi)",
+        "bullet2": "rhoi eich cyfeiriad cartref presennol (a’ch cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)",
+        "bullet3": "ateb rhai cwestiynau mai dim ond chi ddylai wybod yr atebion iddynt",
+        "subHeading": "Pa ID gyda llun hoffech chi ei ddefnyddio?",
+        "formRadioButtons": {
+          "continuePassportButtonText": "Pasbort y DU",
+          "continueDrivingLicenceButtonText": "Trwydded yrru’r DU",
+          "separateOptionsInFormText": "neu",
+          "otherWayButtonText": "Profi pwy ydych chi mewn ffordd arall"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -178,8 +178,24 @@
         "formRadioButtons": {
           "continueButtonText": "Continue to prove your identity this way",
           "continueButtonHint": "You’ll need a UK passport",
-          "otherWayButtonText": "Prove your identity another way",
-          "otherWayButtonHint": "You can prove your identity online with GOV.UK Verify or take your identity documents to be checked in person."
+          "otherWayButtonText": "Prove your identity another way"
+        }
+      }
+    },
+    "pageMultipleDocCheck": {
+      "title": "Enter the details from your photo ID and answer security questions",
+      "header": "Enter the details from your photo ID and answer security questions",
+      "content": {
+        "paragraph1": "To prove your identity, you’ll need to:",
+        "bullet1": "enter the details from your UK driving licence or UK passport (you might find it easier to do this if you have the photo ID you want to use with you)",
+        "bullet2": "enter your current home address (and your previous address if you’ve recently moved)",
+        "bullet3": "answer some questions that only you should know the answers to",
+        "subHeading": "Which photo ID would you like to use?",
+        "formRadioButtons": {
+          "continuePassportButtonText": "UK passport",
+          "continueDrivingLicenceButtonText": "UK driving licence",
+          "separateOptionsInFormText": "or",
+          "otherWayButtonText": "Prove your identity another way"
         }
       }
     },

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -1,0 +1,58 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.pageMultipleDocCheck.title' | translate %}
+{% set googleTagManagerPageId = "pageMultipleDocCheck" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageMultipleDocCheck.header' | translate }}</h1>
+  <p class="govuk-body">{{'pages.pageMultipleDocCheck.content.paragraph1' | translate | safe }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.pageMultipleDocCheck.content.bullet1' | translate | safe }}</li>
+    <li>{{'pages.pageMultipleDocCheck.content.bullet2' | translate | safe }}</li>
+    <li>{{'pages.pageMultipleDocCheck.content.bullet3' | translate | safe }}</li>
+  </ul>
+
+  <h2 class="govuk-heading-m">{{'pages.pageMultipleDocCheck.content.subHeading' | translate }}</h2>
+
+  <form id="passportMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return passportMultipleDocCheckingFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    {{ govukRadios({
+    idPrefix: "journey",
+    name: "journey",
+    items: [
+              {
+                value: "next/passport",
+                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translate
+              },
+              {
+                value: "next/driving-licence",
+                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate
+              },
+              {
+                divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
+              },
+              {
+                value: "end",
+                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translate
+              }
+            ]
+      })
+    }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <script>
+    let disableSubmit = false;
+    function passportMultipleDocCheckingFormSubmit() {
+      if(!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+        return true
+      }
+      return false;
+    }
+  </script>
+{% endblock %}

--- a/src/views/ipv/page-passport-doc-check.njk
+++ b/src/views/ipv/page-passport-doc-check.njk
@@ -13,7 +13,7 @@
     <li>{{'pages.pagePassportDocCheck.content.bullet3' | translate | safe }}</li>
   </ul>
 
-  <p class="govuk-body">{{'pages.pagePassportDocCheck.content.subHeading' | translate }}</p>
+ <h2 class="govuk-heading-m">{{'pages.pagePassportDocCheck.content.subHeading' | translate }}</h2>
 
   <form id="passportDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return passportDocCheckingFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
@@ -28,13 +28,12 @@
               },
               {
                 value: "end",
-                text: 'pages.pagePassportDocCheck.content.formRadioButtons.otherWayButtonText' | translate,
-                hint: {text: 'pages.pagePassportDocCheck.content.formRadioButtons.otherWayButtonHint' | translate}
+                text: 'pages.pagePassportDocCheck.content.formRadioButtons.otherWayButtonText' | translate
               }
             ]
       })
     }}
-    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{'general.buttons.next' | translate }}
     </button>
   </form>


### PR DESCRIPTION
This is a new version of an existing page that adds driving licence as an option to the IDs users can nominate to complete the journey.

## Proposed changes

There are two versions of this page in core currently, one with 2 options and the other with 3. Over time, as more options are added, it may be a good idea to be able to add options dynamically. One way of doing this is via a query string in the URI, which could be implemented in `app/ipv/middleware.js` like so:

```
switch (pageId) {
 case "a-dynamic-page":
          return res.render(`ipv/${pageId}`, { pageState: req.query });
}
```
and then the `pageState` object can be passed into the nunjucks code, e.g. if the page `a-dynamic-page?options=3` is requested, the nunjucks code for `a-dynamic-page.html` could include:
```
{% block content %}

{# debug the pageState variable #}
<pre>{{ pageState | dump }}</pre>
{# would output { options: 3} #}

{# use the pageState variable as a conditional #}
{% if pageState.options == 3 %}
<p>e.g. output HTML code with three options</p>
{% endif %}

{% endblock %}
```

### What changed

The content `yaml` files have been updated and a new `html`/`nunjucks` page added.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

This gives users more options to prove their identity.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [PYIC-2076](https://govukverify.atlassian.net/browse/PYIC-2076) is covered by this PR
- [PYIC-2111](https://govukverify.atlassian.net/browse/PYIC-2111) is the JIRA ticket related to connecting this page to the backend work required to support the driving licence CRI in core.

