### PR TITLE
PYIC-2190: Create page for returning users who have a complete identity

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -24,6 +24,7 @@ const {
   LOG_TYPE_PAGE,
 } = require("../shared/loggerConstants");
 const { generateHTMLofAddress } = require("../shared/addressHelper");
+const { samplePersistedUserDetails } = require("../shared/debugJourneyHelper");
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -202,10 +203,16 @@ module.exports = {
             csrfToken: req.csrfToken(),
           });
         case "page-persist-identity": {
-          const userDetailsResponse = await getAxios(req).get(
-            `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
-            generateAxiosConfig(req)
-          );
+          let userDetailsResponse = {};
+
+          if (req.session.isDebugJourney) {
+            userDetailsResponse = samplePersistedUserDetails;
+          } else {
+            userDetailsResponse = await getAxios(req).get(
+              `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
+              generateAxiosConfig(req)
+            );
+          }
 
           const userDetails = {
             name: userDetailsResponse.data?.name,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -154,6 +154,7 @@ module.exports = {
         "/journey/cri/validate/stubDcmaw",
         "/journey/end-mitigation-journey/MJ01",
         "/journey/end-mitigation-journey/MJ02",
+        "/journey/build-proven-user-identity-details",
       ];
 
       const action = allowedActions.find((x) => x === req.url);

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -165,19 +165,30 @@ module.exports = {
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;
-      if (!req.session.isDebugJourney && req.session.currentPage !== pageId) {
-        logError(
-          req,
-          {
-            pageId: pageId,
-            expectedPage: req.session.currentPage,
-          },
-          "page :pageId doesn't match expected session page :expectedPage"
-        );
+      // if (!req.session.isDebugJourney && req.session.currentPage !== pageId) {
+      //   logError(
+      //     req,
+      //     {
+      //       pageId: pageId,
+      //       expectedPage: req.session.currentPage,
+      //     },
+      //     "page :pageId doesn't match expected session page :expectedPage"
+      //   );
+      //
+      //   req.session.currentPage = "pyi-technical-unrecoverable";
+      //   return res.redirect(req.session.currentPage);
+      // }
 
-        req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.redirect(req.session.currentPage);
-      }
+      // Full name guidance? Do we show middle name(s)?
+      // Date of birth formatting guidance https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+      // Address formatting guidance https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#addresses-in-the-uk
+
+      const userDetails =
+        {
+          'name': 'Hubert Blaine Wolfeschlegelsteinhausenbergerdorff',
+          'dateOfBirth': '4 December 1975',
+          'addressDetails': 'The Old Vicarage<br>251 St Martin-in-the-Fields Church Path<br>Sutton-Under-Whitestonecliffe<br>SK11 8JA'
+        };
 
       switch (pageId) {
         case "page-ipv-debug":
@@ -188,6 +199,12 @@ module.exports = {
         case "page-dcmaw-success":
         case "page-passport-doc-check":
         case "page-multiple-doc-check":
+        case "page-persist-identity":
+          return res.render(`ipv/${sanitize(pageId)}.njk`, {
+            userDetails,
+            pageId,
+            csrfToken: req.csrfToken(),
+          });
         case "pyi-kbv-fail":
         case "pyi-kbv-thin-file":
         case "pyi-no-match":

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -42,7 +42,8 @@ describe("journey middleware", () => {
       log: { info: sinon.fake(), error: sinon.fake() },
     };
     next = sinon.fake();
-    axiosStub.post.reset();
+    axiosStub.post = sinon.stub();
+    axiosStub.get = sinon.stub();
   });
 
   context("from a sequence of events that ends with a page response", () => {
@@ -446,6 +447,22 @@ describe("journey middleware", () => {
         `ipv/${pageId}.njk`,
         sinon.match.has("userDetails", expectedUserDetail)
       );
+    });
+
+    it("should not call build-proven-user-identity-details endpoint when debug mode", async function () {
+      req = {
+        id: "1",
+        params: { pageId: pageId },
+        csrfToken: sinon.fake(),
+        session: { currentPage: pageId, isDebugJourney: true },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+
+      await middleware.handleJourneyPage(req, res);
+
+      expect(axiosStub.get).to.not.have.been.called;
+
+      expect(res.render).to.have.been.calledWith(`ipv/${pageId}.njk`);
     });
   });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -424,7 +424,7 @@ describe("journey middleware", () => {
         name: "firstName LastName",
         dateOfBirth: "01 11 1973",
         addressDetails:
-          "My deparment My company Room 5 my building<br>1 My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+          "My deparment My company Room 5 my building<br>1 My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode",
       };
 
       axiosStub.get = sinon.fake.returns(axiosResponse);

--- a/src/app/shared/addressHelper.js
+++ b/src/app/shared/addressHelper.js
@@ -1,0 +1,64 @@
+// functions duplicated from address cri
+module.exports = {
+  generateHTMLofAddress: function (address) {
+    const { buildingNames, streetNames, localityNames } =
+      extractAddressFields(address);
+
+    const fullBuildingName = buildingNames.join(" ");
+    let fullStreetName;
+    if (streetNames) {
+      fullStreetName = streetNames.join(" ");
+    }
+
+    const fullLocality = localityNames.join(" ");
+
+    if (fullStreetName) {
+      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+    } else {
+      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+    }
+  },
+};
+
+function extractAddressFields(address) {
+  let buildingNames = [];
+  let streetNames = [];
+  let localityNames = [];
+
+  // handle building name
+  if (address.departmentName) {
+    buildingNames.push(address.departmentName);
+  }
+  if (address.organisationName) {
+    buildingNames.push(address.organisationName);
+  }
+  if (address.subBuildingName) {
+    buildingNames.push(address.subBuildingName);
+  }
+  if (address.buildingName) {
+    buildingNames.push(address.buildingName);
+  }
+
+  // street names
+  if (address.buildingNumber) {
+    streetNames.push(address.buildingNumber);
+  }
+  if (address.dependentStreetName) {
+    streetNames.push(address.dependentStreetName);
+  }
+  if (address.streetName) {
+    streetNames.push(address.streetName);
+  }
+
+  // locality names
+  if (address.doubleDependentAddressLocality) {
+    localityNames.push(address.doubleDependentAddressLocality);
+  }
+  if (address.dependentAddressLocality) {
+    localityNames.push(address.dependentAddressLocality);
+  }
+  if (address.addressLocality) {
+    localityNames.push(address.addressLocality);
+  }
+  return { buildingNames, streetNames, localityNames };
+}

--- a/src/app/shared/addressHelper.js
+++ b/src/app/shared/addressHelper.js
@@ -13,9 +13,9 @@ module.exports = {
     const fullLocality = localityNames.join(" ");
 
     if (fullStreetName) {
-      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}`;
     } else {
-      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}`;
     }
   },
 };

--- a/src/app/shared/addressHelper.test.js
+++ b/src/app/shared/addressHelper.test.js
@@ -1,0 +1,62 @@
+const { expect } = require("chai");
+const { generateHTMLofAddress } = require("./addressHelper");
+
+describe("Address Helper", () => {
+  context("generateHTMLofAddress", () => {
+    it("should generate HTML with street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            streetName: "my inner street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+        },
+      ];
+
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateHTMLofAddress(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
+      });
+    });
+
+    it("should generate HTML without street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            streetName: "my inner street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+        },
+      ];
+
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateHTMLofAddress(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
+      });
+    });
+  });
+});

--- a/src/app/shared/addressHelper.test.js
+++ b/src/app/shared/addressHelper.test.js
@@ -8,7 +8,7 @@ describe("Address Helper", () => {
         {
           address: {
             organisationName: "My company",
-            departmentName: "My deparment",
+            departmentName: "My department",
             buildingName: "my building",
             subBuildingName: "Room 5",
             buildingNumber: "1",
@@ -19,7 +19,7 @@ describe("Address Helper", () => {
             addressLocality: "my town",
             postalCode: "myCode",
           },
-          text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+          text: "My company My department my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
         },
       ];
 

--- a/src/app/shared/debugJourneyHelper.js
+++ b/src/app/shared/debugJourneyHelper.js
@@ -1,0 +1,14 @@
+module.exports = {
+  samplePersistedUserDetails: {
+    data: {
+      name: "FirstName LastName",
+      dateOfBirth: "01 11 1973",
+      addressDetails: {
+        buildingNumber: "10",
+        streetName: "Downing Street",
+        addressLocality: "London",
+        postalCode: "SW1A 2AA ",
+      },
+    },
+  },
+};

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,6 +14,8 @@ module.exports = {
   API_REQUEST_CONFIG_PATH: "/request-config",
   API_CRI_CALLBACK: "/journey/cri/callback",
   API_SESSION_INITIALISE: "/session/initialise",
+  API_BUILD_PROVEN_USER_IDENTITY_DETAILS:
+    "/journey/build-proven-user-identity-details",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -199,6 +199,23 @@
         }
       }
     },
+    "pagePersistIdentity": {
+      "title": "Rydych wedi mewngofnodi i’ch cyfrif GOV.UK",
+      "header": "Rydych wedi mewngofnodi i’ch cyfrif GOV.UK",
+      "content": {
+        "paragraph1": "Rydych wedi brofi pwy ydych chi pan wnaethoch ddefnyddio eich cyfrif GOV.UK o'r blaen. Nid oes angen i chi wneud hyn eto i ddefnyddio'r gwasanaeth hwn.",
+        "paragraph2": "Os nad ydych wedi mewngofnodi i'ch cyfrif GOV.UK ers amser, efallai y byddwch am wirio bod eich manylion dal yn gywir.",
+        "userDetailsInformation": {
+          "fullName": "Enw",
+          "dateOfBirth": "Dyddiad geni",
+          "homeAddress": "Cyfeiriad cartref presennol"
+        },
+        "updateUserDetailsInformation": {
+          "updateDetailsLabel": "Sut i ddiweddaru eich manylion",
+          "updateDetailsHtml": "Gallwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">gysylltu â'r tîm cefnogi cyfrif (agor mewn tab newydd)</a> i ddiweddaru eich manylion."
+        }
+      }
+    },
     "pageIpvSuccess": {
       "title": "Rydych wedi profi pwy ydych chi yn llwyddiannus",
       "header": "Rydych wedi profi pwy ydych chi yn llwyddiannus",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -203,9 +203,9 @@
       "title": "Rydych wedi profi pwy ydych chi yn barod",
       "header": "Rydych wedi profi pwy ydych chi yn barod",
       "content": {
-        "paragraph1": "Rydych wedi brofi pwy ydych chi pan wnaethoch ddefnyddio eich cyfrif GOV.UK o'r blaen. Nid oes angen i chi wneud hyn eto i ddefnyddio'r gwasanaeth hwn.",
+        "paragraph1": "Rydych wedi brofi pwy ydych chi pan wnaethoch ddefnyddio eich cyfrif GOV.UK o’r blaen. Nid oes angen i chi wneud hyn eto i ddefnyddio’r gwasanaeth hwn.",
         "subHeading": "Gwirio eich manylion",
-        "paragraph2": "Os nad ydych wedi mewngofnodi i'ch cyfrif GOV.UK ers amser, efallai y byddwch am wirio bod eich manylion dal yn gywir.",
+        "paragraph2": "Os nad ydych wedi mewngofnodi i’ch cyfrif GOV.UK ers amser, efallai y byddwch am wirio bod eich manylion dal yn gywir.",
         "userDetailsInformation": {
           "fullName": "Enw",
           "dateOfBirth": "Dyddiad geni",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -200,10 +200,11 @@
       }
     },
     "pagePersistIdentity": {
-      "title": "Rydych wedi mewngofnodi i’ch cyfrif GOV.UK",
-      "header": "Rydych wedi mewngofnodi i’ch cyfrif GOV.UK",
+      "title": "Rydych wedi profi pwy ydych chi yn barod",
+      "header": "Rydych wedi profi pwy ydych chi yn barod",
       "content": {
         "paragraph1": "Rydych wedi brofi pwy ydych chi pan wnaethoch ddefnyddio eich cyfrif GOV.UK o'r blaen. Nid oes angen i chi wneud hyn eto i ddefnyddio'r gwasanaeth hwn.",
+        "subHeading": "Gwirio eich manylion",
         "paragraph2": "Os nad ydych wedi mewngofnodi i'ch cyfrif GOV.UK ers amser, efallai y byddwch am wirio bod eich manylion dal yn gywir.",
         "userDetailsInformation": {
           "fullName": "Enw",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -200,15 +200,16 @@
       }
     },
     "pagePersistIdentity": {
-      "title": "You’ve signed in to your GOV.UK account",
-      "header": "You’ve signed in to your GOV.UK account",
+      "title": "You have already proved your identity",
+      "header": "You have already proved your identity",
       "content": {
         "paragraph1": "You proved your identity when you used your GOV.UK account before. You will\nnot need to do it again to use this service.",
+        "subHeading": "Check your details",
         "paragraph2": "If you have not signed in to your GOV.UK account in a while, you might want to\ncheck your details are still correct.",
         "userDetailsInformation": {
           "fullName": "Name",
           "dateOfBirth": "Date of birth",
-          "homeAddress": "Current Home Address"
+          "homeAddress": "Current home address"
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "How to update your details",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -199,6 +199,23 @@
         }
       }
     },
+    "pagePersistIdentity": {
+      "title": "You’ve signed in to your GOV.UK account",
+      "header": "You’ve signed in to your GOV.UK account",
+      "content": {
+        "paragraph1": "You proved your identity when you used your GOV.UK account before. You will\nnot need to do it again to use this service.",
+        "paragraph2": "If you have not signed in to your GOV.UK account in a while, you might want to\ncheck your details are still correct.",
+        "userDetailsInformation": {
+          "fullName": "Name",
+          "dateOfBirth": "Date of birth",
+          "homeAddress": "Current Home Address"
+        },
+        "updateUserDetailsInformation": {
+          "updateDetailsLabel": "How to update your details",
+          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">contact the GOV.UK account support team (opens in a new tab)</a> to update your details."
+        }
+      }
+    },
     "pageIpvSuccess": {
       "title": "You’ve successfully proved your identity",
       "header": "You’ve successfully proved your identity",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,9 +203,9 @@
       "title": "You have already proved your identity",
       "header": "You have already proved your identity",
       "content": {
-        "paragraph1": "You proved your identity when you used your GOV.UK account before. You will\nnot need to do it again to use this service.",
+        "paragraph1": "You proved your identity when you used your GOV.UK account before. You will not need to do it again to use this service.",
         "subHeading": "Check your details",
-        "paragraph2": "If you have not signed in to your GOV.UK account in a while, you might want to\ncheck your details are still correct.",
+        "paragraph2": "If you have not signed in to your GOV.UK account in a while, you might want to check your details are still correct.",
         "userDetailsInformation": {
           "fullName": "Name",
           "dateOfBirth": "Date of birth",

--- a/src/views/debug/page-ipv-debug.njk
+++ b/src/views/debug/page-ipv-debug.njk
@@ -20,7 +20,7 @@
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            <a id="cri-link-{{ cri.id }}" class="govuk-heading-s govuk-link"" href="/ipv/journey/cri/build-oauth-request/{{ cri.id }}">{{cri.name}}</a>
+            <a id="cri-link-{{ cri.id }}" class="govuk-heading-s govuk-link" href="/ipv/journey/cri/build-oauth-request/{{ cri.id }}">{{cri.name}}</a>
           </dt>
           {% if issuedCredentials[cri.id] %}
             {% set issuedCredential = issuedCredentials[cri.id] %}
@@ -104,6 +104,12 @@
                 <th scope="row" class="govuk-table__header">page-ipv-success</th>
                 <td class="govuk-table__cell">
                   <a class="govuk-link" href="/ipv/page/page-ipv-success?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-ipv-success?lang=cy">Welsh</a>
+                </td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">page-persist-identity</th>
+                <td class="govuk-table__cell">
+                  <a class="govuk-link" href="/ipv/page/page-persist-identity?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-persist-identity?lang=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">

--- a/src/views/debug/page-ipv-debug.njk
+++ b/src/views/debug/page-ipv-debug.njk
@@ -79,67 +79,67 @@
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-ipv-identity-start</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-ipv-identity-start?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-ipv-identity-start?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-ipv-identity-start?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-ipv-identity-start?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-pre-kbv-transition</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-pre-kbv-transition?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-pre-kbv-transition?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-pre-kbv-transition?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-pre-kbv-transition?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-dcmaw-success</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-dcmaw-success?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-dcmaw-success?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-dcmaw-success?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-dcmaw-success?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-passport-doc-check</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-passport-doc-check?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-passport-doc-check?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-passport-doc-check?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-passport-doc-check?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-ipv-success</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-ipv-success?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-ipv-success?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-ipv-success?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-ipv-success?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">page-persist-identity</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/page-persist-identity?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/page-persist-identity?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/page-persist-identity?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/page-persist-identity?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">pyi-kbv-fail</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/pyi-kbv-fail?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-kbv-fail?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/pyi-kbv-fail?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-kbv-fail?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">pyi-kbv-thin-file</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/pyi-kbv-thin-file?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-kbv-thin-file?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/pyi-kbv-thin-file?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-kbv-thin-file?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">pyi-no-match</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/pyi-no-match?lang=en">English</a> / <a class="govuk-link" href="/ipv/page//pyi-no-match?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/pyi-no-match?lng=en">English</a> / <a class="govuk-link" href="/ipv/page//pyi-no-match?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">pyi-technical</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/pyi-technical?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-technical?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/pyi-technical?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-technical?lng=cy">Welsh</a>
                 </td>
               </tr>
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">pyi-technical-unrecoverable</th>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/ipv/page/pyi-technical-unrecoverable?lang=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-technical-unrecoverable?lang=cy">Welsh</a>
+                  <a class="govuk-link" href="/ipv/page/pyi-technical-unrecoverable?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/pyi-technical-unrecoverable?lng=cy">Welsh</a>
                 </td>
               </tr>
             </tbody>

--- a/src/views/ipv/page-persist-identity.njk
+++ b/src/views/ipv/page-persist-identity.njk
@@ -12,8 +12,6 @@
     <h2 class="govuk-heading-m">{{ 'pages.pagePersistIdentity.content.subHeading' | translate }}</h2>
     <p class="govuk-body">{{ 'pages.pagePersistIdentity.content.paragraph2' | translate }}</p>
 
-    {#  This is the https://design-system.service.gov.uk/components/summary-list/ component #}
-
     {{ govukSummaryList({
         rows: [
             {

--- a/src/views/ipv/page-persist-identity.njk
+++ b/src/views/ipv/page-persist-identity.njk
@@ -1,0 +1,51 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set pageTitleName = 'pages.pagePersistIdentity.title' | translate %}
+{% set googleTagManagerPageId = "pagePersistIdentity" %}
+
+{% block content %}
+    <h1 class="govuk-heading-l" id="header"
+        data-page="{{ googleTagManagerPageId }}">{{ 'pages.pagePersistIdentity.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'pages.pagePersistIdentity.content.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.pagePersistIdentity.content.paragraph2' | translate }}</p>
+
+    {#  This is the https://design-system.service.gov.uk/components/summary-list/ component #}
+
+    {{ govukSummaryList({
+        rows: [
+            {
+                key: {
+                text: 'pages.pagePersistIdentity.content.userDetailsInformation.fullName' | translate
+            },
+                value: {
+                text: userDetails.name
+            }
+            },
+            {
+                key: {
+                text: 'pages.pagePersistIdentity.content.userDetailsInformation.dateOfBirth' | translate
+            },
+                value: {
+                text: userDetails.dateOfBirth
+            }
+            },
+            {
+                key: {
+                text: 'pages.pagePersistIdentity.content.userDetailsInformation.homeAddress' | translate
+            },
+                value: {
+                html: userDetails.addressDetails
+            }
+            }
+        ]
+    }) }}
+
+    {{ govukDetails({
+        summaryText: 'pages.pagePersistIdentity.content.updateUserDetailsInformation.updateDetailsLabel' | translate,
+        text: 'pages.pagePersistIdentity.content.updateUserDetailsInformation.updateDetailsHtml' | translate | safe
+    }) }}
+
+    {% include 'shared/journey-next-form.njk' %}
+{% endblock %}

--- a/src/views/ipv/page-persist-identity.njk
+++ b/src/views/ipv/page-persist-identity.njk
@@ -9,6 +9,7 @@
     <h1 class="govuk-heading-l" id="header"
         data-page="{{ googleTagManagerPageId }}">{{ 'pages.pagePersistIdentity.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.pagePersistIdentity.content.paragraph1' | translate }}</p>
+    <h2 class="govuk-heading-m">{{ 'pages.pagePersistIdentity.content.subHeading' | translate }}</h2>
     <p class="govuk-body">{{ 'pages.pagePersistIdentity.content.paragraph2' | translate }}</p>
 
     {#  This is the https://design-system.service.gov.uk/components/summary-list/ component #}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This code creates the behaviour designed in PYIC-2190. This front-end ticket is related to back-end work to create an API that retrieves the correct user details.

Currently this page will only show one address to the user.

The information in `const UserDetails` is based on the style guide’s formatting for content - the `<br>` tags match the implementation in the GDS Design System guide for [the summary list component](https://design-system.service.gov.uk/components/summary-list/).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2190](https://govukverify.atlassian.net/browse/PYIC-2190)

