### PR TITLE
PYIC-2537 Change domain name to add a dot as a 'wildcard'

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -432,7 +432,7 @@ Resources:
             - Name: GTM_ID
               Value: !If [ IsProduction, "GTM-TT5HDKV", "GTM-TK92W68" ]
             - Name: ANALYTICS_DOMAIN
-              Value: "account.gov.uk"
+              Value: ".account.gov.uk"
             - Name: SESSION_SECRET
               Value: "no-secret"
             - Name: NODE_OPTIONS


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use a dot at the beginning of the domain name as this appears to be the correct browser behaviour to set cookies on a domain.

### What changed

<!-- Describe the changes in detail - the "what"-->
A dot was added to the domain name as a 'wildcard'.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
After the initial change the `lng` cookie was set to `identity.build.account.gov.uk`, when it should be set to `account.gov.uk`.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2537](https://govukverify.atlassian.net/browse/PYIC-2537)



[PYIC-2537]: https://govukverify.atlassian.net/browse/PYIC-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ