### PR TITLE
PYIC-2415: Fix sonarcloud coverage

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,5 +1,8 @@
 name: Pre-merge checks
 on:
+  push: 
+    branches: 
+      - main  
   pull_request:
     types:
       - opened

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -9,6 +9,7 @@ exclude:
   - "src/lib/*"
   - "src/app.js"
   - "src/app/shared/axiosHelper.js"
+  - "src/config/*"
 report-dir: coverage
 statements: 80
 branches: 80

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=alphagov_di-ipv-core-front
 sonar.organization=alphagov
 
 sonar.sources=src/
-sonar.exclusions=**/assets/**,**/*.test.js,**/service-unavailable-s3/**
+sonar.exclusions=**/assets/**,**/*.test.js,**/service-unavailable-s3/**,**/config/**,**/lib/**,**/*router.js,**/axiosHelper.js,**/app.js
 
 sonar.tests=src/
 sonar.test.inclusions=**/*.test.js


### PR DESCRIPTION
## Proposed changes

### What changed

Align nycrc with sonarcloud.properties
Add additonal files/directroy which dont require analysis - missed in removing hmpo-app
Make the GitHub action run on push to main as we are not getting code analysis on sonarcloud dashboard

### Why did it change

The coverage report on PR's is not showing accurate coverage to when running locally. 
Sonarcloud dashboard is not showing analysis on main

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2415](https://govukverify.atlassian.net/browse/PYIC-2415)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-2415]: https://govukverify.atlassian.net/browse/PYIC-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ