### PR TITLE
Set evaluation periods and datapoints for alarms to 2

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -686,8 +686,8 @@ Resources:
       OKActions:
         - !ImportValue sns-topics-AlarmTopic
       InsufficientDataActions: []
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
       Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lb500ErrorLimit ]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -719,8 +719,8 @@ Resources:
       OKActions:
         - !ImportValue sns-topics-AlarmTopic
       InsufficientDataActions: [ ]
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
       Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorLimit ]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
This should prevent false positives from one session creating many 500 errors.
