### PR TITLE
PYIC-2308: Handle new error type responses

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,9 @@ const Backend = require("i18next-fs-backend");
 const i18nextMiddleware = require("i18next-http-middleware");
 const { i18nextConfigurationOptions } = require("./config/i18next");
 const {
+  journeyEventErrorHandler,
+} = require("./handlers/journey-event-error-handler");
+const {
   serverErrorHandler,
 } = require("./handlers/internal-server-error-handler");
 const { pageNotFoundHandler } = require("./handlers/page-not-found-handler");
@@ -137,6 +140,7 @@ router.get("/healthcheck", (req, res) => {
 
 app.use(router);
 
+app.use(journeyEventErrorHandler);
 app.use(serverErrorHandler);
 app.use(pageNotFoundHandler);
 

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -1,0 +1,109 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+const {
+  pageNotFoundHandler,
+} = require("../../src/handlers/page-not-found-handler");
+const {
+  serverErrorHandler,
+} = require("../../src/handlers/internal-server-error-handler");
+const {
+  journeyEventErrorHandler,
+} = require("../../src/handlers/journey-event-error-handler");
+
+describe("Error handlers", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      session: {},
+      log: { info: sinon.fake(), error: sinon.fake() },
+    };
+
+    res = {
+      status: sinon.fake(),
+      redirect: sinon.fake(),
+      send: sinon.fake(),
+      render: sinon.fake(),
+    };
+
+    next = sinon.fake();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("pageNotFoundHandler", () => {
+    it("should render page-not-found view", () => {
+      pageNotFoundHandler(req, res, next);
+
+      expect(res.status).to.have.been.calledOnceWith(404);
+      expect(res.render).to.have.been.calledOnceWith(
+        "errors/page-not-found.njk"
+      );
+    });
+  });
+
+  describe("serverErrorHandler", () => {
+    it("should render pyi-unrecoverable view when csrf token is invalid", () => {
+      const err = new Error("invalid csrf token");
+      err["code"] = "EBADCSRFTOKEN";
+
+      serverErrorHandler(err, req, res, next);
+
+      expect(res.status).to.have.been.calledOnceWith(500);
+      expect(res.render).to.have.been.calledOnceWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
+    });
+
+    it("should render pyi-unrecoverable view when unexpected error", () => {
+      const err = new Error("internal server error");
+
+      serverErrorHandler(err, req, res, next);
+
+      expect(res.status).to.have.been.calledOnceWith(500);
+      expect(res.render).to.have.been.calledOnceWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
+    });
+
+    it("should render session-ended view when no session", () => {
+      const err = new Error("timeout");
+      res.statusCode = 401;
+
+      serverErrorHandler(err, req, res, next);
+
+      expect(res.render).to.have.been.calledOnceWith(
+        "errors/session-ended.njk"
+      );
+    });
+  });
+
+  describe("journeyEventErrorHandler", () => {
+    it("should render page with provided pageId", () => {
+      let axiosResponse;
+      let axiosStub = {};
+      let axiosHelperStub = {};
+      axiosHelperStub.getAxios = () => axiosStub;
+      axiosResponse = {
+        status: {},
+      };
+      axiosResponse.data = {
+        page: "pyi-technical",
+        statusCode: 400,
+      };
+
+      const err = new Error();
+      err.response = axiosResponse;
+      axiosStub.post = sinon.fake.throws(err);
+
+      journeyEventErrorHandler(err, req, res, next);
+
+      expect(res.status).to.have.been.calledOnceWith(400);
+      expect(res.render).to.have.been.calledOnceWith("ipv/pyi-technical.njk");
+    });
+  });
+});

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -13,7 +13,9 @@ module.exports = {
     res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
 
     try {
-      res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+      res.err?.status
+        ? res.status(res.err.status)
+        : res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
     } catch (e) {
       logError(req, e, "Bad response - status is not a function");
     }

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,3 +1,5 @@
+const sanitize = require("sanitize-filename");
+
 module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
     if (res.headersSent) {
@@ -8,7 +10,7 @@ module.exports = {
 
     if (res.err?.response?.data?.page) {
       res.status(res.err.response.data.statusCode);
-      return res.render(`ipv/${res.err.response.data.page}.njk`);
+      return res.render(`ipv/${sanitize(res.err.response.data.page)}.njk`);
     }
 
     next(err);

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,0 +1,16 @@
+module.exports = {
+  journeyEventErrorHandler(err, req, res, next) {
+    if (res.headersSent) {
+      return next(err);
+    }
+
+    res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
+
+    if (res.err?.response?.data?.page) {
+      res.status(res.err.response.data.statusCode);
+      return res.render(`ipv/${res.err.response.data.page}.njk`);
+    }
+
+    next(err);
+  },
+};


### PR DESCRIPTION
## Proposed changes

### What changed

Added an additional error handler to handle new error responses 

It checks to see if the error has come with a page, which it then sets the provided statusCode and renders the provided page 

Tests have been added for the all the handlers which was previously missing

### Why did it change

To reduce the proportion of journeys ending in an error and better handle unexpected journeys. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2308](https://govukverify.atlassian.net/browse/PYIC-2308)


[PYIC-2308]: https://govukverify.atlassian.net/browse/PYIC-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ