### PR TITLE
PYIC-2334: Add content for attempt recovery

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -93,10 +93,12 @@
   },
   "pages": {
     "pyiAttemptRecovery": {
-      "title": "Attempt Recovery Page - Sorry, there is a problem",
-      "header": "Attempt Recovery Page - Sorry, there is a problem",
+      "title": "Mae'n ddrwg gennym, ni allwch fynd yn ôl",
+      "header": "Mae'n ddrwg gennym, ni allwch fynd yn ôl",
       "content": {
-        "paragraph1": "We cannot prove your identity right now."
+        "paragraph1": "Ni allwch fynd yn ôl os ydych eisoes wedi dechrau rhoi gwybodaeth i brofi pwy ydych chi ar-lein.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Parhau i brofi pwy ydych chi ar-lein"
       }
     },
     "pyiNoMatch": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -93,10 +93,12 @@
   },
   "pages": {
     "pyiAttemptRecovery": {
-      "title": "Attempt Recovery Page - Sorry, there is a problem",
-      "header": "Attempt Recovery Page - Sorry, there is a problem",
+      "title": "Sorry, you cannot go back",
+      "header": "Sorry, you cannot go back",
       "content": {
-        "paragraph1": "We cannot prove your identity right now."
+        "paragraph1": "You cannot go back if you’ve already started entering information to prove your identity online.",
+        "subHeading": "What you can do",
+        "paragraph2": "Continue proving your identity online."
       }
     },
     "pyiNoMatch": {

--- a/src/views/ipv/pyi-attempt-recovery.njk
+++ b/src/views/ipv/pyi-attempt-recovery.njk
@@ -6,6 +6,8 @@
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiAttemptRecovery.header' | translate }}</h1>
   <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph1' | translate }}</p>
+  <h2 class="govuk-heading-m">{{'pages.pyiAttemptRecovery.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph2' | translate }}</p>
 
   <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## Proposed changes

### What changed

Add content for attempt recovery with the translations 

<img width="500" alt="Screenshot 2023-01-17 at 09 58 33" src="https://user-images.githubusercontent.com/24409958/212868586-e558b125-073e-4f89-bf1f-6769e346c988.png">

### Why did it change

We need to create a new unhappy path page that we can show users who press the back button in their browser (for now this content will cover all scenarios that will get a user on the attempt-recovery). 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2334](https://govukverify.atlassian.net/browse/PYIC-2334)


[PYIC-2334]: https://govukverify.atlassian.net/browse/PYIC-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ