### PR TITLE
PYIC-2345 Remove obsolete front-end code

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -4,7 +4,7 @@
 // based on the code at
 // https://github.com/alphagov/di-authentication-frontend/blob/main/src/assets/javascript/cookies.js
 
-var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
+var cookies = function cookies(trackingId, analyticsCookieDomain, journeyState) {
   var COOKIES_PREFERENCES_SET = "cookies_preferences_set";
   var cookiesAccepted = document.querySelector("#cookies-accepted");
   var cookiesRejected = document.querySelector("#cookies-rejected");
@@ -15,17 +15,17 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
   var rejectCookies = document.querySelector('button[name="cookiesReject"]');
 
   function cookieBannerInit() {
-    acceptCookies.addEventListener("click", function(event) {
+    acceptCookies.addEventListener("click", function (event) {
       event.preventDefault();
       setBannerCookieConsent(true);
     }.bind(this));
-    rejectCookies.addEventListener("click", function(event) {
+    rejectCookies.addEventListener("click", function (event) {
       event.preventDefault();
       setBannerCookieConsent(false);
     }.bind(this));
     var hideButtons = Array.prototype.slice.call(hideCookieBanner);
-    hideButtons.forEach(function(element) {
-      element.addEventListener("click", function(event) {
+    hideButtons.forEach(function (element) {
+      element.addEventListener("click", function (event) {
         event.preventDefault();
         hideElement(cookieBannerContainer);
       }.bind(this));
@@ -35,6 +35,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
       showElement(cookieBannerContainer);
     }
   }
+
   function setBannerCookieConsent(analyticsConsent) {
     setCookie(COOKIES_PREFERENCES_SET, {
       analytics: analyticsConsent
@@ -49,10 +50,12 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
       showElement(cookiesRejected);
     }
   }
+
   function hasConsentForAnalytics() {
     var cookieConsent = JSON.parse(getCookie(COOKIES_PREFERENCES_SET));
     return cookieConsent ? cookieConsent.analytics : false;
   }
+
   function initAnalytics() {
     loadGtmScript();
     initGtm();
@@ -61,9 +64,9 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
 
   function pushLanguageToDataLayer() {
 
-    const languageNames = {
-      'en':'english',
-      'cy':'welsh'
+    var languageNames = {
+      'en': 'english',
+      'cy': 'welsh'
     }
 
     var languageCode = document.querySelector('html') &&
@@ -86,20 +89,23 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
     gtmScriptTag.setAttribute("src", "https://www.googletagmanager.com/gtm.js?id=" + trackingId);
     document.documentElement.firstChild.appendChild(gtmScriptTag);
   }
+
   function initGtm() {
-    window.dataLayer = [ {
-      "gtm.allowlist": [ "google" ],
-      "gtm.blocklist": [ "adm", "awct", "sp", "gclidw", "gcs", "opt" ]
+    window.dataLayer = [{
+      "gtm.allowlist": ["google"],
+      "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"]
     },
       {
         'event': "progEvent",
         'ProgrammeName': 'DI - PYI'
-      } ];
+      }];
+
     //var sessionJourney = getJourneyMapping(journeyState);
 
     function gtag(obj) {
       dataLayer.push(obj);
     }
+
     if (journeyState) {
       dataLayer.push({
         event: "journeyEvent",
@@ -112,6 +118,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
       event: "gtm.js"
     });
   }
+
   function initLinkerHandlers() {
     //
     // Currently this is not required
@@ -152,6 +159,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
     //   });
     // }
   }
+
   // function generateSessionJourney(journey, status) {
   //   return {
   //     JourneyStatus: status
@@ -192,6 +200,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
     }
     return null;
   }
+
   function setCookie(name, values, options) {
     if (typeof options === "undefined") {
       options = {};
@@ -207,12 +216,15 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
     }
     document.cookie = cookieString;
   }
+
   function hideElement(el) {
     el.style.display = "none";
   }
+
   function showElement(el) {
     el.style.display = "block";
   }
+
   return {
     cookieBannerInit: cookieBannerInit,
     hasConsentForAnalytics: hasConsentForAnalytics,
@@ -223,8 +235,9 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
 window.GOVSignIn = window.GOVSignIn || {};
 window.GOVSignIn.Cookies = cookies;
 
-(function(w) {
+(function (w) {
   "use strict";
+
   function appInit(trackingId, analyticsCookieDomain, journeyState) {
     window.GOVUKFrontend.initAll();
     var cookies = window.GOVSignIn.Cookies(trackingId, analyticsCookieDomain, journeyState);
@@ -233,11 +246,12 @@ window.GOVSignIn.Cookies = cookies;
     }
     cookies.cookieBannerInit();
   }
+
   w.GOVSignIn.appInit = appInit;
 
   function disableAfterClick(link) {
 
-    link.onclick = function(event) {
+    link.onclick = function (event) {
       event.preventDefault();
     }
   }

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -3,26 +3,10 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% block head %}
-
-    <!--[if !IE 8]><!-->
-    <link href="/public/stylesheets/application.css" rel="stylesheet">
-    <!--<![endif]-->
-
-    {# For Internet Explorer 8, you need to compile specific stylesheet #}
-    {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-    <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-    <![endif]-->
-
-    {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-    <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
-
-    {% block headMetaData %}{% endblock %}
-
-{% endblock %}
+{%- block head %}
+    <link href="/public/stylesheets/application.css" rel="stylesheet" media="all">
+    {%- block headMetaData %}{%- endblock %}
+{%- endblock %}
 
 {% block pageTitle-%}
     {%- if error or errors %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Our front-end HTML source code attempts to serve assets to support very old browsers that don’t have modern CSS support or support for HTML5 block level elements such as `<nav>` or `<footer>`. This change removes this code to reduce complexity and increase performance.

Our current code is also wrapped in Internet Explorer specific conditional comments which are no longer necessary as all browsers we target will be required to parse the single file served. At the same time, the code that is served to modern browsers to fetch the stylesheet does not currently indicate which `media` the stylesheet supports, so this change adds the `media` attribute to the stylesheet `<link>`.

### What changed

<!-- Describe the changes in detail - the "what"-->
In the global `base.njk` file the references to an IE specific stylesheet and the [HTML5 shim/shiv](https://github.com/aFarkas/html5shiv) have been removed. The `link` to the stylesheet is no longer surrounded by [conditional comments](https://www.htmldog.com/guides/html/advanced/conditionalcomments/) and has the [`media="all"` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-media) added, to indicate to user agents that this stylesheet is applicable to print and screen styles. The code has been tested and print styles are applied if a user wishes to print out a page.

The nunjucks code also has dashes added to relevant tags to trim whitespace in the generated HTML source code.

### Why did it change

This will reduce the complexity of our `<head>` code and remove calls to files that are not part of our build pipeline.

#### Data on browser usage related to this change

Examining the statistics available shows that there is a very tiny percentage (0.06%) of users visiting DI with Internet Explorer 11, and no users at all visiting the site with IE10 or below. This follows trends seen elsewhere on GOV.UK. The situation will be monitored as the DI service is rolled out.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2345](https://govukverify.atlassian.net/browse/PYIC-2345)


[PYIC-2345]: https://govukverify.atlassian.net/browse/PYIC-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ