### PR TITLE
Upped alarm thresholds for non-prod instances

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -64,22 +64,22 @@ Mappings:
       desiredTaskCount: 2
   EnvironmentConfiguration:
     "130355686670": # Development
-      lb500ErrorLimit: 1
+      lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
     "457601271792": # Build
-      lb500ErrorLimit: 1
+      lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
     "335257547869": # Staging
-      lb500ErrorLimit: 1
+      lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
     "991138514218": # Integration
-      lb500ErrorLimit: 1
+      lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300


### PR DESCRIPTION
Alarms are firing too frequently on the non-prod instances - this will reduce the alarm noise

As dicussed in standup today