### PR TITLE
BAU: fix incorrect translations and add attributes to footer

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -30,7 +30,7 @@
         "paragraph2": "Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut rydych yn defnyddio’r gwasanaeth a gwneud gwelliannau.",
         "changeCookiePreferencesLink": "newid eich gosodiadau cwcis",
         "cookieBannerAccept": {
-          "paragraph1": "newid eich gosodiadau cwcis",
+          "paragraph1": "Rydych wedi derbyn cwcis ychwanegol. Gallwch ",
           "paragraph2": " unrhyw bryd."
         },
         "cookieBannerReject": {
@@ -60,7 +60,7 @@
         "linkText": "Hysbysiad preifatrwydd"
       },
       "support": {
-        "linkText": "Cymorth"
+        "linkText": "Cymorth (agor mewn tab newydd)"
       },
       "copyright": {
         "linkText": "© Hawlfraint y goron"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,7 +8,7 @@
     },
     "govuk": {
       "backLink": "Back",
-      "errorSummaryTitle": "There’s is a problem",
+      "errorSummaryTitle": "There’s a problem",
       "error": "Error",
       "warning": "Warning",
       "phaseBanner": {

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -89,7 +89,7 @@
                 },
                 {
                     href: "https://signin.account.gov.uk/contact-us",
-                    attributes: {target: "_blank"},
+                    attributes: {target: "_blank", rel:"noreferrer noopener"},
                     text: 'general.footer.support.linkText' | translate
                 }
             ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR fixes some small errors spotted after the move to the non-HMPO version of the core-front app.

### What changed

2 translations in the Welsh `translations.json` file were changed, one in the footer to add information about where the page would open, and one in the cookie banner acceptance text. One translation in the English `translations.json` file was edited to remove a grammar issue. `attributes: {rel:"noreferrer noopener"},` was added to the contact us link which opens in a new window to follow [design system best practice](https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab).

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

These changes were made to improve the user experience.

## Checklists

The global `base.njk` file was modified.


