### PR TITLE
PYIC-2380 Modify ipv_core_service_session cookie settings

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -89,7 +89,7 @@ app.use(
     resave: false,
     cookie: {
       name: "ipv_core_service_session",
-      maxAge: 720000,
+      expires: false,
       secret: SESSION_SECRET,
       signed: true,
       secure: "auto",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change removes the `maxAge` setting in app.js, which had the side effect of removing the session cookie after 720000 milliseconds/12 minutes, causing unexpected behaviour.

### What changed

The `expires:false` setting is added to the session cookie set by express, so the cookie type is now `session`, meaning it persists until the user closes their browser.

### Why did it change

Discovered while exploring unexpected user behaviour.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2380](https://govukverify.atlassian.net/browse/PYIC-2380)



[PYIC-2380]: https://govukverify.atlassian.net/browse/PYIC-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ