### PR TITLE
BAU Add no-cache headers and tidy up logs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -117,6 +117,14 @@ app.use((req, res, next) => {
 
 app.use(cookieParser());
 
+app.use((req, res, next) => {
+  res.set(
+    "Cache-Control",
+    "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0"
+  );
+  next();
+});
+
 const router = express.Router();
 
 router.use((req, res, next) => {

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -102,7 +102,6 @@ describe("Error handlers", () => {
 
       journeyEventErrorHandler(err, req, res, next);
 
-      expect(res.status).to.have.been.calledOnceWith(400);
       expect(res.redirect).to.have.been.calledOnceWith(
         "/ipv/page/pyi-technical"
       );

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -5,16 +5,12 @@ module.exports = {
   serverErrorHandler(err, req, res, next) {
     const message = {
       err: err,
-      description: "Error recieved in server error handler",
+      response: err?.response?.data,
+      description: "Error received in server error handler",
     };
     req.log.error({ message, level: "ERROR", requestId: req.id });
 
     if (res.headersSent) {
-      const message = {
-        description: "res.headers sent is true",
-      };
-      req.log.info({ message, level: "INFO", requestId: req.id });
-
       return next(err);
     }
 

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -4,25 +4,21 @@ module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
     const message = {
       err: err,
-      description: "Error recieved in server error handler",
+      response: err?.response?.data,
+      description: "Error received in journey event error handler",
     };
     req.log.error({ message, level: "ERROR", requestId: req.id });
 
     if (res.headersSent) {
-      const message = {
-        description: "res.headers sent is true",
-      };
-      req.log.info({ message, level: "INFO", requestId: req.id });
-
       return next(err);
     }
 
     res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
 
     if (res.err?.response?.data?.page) {
-      res.status(res.err.response.data.statusCode);
-      req.session.currentPage = res.err.response.data.page;
-      return res.redirect(`/ipv/page/${sanitize(res.err.response.data.page)}`);
+      const pageId = sanitize(res.err.response.data.page);
+      req.session.currentPage = pageId;
+      return res.redirect(`/ipv/page/${pageId}`);
     }
 
     next(err);


### PR DESCRIPTION
## Proposed changes

### What changed

Add no-cache headers and tidy up logs

### Why did it change

Prevent issues with redirects from CRIs where the browser caches the response.
We'd added some logs for debugging that we don't need anymore.

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
