### PR TITLE
PYIC-2481 Stricter filtering on IP for audit messages

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -3,7 +3,7 @@ const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const axios = require("axios");
 
-const IPV4_MATCH = "\\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\\b";
+const IPV4_MATCH = "\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b";
 
 module.exports = {
   setDebugJourneyType: (req, _res, next) => {
@@ -21,7 +21,7 @@ module.exports = {
     if (req.headers && req.headers["forwarded"]) {
       const ipAddress = req.headers["forwarded"].match(IPV4_MATCH);
       if (ipAddress) {
-        req.session.ipAddress = ipAddress[0]
+        req.session.ipAddress = ipAddress[0];
       } else {
         req.session.ipAddress = "unknown";
       }

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -3,6 +3,8 @@ const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const axios = require("axios");
 
+const IPV4_MATCH = "\\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\\b";
+
 module.exports = {
   setDebugJourneyType: (req, _res, next) => {
     req.session.isDebugJourney = true;
@@ -17,8 +19,12 @@ module.exports = {
 
   setIpAddress: (req, res, next) => {
     if (req.headers && req.headers["forwarded"]) {
-      const ipAddress = req.headers["forwarded"].split(";")[0].split("=")[1];
-      req.session.ipAddress = ipAddress || "unknown";
+      const ipAddress = req.headers["forwarded"].match(IPV4_MATCH);
+      if (ipAddress) {
+        req.session.ipAddress = ipAddress[0]
+      } else {
+        req.session.ipAddress = "unknown";
+      }
     } else {
       req.session.ipAddress = "unknown";
     }

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -185,5 +185,16 @@ describe("oauth middleware", () => {
         expect(req.session.ipAddress).to.eq("unknown");
       });
     });
+
+    context("with no ipv4 match in forwarded", () => {
+      beforeEach(() => {
+        req.headers.forwarded = "malformed-header";
+      });
+
+      it("should set ipAddress as 'unknown'", async function () {
+        await middleware.setIpAddress(req, res, next);
+        expect(req.session.ipAddress).to.eq("unknown");
+      });
+    });
   });
 });

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -160,7 +160,8 @@ describe("oauth middleware", () => {
 
     context("with forwarded multiple", () => {
       beforeEach(() => {
-        req.headers.forwarded = "for=1.2.3.4,1.2.3.4;proto=https;by=4.3.2.1,4.3.2.1";
+        req.headers.forwarded =
+          "for=1.2.3.4,1.2.3.4;proto=https;by=4.3.2.1,4.3.2.1";
       });
 
       it("should set first ipAddress in session", async function () {

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -158,6 +158,22 @@ describe("oauth middleware", () => {
       });
     });
 
+    context("with forwarded multiple", () => {
+      beforeEach(() => {
+        req.headers.forwarded = "for=1.2.3.4,1.2.3.4;proto=https;by=4.3.2.1,4.3.2.1";
+      });
+
+      it("should set first ipAddress in session", async function () {
+        await middleware.setIpAddress(req, res, next);
+        expect(req.session.ipAddress).to.eq("1.2.3.4");
+      });
+
+      it("should call next", async function () {
+        await middleware.setIpAddress(req, res, next);
+        expect(next).to.have.been.called;
+      });
+    });
+
     context("with missing forwarded", () => {
       beforeEach(() => {
         req.headers.forwarded = null;


### PR DESCRIPTION
Filter IP addresses based on IPV4 regex match rather than relying on string splitting

## Proposed changes

### What changed

- Replace string split in oauth2 middleware with ipv4 regex
- Additional test cases for multiple ips in header

### Why did it change

- Existing string split correctly parsed single ip addresses in headers but failed to account for multiple ips, resulting in additional non-ip text appearing in audit logs

### Issue tracking

- [PYIC-2481](https://govukverify.atlassian.net/browse/PYIC-2481)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
