### PR TITLE
PYIC-2378 Audit component usage and reduce CSS file size

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start-dev": "node src/app.js | pino-pretty",
     "dev": "nodemon --inspect=0.0.0.0:9228 src/app.js",
     "build": "yarn minfiy-build-front-end-gov-js && yarn build-sass && yarn copy-locales",
-    "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
+    "build-sass": "rm -rf dist/public/style.css && sass --load-path=node_modules/govuk-frontend/govuk --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-locales": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ ",
     "minfiy-build-front-end-gov-js": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js src/assets/javascript/application.js -o dist/public/javascripts/application.js -c -m ",
     "lint": "prettier --check src test && eslint .",

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -26,7 +26,6 @@ $govuk-new-link-styles: true;
 @import "components/phase-banner/index"; // use govukPhaseBanner
 @import "components/back-link/index"; // use govukBackLink
 
-
 // Task list pattern
 
 .app-task-list {

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -1,5 +1,31 @@
-@use "../../../node_modules/govuk-frontend/govuk/all";
-@import "../../../node_modules/govuk-frontend/govuk/base";
+$govuk-new-link-styles: true;
+
+// correct path to the node_module version of these gov.uk frontend files is set in package.json
+
+@import "base";
+@import "core/all";
+@import "utilities/all";
+@import "objects/all";
+@import "overrides/all";
+
+// global page layout components
+
+@import "components/cookie-banner/cookie-banner";
+@import "components/footer/footer";
+@import "components/header/header";
+@import "components/skip-link/skip-link";
+
+// start specific Design System component imports
+
+@import "components/button/index"; // use govukButton
+@import "components/summary-list/index"; // use govukSummaryList
+@import "components/details/index"; // use govukDetails
+@import "components/radios/index"; // use govukRadios
+@import "components/warning-text/index"; // use govukWarningText
+@import "components/cookie-banner/index"; // use govukCookieBanner
+@import "components/phase-banner/index"; // use govukPhaseBanner
+@import "components/back-link/index"; // use govukBackLink
+
 
 // Task list pattern
 

--- a/utils/css-scan.js
+++ b/utils/css-scan.js
@@ -1,0 +1,77 @@
+// scan the
+
+const fs = require("fs");
+const path = require("path");
+
+const componentsUsed = [];
+const allFiles = [];
+const testArray = [];
+
+function readFile(filepath) {
+  console.log("Checked for components: " + filepath);
+  return new Promise((resolve, reject) => {
+    fs.readFile(filepath, "utf-8", (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+}
+
+function createOutput(data) {
+
+  const possibleOutput = [
+    ...data.matchAll(/{% from "([a-z-/.]*)" import ([a-zA-Z]*) %}/g),
+  ];
+
+  for (const output of possibleOutput) {
+    const sassInstruction = output[1]
+      .replace("govuk/components/", "")
+      .replace("/macro.njk", "");
+    componentsUsed.push(
+      `@import "../../../node_modules/govuk-frontend/govuk/components/${sassInstruction}/index"; // use ${output[2]}`
+    );
+  }
+  const CLIoutput = [...new Set(componentsUsed)];
+  console.log('...');
+  for(const line of CLIoutput){
+    console.log(line);
+  }
+}
+
+
+
+function fromDir(startPath, filter) {
+  if (!fs.existsSync(startPath)) {
+    console.log("There is no directory at: ", startPath);
+    return;
+  }
+
+  var files = fs.readdirSync(startPath);
+  for (var i = 0; i < files.length; i++) {
+    var filename = path.join(startPath, files[i]);
+    var stat = fs.lstatSync(filename);
+    if (stat.isDirectory()) {
+      fromDir(filename, filter); //recurse
+    } else if (filename.endsWith(filter)) {
+      allFiles.push(filename);
+    }
+  }
+}
+
+// find all nunjucks files in the repo
+
+fromDir("./src", ".njk");
+
+// read through them all and match them against the regex for design system modules
+
+allFiles.forEach((file) => {
+  readFile(file).then((data) => {
+    //console.log(data);
+    const whatisdata = createOutput(data);
+  })
+})
+
+// create a list we can output to the command line

--- a/utils/css-scan.js
+++ b/utils/css-scan.js
@@ -1,14 +1,18 @@
-// scan the
+// scan the repository for Nunjucks macros that imply the use of component scss
+// the pattern is
+// {% from "govuk/components/[component]/macro.njk" import [component name] %}
 
 const fs = require("fs");
 const path = require("path");
 
 const componentsUsed = [];
 const allFiles = [];
-const testArray = [];
 
 function readFile(filepath) {
+  /* eslint-disable no-console */
   console.log("Checked for components: " + filepath);
+  /* eslint-enable no-console */
+
   return new Promise((resolve, reject) => {
     fs.readFile(filepath, "utf-8", (err, data) => {
       if (err) {
@@ -21,7 +25,6 @@ function readFile(filepath) {
 }
 
 function createOutput(data) {
-
   const possibleOutput = [
     ...data.matchAll(/{% from "([a-z-/.]*)" import ([a-zA-Z]*) %}/g),
   ];
@@ -35,17 +38,22 @@ function createOutput(data) {
     );
   }
   const CLIoutput = [...new Set(componentsUsed)];
-  console.log('...');
-  for(const line of CLIoutput){
+  // I will learn how to output this once
+  /* eslint-disable no-console */
+  // create a list we can output to the command line
+  console.log("...");
+  for (const line of CLIoutput) {
+    // prettier-ignore
     console.log(line);
   }
+  /* eslint-enable no-console */
 }
-
-
 
 function fromDir(startPath, filter) {
   if (!fs.existsSync(startPath)) {
+    /* eslint-disable no-console */
     console.log("There is no directory at: ", startPath);
+    /* eslint-enable no-console */
     return;
   }
 
@@ -69,9 +77,7 @@ fromDir("./src", ".njk");
 
 allFiles.forEach((file) => {
   readFile(file).then((data) => {
-    //console.log(data);
-    const whatisdata = createOutput(data);
-  })
-})
+    createOutput(data);
+  });
+});
 
-// create a list we can output to the command line


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change changes the process used to create the `application.css` file, reducing the minified file size from 126KB to 83KB.

The new process only asks for the components we know we use from the design system, rather than asking for all the components. To do this the (hacked together) `utils/css-scan.js` node file runs a regex on the `.njk` files we have to find all the places where we import a design system component. The regex then creates a list of includes that can be cut and pasted into the `scss` file that creates `application.css`.

### What changed

<!-- Describe the changes in detail - the "what"-->
* `package.json` now passes a `--load-path` parameter in the `build-sass` command to make the file paths in the `scss` file much shorter and more readable
* `application.scss` follows [the lead of the account front-end repo](https://github.com/alphagov/di-account-management-frontend/pull/818/files) by importing specific modules from the `govuk-frontend` repository
* `utils/css-scan.js` is a very hacky node utility that finds the modules we need - eventually this should run and populate (or write out) application.scss automatically

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To improve web performance and reduce the overall size of what the user needs to download. It is also a Lighthouse recommendation.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2378](https://govukverify.atlassian.net/browse/PYIC-2378)



[PYIC-2378]: https://govukverify.atlassian.net/browse/PYIC-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ