### PR TITLE
PYIC-2316 Create new pages for Timeout and browser feature journeys

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -225,6 +225,8 @@ module.exports = {
         case "pyi-kbv-fail":
         case "pyi-kbv-thin-file":
         case "pyi-no-match":
+        case "pyi-timeout-recoverable":
+        case "pyi-timeout-unrecoverable":
         case "pyi-technical":
         case "pyi-technical-unrecoverable":
           return res.render(`ipv/${sanitize(pageId)}.njk`, {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -111,6 +111,30 @@
         "paragraph3": "Ewch yn eich blaen i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     },
+    "pyiTimeoutRecoverable": {
+      "title": "Rydych wedi allgofnodi o’ch GOV.UK One Login",
+      "header": "Rydych wedi allgofnodi o’ch GOV.UK One Login",
+      "content": {
+        "paragraph1": "Gallai hyn fod oherwydd:",
+        "bullet1": "fe wnaethoch fewngofnodi dros 2 awr yn ôl",
+        "bullet2": "fe wnaethoch allgofnodi tra roeddech yn defnyddio gwasanaeth arall",
+        "bullet3": "defnyddiwyd mwy nag un porwr (er enghraifft Chrome, Safari)",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)"
+      }
+    },
+    "pyiTimeoutUnrecoverable": {
+      "title": "Rydych wedi allgofnodi o’ch GOV.UK One Login",
+      "header": "Rydych wedi allgofnodi o’ch GOV.UK One Login",
+      "content": {
+        "paragraph1": "Gallai hyn fod oherwydd:",
+        "bullet1": "fe wnaethoch fewngofnodi dros 2 awr yn ôl",
+        "bullet2": "fe wnaethoch allgofnodi tra roeddech yn defnyddio gwasanaeth arall",
+        "bullet3": "defnyddiwyd mwy nag un porwr (er enghraifft Chrome, Safari)",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Ewch yn ôl i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK."
+      }
+    },
     "pyiTechnical": {
       "title": "Mae’n ddrwg gennym, mae problem",
       "header": "Mae’n ddrwg gennym, mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -111,6 +111,30 @@
         "paragraph3": "Continue to the service you were trying to use and look for other ways to prove your identity."
       }
     },
+    "pyiTimeoutRecoverable": {
+      "title": "You have been signed out of your GOV.UK One Login",
+      "header": "You have been signed out of your GOV.UK One Login",
+      "content": {
+        "paragraph1": "This could be because:",
+        "bullet1": "you signed in over 2 hours ago",
+        "bullet2": "you signed out while you were using another service",
+        "bullet3": "more than one browser (for example Chrome, Safari) was used",
+        "subHeading": "What you can do",
+        "paragraph2": "Go back to the service you were trying to use and start again."
+      }
+    },
+    "pyiTimeoutUnrecoverable": {
+      "title": "You have been signed out of your GOV.UK One Login",
+      "header": "You have been signed out of your GOV.UK One Login",
+      "content": {
+        "paragraph1": "This could be because:",
+        "bullet1": "you signed in over 2 hours ago",
+        "bullet2": "you signed out while you were using another service",
+        "bullet3": "more than one browser (for example Chrome, Safari) was used",
+        "subHeading": "What you can do",
+        "paragraph2": "Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage."
+      }
+    },
     "pyiTechnical": {
       "title": "Sorry, there is a problem",
       "header": "Sorry, there is a problem",

--- a/src/views/ipv/pyi-timeout-recoverable.njk
+++ b/src/views/ipv/pyi-timeout-recoverable.njk
@@ -1,0 +1,37 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.pyiTimeoutRecoverable.title' | translate %}
+{% set googleTagManagerPageId = "pyiTimeoutRecoverable" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiTimeoutRecoverable.header' | translate }}</h1>
+  <p class="govuk-body">{{'pages.pyiTimeoutRecoverable.content.paragraph1' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet1' | translate }}</li>
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet2' | translate }}</li>
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet3' | translate }}</li>
+  </ul>
+  <h2 class="govuk-heading-m">{{'pages.pyiTimeoutRecoverable.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{'pages.pyiTimeoutRecoverable.content.paragraph2' | translate }}</p>
+  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <input type="hidden" name="journey" value="attempt-recovery">
+    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
+      {{'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <script>
+    let disableSubmit = false;
+    function attemptRecoveryFormSubmit() {
+      if(!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+        return true
+      }
+      return false;
+    }
+  </script>
+
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+{% endblock %}

--- a/src/views/ipv/pyi-timeout-unrecoverable.njk
+++ b/src/views/ipv/pyi-timeout-unrecoverable.njk
@@ -1,0 +1,23 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.pyiTimeoutUnrecoverable.title' | translate %}
+{% set googleTagManagerPageId = "pyiTimeoutUnrecoverable" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiTimeoutUnrecoverable.header' | translate }}</h1>
+  <p class="govuk-body">{{'pages.pyiTimeoutUnrecoverable.content.paragraph1' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet1' | translate }}</li>
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet2' | translate }}</li>
+    <li>{{'pages.pyiTimeoutRecoverable.content.bullet3' | translate }}</li>
+  </ul>
+  <h2 class="govuk-heading-m">{{'pages.pyiTimeoutUnrecoverable.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{'pages.pyiTimeoutUnrecoverable.content.paragraph2' | translate }}</p>
+  {{ govukButton({
+    "text": button_text|default('general.shared.govUKHomepageButtonText' | translate, true),
+    "type": "Submit",
+    "href": 'general.shared.govUKHomepageButtonHref' | translate
+  }) }}
+
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR add two new pages `ipv/pyic-timeout-recoverable` and `ipv/pyic-timeout-unrecoverable` to support a wider range of unhappy paths, including the situations where a user’s device has fallen back to a default browser when that wasn’t the users intention.

### What changed

<!-- Describe the changes in detail - the "what"-->
Two `.njk` files were added and the `translation.json` files have been updated.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To assist users to recover from errors on the journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2316](https://govukverify.atlassian.net/browse/PYIC-2316)



[PYIC-2316]: https://govukverify.atlassian.net/browse/PYIC-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ