### PR TITLE
PYIC-2357: Update core-front to delete the core-back session ID after…

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -82,6 +82,14 @@ async function handleBackendResponse(req, res, backendResponse) {
     });
 
     req.session.currentPage = "orchestrator";
+
+    const message = {
+      description:
+        "Deleting the core-back ipvSessionId from core-front session",
+    };
+    req.log.info({ message, level: "INFO", requestId: req.id });
+
+    req.session.ipvSessionId = null;
     const { redirectUrl } = backendResponse.client;
     return res.redirect(redirectUrl);
   }
@@ -177,7 +185,22 @@ module.exports = {
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;
-      if (!req.session.isDebugJourney && req.session.currentPage !== pageId) {
+      if (req.session?.ipvSessionId === null) {
+        logError(
+          req,
+          {
+            pageId: pageId,
+            expectedPage: req.session.currentPage,
+          },
+          "req.ipvSessionId is missing"
+        );
+
+        req.session.currentPage = "pyi-technical-unrecoverable";
+        return res.render(`ipv/${req.session.currentPage}.njk`);
+      } else if (
+        !req.session.isDebugJourney &&
+        req.session.currentPage !== pageId
+      ) {
         logError(
           req,
           {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -172,6 +172,20 @@ describe("journey middleware", () => {
       await middleware.handleJourneyPage(req, res, next);
       expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
     });
+
+    it("should render pyi-technical-unrecoverable page if ipvSessionId is missing", async () => {
+      req = {
+        id: "1",
+        params: { pageId: "../debug/page-ipv-debug" },
+        session: { currentPage: "page-ipv-success", ipvSessionId: null },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+
+      await middleware.handleJourneyPage(req, res);
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
+    });
   });
 
   context("calling the updateJourneyState", () => {


### PR DESCRIPTION
… user leaves

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Delete the core-back ipvSesionId value from the core-front session after the user is redirected back to the auth client.

If we receive a page request while the ipvSessionId is missing then we render the ipv-technical-unrecoverable error page.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This situation will display the unrecoverable error page when a user redirects out of the IPV core but uses the back button to come back.

This is just a temp solution. We may look in the future to ask the auth team to setup a well known recovery endpoint for us to send users to.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2357](https://govukverify.atlassian.net/browse/PYIC-2357)



[PYIC-2357]: https://govukverify.atlassian.net/browse/PYIC-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ