### PR TITLE
BAU: restore lang attribute for translated content

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const DynamoDBStore = require("connect-dynamodb")(session);
 const { PORT, SESSION_SECRET, SESSION_TABLE_NAME } = require("./lib/config");
 
 const { getGTM } = require("./lib/locals");
+
 const { loggerMiddleware, logger } = require("./lib/logger");
 const express = require("express");
 const { configureNunjucks } = require("./config/nunjucks");
@@ -92,6 +93,15 @@ app.use(
     },
   })
 );
+
+app.use((req, res, next) => {
+  if (req.i18n) {
+    res.locals.htmlLang = req.i18n.language;
+    res.locals.pageTitleLang = req.i18n.language;
+    res.locals.mainLang = req.i18n.language;
+    next();
+  }
+});
 
 app.use((req, res, next) => {
   req.log = logger.child({

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -25,12 +25,12 @@
 {% endblock %}
 
 {% block pageTitle-%}
-    {% if error or errors %}
+    {%- if error or errors %}
       {{ 'general.govuk.errorTitlePrefix' | translate }}
       -
-    {% endif %}
-    {% if pageTitleName %}{{ pageTitleName }}{% endif %}
-{% endblock %}
+    {%- endif %}
+    {%- if pageTitleName %}{{ pageTitleName }}{% endif %}
+{%- endblock %}
 
 {% block bodyStart %}
     {% include 'shared/banner.njk' %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR restores the attributes added to the `<html>`, `<title>` and `<main>` tags in the HTML source code of every page when the content is presented in a language other than English.

### What changed

<!-- Describe the changes in detail - the "what"-->

The `setHtmlLangMiddleware` functionality [from the DI Auth front-end repo](https://github.com/alphagov/di-authentication-frontend/blob/main/src/middleware/html-lang-middleware.ts) is duplicated and extended to populate 3 nunjucks variables that control the output of `lang` attributes in `govuk-frontend/govuk/template.njk`. 

`base.njk` has a small nunjucks change to the <title> tag to remove excess white space from the source code.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This is an accessibility (and google analytics tracking) requirement.

