### PR TITLE
PYIC-2659: handle error response from step function and save into session

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -83,9 +83,13 @@ async function handleBackendResponse(req, res, backendResponse) {
 
     const message = {
       description:
-        "Deleting the core-back ipvSessionId from core-front session",
+        "Deleting the core-back ipvSessionId and clientOauthSessionId from core-front session",
     };
     req.log.info({ message, level: "INFO", requestId: req.id });
+
+    if (req?.session?.clientOauthSessionId) {
+      req.session.clientOauthSessionId = null;
+    }
 
     req.session.ipvSessionId = null;
     const { redirectUrl } = backendResponse.client;

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -302,6 +302,8 @@ module.exports = {
         await handleJourneyResponse(req, res, "journey/end");
       } else if (req.body?.journey === "attempt-recovery") {
         await handleJourneyResponse(req, res, "journey/attempt-recovery");
+      } else if (req.body?.journey === "timeout-recoverable") {
+        await handleJourneyResponse(req, res, "journey/timeout-recoverable");
       } else {
         await handleJourneyResponse(req, res, "journey/next");
       }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -448,6 +448,20 @@ describe("journey middleware", () => {
         );
       });
 
+      it("should post with journey/timeout-recoverable", async function () {
+        req = {
+          id: "1",
+          body: { journey: "timeout-recoverable" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/timeout-recoverable`
+        );
+      });
+
       it("should post with journey/next by default", async function () {
         await middleware.handleJourneyAction(req, res, next);
         expect(axiosStub.post.firstCall).to.have.been.calledWith(

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -374,8 +374,10 @@ describe("journey middleware", () => {
     });
 
     it("should be redirected to a valid Client URL", async function () {
+      req.session.clientOauthSessionId = "fake-client-session";
       await middleware.handleJourneyResponse(req, res, "/journey/next");
       expect(res.redirect).to.be.calledWith(`${redirectUrl}`);
+      expect(req.session.clientOauthSessionId).to.be.null;
     });
   });
 

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -152,7 +152,7 @@ describe("Error handlers", () => {
       axiosResponse.data = {
         page: "pyi-timeout-recoverable",
         statusCode: 401,
-        criOAuthSessionId: "fake-session-id",
+        clientOAuthSessionId: "fake-session-id",
       };
       res.statusCode = 401;
       const err = new Error("timeout recoverable error");

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -109,6 +109,19 @@ describe("Error handlers", () => {
 
       expect(next).to.be.have.been.calledOnce;
     });
+
+    it("should render pyi-timeout-recoverable page", () => {
+      res.statusCode = 401;
+      res.page = "pyi-timeout-recoverable";
+      res.criOAuthSessionId = "fake-session-id";
+      const err = new Error("timeout recoverable error");
+      serverErrorHandler(err, req, res, next);
+      expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
+
+      expect(res.render).to.have.been.calledOnceWith(
+        "ipv/pyi-timeout-recoverable.njk"
+      );
+    });
   });
 
   describe("journeyEventErrorHandler", () => {

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -109,19 +109,6 @@ describe("Error handlers", () => {
 
       expect(next).to.be.have.been.calledOnce;
     });
-
-    it("should render pyi-timeout-recoverable page", () => {
-      res.statusCode = 401;
-      res.page = "pyi-timeout-recoverable";
-      res.criOAuthSessionId = "fake-session-id";
-      const err = new Error("timeout recoverable error");
-      serverErrorHandler(err, req, res, next);
-      expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
-
-      expect(res.render).to.have.been.calledOnceWith(
-        "ipv/pyi-timeout-recoverable.njk"
-      );
-    });
   });
 
   describe("journeyEventErrorHandler", () => {
@@ -159,6 +146,24 @@ describe("Error handlers", () => {
       journeyEventErrorHandler(err, req, res, next);
 
       expect(next).to.be.calledWith(sinon.match.instanceOf(Error));
+    });
+
+    it("should render pyi-timeout-recoverable page", () => {
+      axiosResponse.data = {
+        page: "pyi-timeout-recoverable",
+        statusCode: 401,
+        criOAuthSessionId: "fake-session-id",
+      };
+      res.statusCode = 401;
+      const err = new Error("timeout recoverable error");
+      err.response = axiosResponse;
+      axiosStub.post = sinon.fake.throws(err);
+      journeyEventErrorHandler(err, req, res, next);
+      expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
+
+      expect(res.render).to.have.been.calledOnceWith(
+        "ipv/pyi-timeout-recoverable.njk"
+      );
     });
 
     it("should call next if headers sent", () => {

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -161,8 +161,8 @@ describe("Error handlers", () => {
       journeyEventErrorHandler(err, req, res, next);
       expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
 
-      expect(res.render).to.have.been.calledOnceWith(
-        "ipv/pyi-timeout-recoverable.njk"
+      expect(res.redirect).to.have.been.calledOnceWith(
+        "/ipv/page/pyi-timeout-recoverable"
       );
     });
 

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -1,3 +1,4 @@
+const sanitize = require("sanitize-filename");
 const { HTTP_STATUS_CODES } = require("../app.constants");
 const { logError } = require("../app/shared/loggerHelper");
 
@@ -12,6 +13,19 @@ module.exports = {
 
     if (res.headersSent) {
       return next(err);
+    }
+
+    if (
+      res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED &&
+      res?.criOAuthSessionId &&
+      res?.page
+    ) {
+      const pageId = res.page;
+      req.session.clientOauthSessionId = res?.criOAuthSessionId;
+      return res.render(`ipv/${sanitize(pageId)}.njk`, {
+        pageId,
+        csrfToken: req.csrfToken(),
+      });
     }
 
     if (res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED) {

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -22,10 +22,7 @@ module.exports = {
     ) {
       const pageId = res.page;
       req.session.clientOauthSessionId = res?.criOAuthSessionId;
-      return res.render(`ipv/${sanitize(pageId)}.njk`, {
-        pageId,
-        csrfToken: req.csrfToken(),
-      });
+      return res.render(`ipv/${sanitize(pageId)}.njk`);
     }
 
     if (res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED) {

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -1,4 +1,3 @@
-const sanitize = require("sanitize-filename");
 const { HTTP_STATUS_CODES } = require("../app.constants");
 const { logError } = require("../app/shared/loggerHelper");
 
@@ -13,16 +12,6 @@ module.exports = {
 
     if (res.headersSent) {
       return next(err);
-    }
-
-    if (
-      res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED &&
-      res?.criOAuthSessionId &&
-      res?.page
-    ) {
-      const pageId = res.page;
-      req.session.clientOauthSessionId = res?.criOAuthSessionId;
-      return res.render(`ipv/${sanitize(pageId)}.njk`);
     }
 
     if (res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED) {

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,5 +1,4 @@
 const sanitize = require("sanitize-filename");
-const { HTTP_STATUS_CODES } = require("../app.constants");
 
 module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
@@ -16,19 +15,13 @@ module.exports = {
 
     res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
 
-    if (
-      res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED &&
-      res.err?.response?.data?.criOAuthSessionId &&
-      res.err?.response?.data?.page
-    ) {
-      const pageId = sanitize(res.err.response.data.page);
-      req.session.clientOauthSessionId =
-        res.err.response.data.criOAuthSessionId;
-      return res.render(`ipv/${pageId}.njk`);
-    }
-
     if (res.err?.response?.data?.page) {
       const pageId = sanitize(res.err.response.data.page);
+
+      if (res.err?.response?.data?.criOAuthSessionId) {
+        req.session.clientOauthSessionId =
+          res.err.response.data.criOAuthSessionId;
+      }
       req.session.currentPage = pageId;
       return res.redirect(`/ipv/page/${pageId}`);
     }

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,4 +1,5 @@
 const sanitize = require("sanitize-filename");
+const { HTTP_STATUS_CODES } = require("../app.constants");
 
 module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
@@ -14,6 +15,17 @@ module.exports = {
     }
 
     res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
+
+    if (
+      res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED &&
+      res.err?.response?.data?.criOAuthSessionId &&
+      res.err?.response?.data?.page
+    ) {
+      const pageId = sanitize(res.err.response.data.page);
+      req.session.clientOauthSessionId =
+        res.err.response.data.criOAuthSessionId;
+      return res.render(`ipv/${pageId}.njk`);
+    }
 
     if (res.err?.response?.data?.page) {
       const pageId = sanitize(res.err.response.data.page);

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -18,9 +18,9 @@ module.exports = {
     if (res.err?.response?.data?.page) {
       const pageId = sanitize(res.err.response.data.page);
 
-      if (res.err?.response?.data?.criOAuthSessionId) {
+      if (res.err?.response?.data?.clientOAuthSessionId) {
         req.session.clientOauthSessionId =
-          res.err.response.data.criOAuthSessionId;
+          res.err.response.data.clientOAuthSessionId;
       }
       req.session.currentPage = pageId;
       return res.redirect(`/ipv/page/${pageId}`);

--- a/src/views/ipv/pyi-timeout-recoverable.njk
+++ b/src/views/ipv/pyi-timeout-recoverable.njk
@@ -13,9 +13,9 @@
   </ul>
   <h2 class="govuk-heading-m">{{'pages.pyiTimeoutRecoverable.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pyiTimeoutRecoverable.content.paragraph2' | translate }}</p>
-  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
+  <form id="timeoutRecoverableForm" action="/ipv/page/pyi-timeout-recoverable" method="POST" onsubmit="return timeoutRecoverableFormSubmit()">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    <input type="hidden" name="journey" value="attempt-recovery">
+    <input type="hidden" name="journey" value="timeout-recoverable">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
       {{'general.buttons.next' | translate }}
     </button>
@@ -23,7 +23,7 @@
 
   <script>
     let disableSubmit = false;
-    function attemptRecoveryFormSubmit() {
+    function timeoutRecoverableFormSubmit() {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Saving criOAuthSessionId into session when there is a error from backend.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2659](https://govukverify.atlassian.net/browse/PYIC-2659)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2659]: https://govukverify.atlassian.net/browse/PYIC-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ