### PR TITLE
PYIC-2537 Use same domain for analytics

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -432,7 +432,7 @@ Resources:
             - Name: GTM_ID
               Value: !If [ IsProduction, "GTM-TT5HDKV", "GTM-TK92W68" ]
             - Name: ANALYTICS_DOMAIN
-              Value: !If [ IsProduction, "account.gov.uk", !Sub "${Environment}.account.gov.uk" ]
+              Value: "account.gov.uk"
             - Name: SESSION_SECRET
               Value: "no-secret"
             - Name: NODE_OPTIONS


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change uses `account.gov.uk` as the domain for all environments to set cookies against.

### What changed

<!-- Describe the changes in detail - the "what"-->
Line 435 of the YAML file now uses the same URI for all environments.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
CRIs cannot use cookies set on domains that are more specific than `account.gov.uk`

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2537](https://govukverify.atlassian.net/browse/PYIC-2537)




[PYIC-2537]: https://govukverify.atlassian.net/browse/PYIC-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ