### PR TITLE
PYIC-2332: Handle missing ipvSessionId

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -5,8 +5,13 @@ const {
 } = require("../../lib/config");
 const { generateJsonAxiosConfig, getAxios } = require("../shared/axiosHelper");
 const { handleBackendResponse } = require("../ipv/middleware");
-const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
+const {
+  logCoreBackCall,
+  transformError,
+  logError,
+} = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
+const { HTTP_STATUS_CODES } = require("../../app.constants");
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -26,6 +31,15 @@ module.exports = {
     }
 
     try {
+      if (!req.session?.ipvSessionId) {
+        const err = new Error("cri req.ipvSessionId is missing");
+        err.status = HTTP_STATUS_CODES.UNAUTHORIZED;
+        logError(req, err);
+
+        req.session.currentPage = "pyi-technical-unrecoverable";
+        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+      }
+
       logCoreBackCall(req, {
         logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
         path: API_CRI_CALLBACK,
@@ -65,6 +79,15 @@ module.exports = {
     }
 
     try {
+      if (!req.session?.ipvSessionId) {
+        const err = new Error("cri req.ipvSessionId is missing");
+        err.status = HTTP_STATUS_CODES.UNAUTHORIZED;
+        logError(req, err);
+
+        req.session.currentPage = "pyi-technical-unrecoverable";
+        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+      }
+
       logCoreBackCall(req, {
         logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
         path: API_CRI_CALLBACK,

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -145,6 +145,16 @@ describe("credential issuer middleware", () => {
 
       expect(next).to.be.calledWith(sinon.match.instanceOf(Error));
     });
+
+    it("should redirect to technical unrecoverable when ipvSessionId is missing", async () => {
+      req.session.ipvSessionId = null;
+
+      await middleware.sendParamsToAPI(req, res, next);
+
+      expect(res.redirect).to.have.been.calledWith(
+        "/ipv/page/pyi-technical-unrecoverable"
+      );
+    });
   });
 
   describe("sendParamsToAPIV2", function () {
@@ -286,6 +296,16 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(next).to.be.calledWith(sinon.match.instanceOf(Error));
+    });
+
+    it("should redirect to technical unrecoverable when ipvSessionId is missing", async () => {
+      req.session.ipvSessionId = null;
+
+      await middleware.sendParamsToAPIV2(req, res, next);
+
+      expect(res.redirect).to.have.been.calledWith(
+        "/ipv/page/pyi-technical-unrecoverable"
+      );
     });
   });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -423,6 +423,25 @@ describe("journey middleware", () => {
     }
   );
 
+  context("handling missing ipvSessionId before calling the backend", () => {
+    it("should redirect to the technical unrecoverable page", async function () {
+      req = {
+        id: "1",
+        session: {
+          currentPage: "page-ipv-identity-start",
+          ipvSessionId: null,
+          ipAddress: "ip-address",
+        },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+
+      await middleware.handleJourneyAction(req, res, next);
+      expect(res.redirect).to.have.been.calledWith(
+        "/ipv/page/pyi-technical-unrecoverable"
+      );
+    });
+  });
+
   context("handling page-ipv-reuse journey route", () => {
     const pageId = "page-ipv-reuse";
     it("should call build-proven-user-identity-details endpoint and user details passed into renderer", async function () {


### PR DESCRIPTION
## Proposed changes

### What changed

There are 3 different areas in the code where the checks should be made 
If ipvSessionId is missing then redirect to technical unrecoverable page

The different scenarios covered:
- A user tries to conitnue to the next page on core-front with no ipvSessionId
- The user tries clicking back from orchestrator
- The user tries to visit a callback url with no ipvSessionId

### Why did it change

We currently to not check to see if the user’s front end session contains an ipvSessionId before calling the backend. If there is no ipv session associated with the front end session, then calling the backend results in an axios error

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2332](https://govukverify.atlassian.net/browse/PYIC-2332)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-2332]: https://govukverify.atlassian.net/browse/PYIC-2332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ