### PR TITLE
PYIC-2310: temporary recovery page

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -40,6 +40,7 @@ module.exports = {
 
       return handleBackendResponse(req, res, apiResponse?.data);
     } catch (error) {
+      error.csrfToken = req.csrfToken();
       transformError(error, "error calling validate-callback lambda");
       next(error);
     }

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -32,6 +32,7 @@ describe("credential issuer middleware", () => {
       req = {
         id: "1",
         params: {},
+        csrfToken: sinon.fake(),
         session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
         query: {
           id: "PassportIssuer",

--- a/src/app/credential-issuer/router.js
+++ b/src/app/credential-issuer/router.js
@@ -1,11 +1,12 @@
 const express = require("express");
+const csrf = require("csurf");
 
 const router = express.Router();
 
 const { sendParamsToAPI, sendParamsToAPIV2 } = require("./middleware");
+const csrfProtection = csrf({});
 
-router.get("/callback", sendParamsToAPI);
-
-router.get("/callback/:criId", sendParamsToAPIV2);
+router.get("/callback", csrfProtection, sendParamsToAPI);
+router.get("/callback/:criId", csrfProtection, sendParamsToAPIV2);
 
 module.exports = router;

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -118,7 +118,9 @@ function tryValidateClientResponse(client) {
 
 module.exports = {
   renderAttemptRecoveryPage: async (req, res) => {
-    res.render("ipv/ipv-attempt-recovery.njk");
+    res.render("ipv/pyi-attempt-recovery.njk", {
+      csrfToken: req.csrfToken(),
+    });
   },
   updateJourneyState: async (req, res, next) => {
     //routine to be removed once debug journey rewrite is complete

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -128,6 +128,7 @@ module.exports = {
         "/journey/next",
         "/journey/error",
         "/journey/fail",
+        "/journey/attempt-recovery",
         "/journey/cri/build-oauth-request/ukPassport",
         "/journey/cri/build-oauth-request/stubUkPassport",
         "/journey/cri/build-oauth-request/fraud",
@@ -194,6 +195,7 @@ module.exports = {
         case "page-dcmaw-success":
         case "page-passport-doc-check":
         case "page-multiple-doc-check":
+        case "pyi-recovery":
         case "pyi-kbv-fail":
         case "pyi-kbv-thin-file":
         case "pyi-no-match":
@@ -255,6 +257,8 @@ module.exports = {
     try {
       if (req.body?.journey === "end") {
         await handleJourneyResponse(req, res, "journey/end");
+      } else if (req.body?.journey === "attempt-recovery") {
+        await handleJourneyResponse(req, res, "journey/attempt-recovery");
       } else {
         await handleJourneyResponse(req, res, "journey/next");
       }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -117,6 +117,9 @@ function tryValidateClientResponse(client) {
 }
 
 module.exports = {
+  renderAttemptRecoveryPage: async (req, res) => {
+    res.render("ipv/ipv-attempt-recovery.njk");
+  },
   updateJourneyState: async (req, res, next) => {
     //routine to be removed once debug journey rewrite is complete
     try {
@@ -195,7 +198,7 @@ module.exports = {
         case "page-dcmaw-success":
         case "page-passport-doc-check":
         case "page-multiple-doc-check":
-        case "pyi-recovery":
+        case "pyi-attempt-recovery":
         case "pyi-kbv-fail":
         case "pyi-kbv-thin-file":
         case "pyi-no-match":

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -388,6 +388,20 @@ describe("journey middleware", () => {
         );
       });
 
+      it("should post with journey/end", async function () {
+        req = {
+          id: "1",
+          body: { journey: "attempt-recovery" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/attempt-recovery`
+        );
+      });
+
       it("should post with journey/next by default", async function () {
         await middleware.handleJourneyAction(req, res, next);
         expect(axiosStub.post.firstCall).to.have.been.calledWith(

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -388,7 +388,7 @@ describe("journey middleware", () => {
         );
       });
 
-      it("should post with journey/end", async function () {
+      it("should post with journey/attempt-recovery", async function () {
         req = {
           id: "1",
           body: { journey: "attempt-recovery" },

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -4,6 +4,7 @@ const bodyParser = require("body-parser");
 const router = express.Router();
 
 const {
+  renderAttemptRecoveryPage,
   updateJourneyState,
   handleJourneyPage,
   handleJourneyAction,
@@ -12,6 +13,7 @@ const {
 const csrfProtection = csrf({});
 const parseForm = bodyParser.urlencoded({ extended: false });
 
+router.get("/page/attempt-recovery", csrfProtection, renderAttemptRecoveryPage);
 router.get("/page/:pageId", csrfProtection, handleJourneyPage);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -10,7 +10,9 @@ module.exports = {
 
     if (res.err?.response?.data?.page) {
       res.status(res.err.response.data.statusCode);
-      return res.render(`ipv/${sanitize(res.err.response.data.page)}.njk`);
+      return res.render(`ipv/${sanitize(res.err.response.data.page)}.njk`, {
+        csrfToken: err.csrfToken,
+      });
     }
 
     next(err);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -90,6 +90,13 @@
     }
   },
   "pages": {
+    "pyiAttemptRecovery": {
+      "title": "Attempt Recovery Page - Sorry, there is a problem",
+      "header": "Attempt Recovery Page - Sorry, there is a problem",
+      "content": {
+        "paragraph1": "We cannot prove your identity right now."
+      }
+    },
     "pyiNoMatch": {
       "title": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd",
       "header": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi ar hyn o bryd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -90,6 +90,13 @@
     }
   },
   "pages": {
+    "pyiAttemptRecovery": {
+      "title": "Attempt Recovery Page - Sorry, there is a problem",
+      "header": "Attempt Recovery Page - Sorry, there is a problem",
+      "content": {
+        "paragraph1": "We cannot prove your identity right now."
+      }
+    },
     "pyiNoMatch": {
       "title": "Sorry, we cannot prove your identity right now",
       "header": "Sorry, we cannot prove your identity right now",

--- a/src/views/ipv/pyi-attempt-recovery.njk
+++ b/src/views/ipv/pyi-attempt-recovery.njk
@@ -7,7 +7,7 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiAttemptRecovery.header' | translate }}</h1>
   <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph1' | translate }}</p>
 
-  <form id="attemptRecoveryForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
+  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="attempt-recovery">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">

--- a/src/views/ipv/pyi-attempt-recovery.njk
+++ b/src/views/ipv/pyi-attempt-recovery.njk
@@ -1,0 +1,31 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.pyiAttemptRecovery.title' | translate %}
+{% set googleTagManagerPageId = "pyiAttemptRecovery" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiAttemptRecovery.header' | translate }}</h1>
+  <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph1' | translate }}</p>
+
+  <form id="attemptRecoveryForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <input type="hidden" name="journey" value="attempt-recovery">
+    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
+      {{'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <script>
+    let disableSubmit = false;
+    function attemptRecoveryFormSubmit() {
+      if(!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+        return true
+      }
+      return false;
+    }
+  </script>
+
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+{% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

Added temporary pyi-attempt-recovery page
The page continue button goes to action journey/attempt-recovery
Add the journey/attempt-recovery action
Set up endpoint that renders the new page


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2310](https://govukverify.atlassian.net/browse/PYIC-2310)


[PYIC-2310]: https://govukverify.atlassian.net/browse/PYIC-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ