### PR TITLE
BAU: Use redirect user to error pages instead of just rendering them …

### DIFF
--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -54,8 +54,8 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.render).to.have.been.calledOnceWith(
-        "ipv/pyi-technical-unrecoverable.njk"
+      expect(res.redirect).to.have.been.calledOnceWith(
+        "/ipv/page/pyi-technical-unrecoverable"
       );
     });
 
@@ -65,8 +65,8 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.render).to.have.been.calledOnceWith(
-        "ipv/pyi-technical-unrecoverable.njk"
+      expect(res.redirect).to.have.been.calledOnceWith(
+        "/ipv/page/pyi-technical-unrecoverable"
       );
     });
 
@@ -103,7 +103,9 @@ describe("Error handlers", () => {
       journeyEventErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(400);
-      expect(res.render).to.have.been.calledOnceWith("ipv/pyi-technical.njk");
+      expect(res.redirect).to.have.been.calledOnceWith(
+        "/ipv/page/pyi-technical"
+      );
     });
   });
 });

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -20,6 +20,7 @@ module.exports = {
       logError(req, e, "Bad response - status is not a function");
     }
 
-    res.render("ipv/pyi-technical-unrecoverable.njk");
+    req.session.currentPage = "pyi-technical-unrecoverable";
+    res.redirect("/ipv/page/pyi-technical-unrecoverable");
   },
 };

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -10,9 +10,8 @@ module.exports = {
 
     if (res.err?.response?.data?.page) {
       res.status(res.err.response.data.statusCode);
-      return res.render(`ipv/${sanitize(res.err.response.data.page)}.njk`, {
-        csrfToken: err.csrfToken,
-      });
+      req.session.currentPage = res.err.response.data.page;
+      return res.redirect(`/ipv/page/${sanitize(res.err.response.data.page)}`);
     }
 
     next(err);


### PR DESCRIPTION
…to avoid refresh errors

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use res.redirect() when we are rendering an error page to ensure the url updates when we display the pages. 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Otherwise the URL won't change meaning users can refresh and repeat their old requests sometimes causing it to look like they have used the browser back button.
<!-- Describe the reason these changes were made - the "why" -->

