### PR TITLE
Set the RAM and CPU size of the fargate containers per environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -68,22 +68,22 @@ Mappings:
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
-      fargateCPUsize: 512
-      fargateRAMsize: 1024
+      fargateCPUsize: 256
+      fargateRAMsize: 512
     "457601271792": # Build
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
-      fargateCPUsize: 512
-      fargateRAMsize: 1024
+      fargateCPUsize: 256
+      fargateRAMsize: 512
     "335257547869": # Staging
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
-      fargateCPUsize: 512
-      fargateRAMsize: 1024
+      fargateCPUsize: 256
+      fargateRAMsize: 512
     "991138514218": # Integration
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -68,26 +68,36 @@ Mappings:
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
+      fargateCPUsize: 512
+      fargateRAMsize: 1024
     "457601271792": # Build
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
+      fargateCPUsize: 512
+      fargateRAMsize: 1024
     "335257547869": # Staging
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
+      fargateCPUsize: 512
+      fargateRAMsize: 1024
     "991138514218": # Integration
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
       tg500ErrorWindow: 300
+      fargateCPUsize: 512
+      fargateRAMsize: 1024
     "075701497069": # Production
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 30
       tg500ErrorWindow: 300
+      fargateCPUsize: 1024
+      fargateRAMsize: 2048
   SecurityGroups:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
@@ -418,9 +428,9 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub core-front-${Environment}
-      Cpu: "512"
+      Cpu: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateCPUsize ]
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: "1024"
+      Memory: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateRAMsize ]
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
The RAM and CPU is too low on Prod meaning we scale too often - this sets Prod to have 1VCPU and  2GB

## Proposed changes
This sets the RAM and  CPU per environment and sets Prod to have more and others to have less.

### Why did it change
We are seeing a scaling pattern which suggests that the prod environment is under resourced
