### PR TITLE
PYIC-2130: Update success page content

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -95,5 +95,5 @@ pageIpvSuccess:
   title: Rydych wedi profi pwy ydych chi yn llwyddiannus
   serviceNameRequired: true
   content:
-    - Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth <strong>Gwneud cais am DBS sylfaenol</strong>.
+    - Gallwch nawr barhau i ddefnyddio’r gwasanaeth rydych am ei ddefnyddio.
     - Efallai bydd rhywfaint o’r wybodaeth rydych eisoes wedi ei rhannu pan wnaethoch brofi pwy ydych chi yn cael ei defnyddio i lenwi ffurflenni o fewn y gwasanaeth yn awtomatig.

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -95,5 +95,5 @@ pageIpvSuccess:
   title: You’ve successfully proved your identity
   serviceNameRequired: true
   content:
-    - Now continue to use the <strong>Request a basic DBS check</strong> service.
+    - You can now continue to the service you want to use.
     - Some of the information you already shared when you proved your identity might be used to automatically fill in forms within the service.


### PR DESCRIPTION

## Proposed changes

### What changed

Update success page content

### Why did it change

We currently reference the ‘Request a basic DBS check’ service by name in ipv-success. This hasn’t been a huge problem as we’ve only been connected to the DBS service for the last few months. But this content will need to change before we onboard the 'Apply for a vehicle operator licence' service later on this month.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2130](https://govukverify.atlassian.net/browse/PYIC-2130)
