### PR TITLE
PYIC-2545 Update start page with new content

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2,6 +2,7 @@
   "general": {
     "buttons": {
       "authorizeAndReturn": "Awdurdodi a Dychwelyd",
+      "start": "Dechrau",
       "next": "Parhau",
       "cancel": "Canslo",
       "govUkHomepage": " Ewch i hafan GOV.UK"
@@ -174,10 +175,10 @@
       }
     },
     "pageIpvIdentityStart": {
-      "title": "Rydych wedi mewngofnodi i GOV.UK One Login",
-      "header": "Rydych wedi mewngofnodi i GOV.UK One Login",
+      "title": "Dechrau profi pwy ydych chi gyda GOV.UK One Login",
+      "header": "Dechrau profi pwy ydych chi gyda GOV.UK One Login",
       "content": {
-        "paragraph1": "Gallwch nawr barhau i brofi pwy ydych chi."
+        "paragraph1": "Yn gyntaf, gofynnir rhai cwestiynau i chi i ddarganfod y ffordd orau o brofi pwy ydych chi."
       }
     },
     "pagePreKbvTransition": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,6 +2,7 @@
   "general": {
     "buttons": {
       "authorizeAndReturn": "Authorize And Return",
+      "start": "Start",
       "next": "Continue",
       "cancel": "Cancel",
       "govUkHomepage": "Go to the GOV.UK homepage"
@@ -174,10 +175,10 @@
       }
     },
     "pageIpvIdentityStart": {
-      "title": "You’ve signed in to GOV.UK One Login",
-      "header": "You’ve signed in to GOV.UK One Login",
+      "title": "Start proving your identity with GOV.UK One Login",
+      "header": "Start proving your identity with GOV.UK One Login",
       "content": {
-        "paragraph1": "You can now continue to prove your identity."
+        "paragraph1": "First, you will be asked some questions to find the best way to prove your identity."
       }
     },
     "pagePreKbvTransition": {

--- a/src/views/ipv/page-ipv-identity-start.njk
+++ b/src/views/ipv/page-ipv-identity-start.njk
@@ -7,5 +7,6 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageIpvIdentityStart.header' | translate }}</h1>
   <p class="govuk-body">{{'pages.pageIpvIdentityStart.content.paragraph1' | translate }}</p>
 
+  {% set customButtonLabel = 'general.buttons.start' | translate %}
   {% include 'shared/journey-next-form.njk' %}
 {% endblock %}

--- a/src/views/shared/journey-next-form.njk
+++ b/src/views/shared/journey-next-form.njk
@@ -3,7 +3,11 @@
 <form id="nextForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return nextFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
+      {% if customButtonLabel %}
+      {{ customButtonLabel }}
+      {% else %}
       {{'general.buttons.next' | translate }}
+      {% endif %}
     </button>
 </form>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR changes the content users will see when they begin their identity journey.

### What changed

<!-- Describe the changes in detail - the "what"-->
The `json` files have updated page content and a new button label, `start`. The shared `journey-next-form.njk` has a condition which will override the standard button label of 'continue' if the variable `customButtonLabel` has been set. This has been tested with the English and Welsh content and pages render correctly with the expected button label.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To assist users to orientate themselves as they begin their identity journey. This is the second iteration of the content.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2545](https://govukverify.atlassian.net/browse/PYIC-2545)



[PYIC-2545]: https://govukverify.atlassian.net/browse/PYIC-2545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ