### PR TITLE
[PYIC-2622] Update middleware to render timeout page when requested

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -195,6 +195,9 @@ module.exports = {
 
         req.session.currentPage = "pyi-technical-unrecoverable";
         return res.render(`ipv/${req.session.currentPage}.njk`);
+      } else if (pageId === "pyi-timeout-unrecoverable") {
+        req.session.currentPage = "pyi-timeout-unrecoverable";
+        return res.render(`ipv/${req.session.currentPage}.njk`);
       } else if (
         !req.session.isDebugJourney &&
         req.session.currentPage !== pageId

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -154,6 +154,20 @@ describe("journey middleware", () => {
       expect(res.render).to.have.been.calledWith("ipv/pyi-technical.njk");
     });
 
+    it("should render unrecoverable timeout error page when given unrecoverable timeout pageId", async () => {
+      req = {
+        id: "1",
+        params: { pageId: "pyi-timeout-unrecoverable" },
+        session: { currentPage: "../debug/page-ipv-debug" },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+
+      await middleware.handleJourneyPage(req, res);
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-timeout-unrecoverable.njk"
+      );
+    });
+
     it("should render attempt recovery error page when current page is not equal to pageId", async () => {
       req = {
         id: "1",


### PR DESCRIPTION
Allow front-end to server unrecoverable timeout page when requested

## Proposed changes

### What changed

Core middleware updated to forward to `pyi-timeout-unrecoverable`

### Why did it change

Required to display `pyi-timeout-unrecoverable` page to users who have timed out

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2622](https://govukverify.atlassian.net/browse/PYIC-2622)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2622]: https://govukverify.atlassian.net/browse/PYIC-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ