### PR TITLE
PYIC-2660: add ip address to session for cross mobile browser issue, when ip address is not present

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -30,6 +30,7 @@ const { generateHTMLofAddress } = require("../shared/addressHelper");
 const { samplePersistedUserDetails } = require("../shared/debugJourneyHelper");
 const { HTTP_STATUS_CODES } = require("../../app.constants");
 const axios = require("axios");
+const { getIpAddress } = require("../shared/ipAddressHelper");
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -314,6 +315,9 @@ module.exports = {
       } else if (req.body?.journey === "attempt-recovery") {
         await handleJourneyResponse(req, res, "journey/attempt-recovery");
       } else if (req.body?.journey === "build-client-oauth-response") {
+        req.session.ipAddress = req?.session?.ipAddress
+          ? req.session.ipAddress
+          : getIpAddress(req);
         await handleJourneyResponse(
           req,
           res,

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -455,11 +455,12 @@ describe("journey middleware", () => {
         );
       });
 
-      it("should post with journey/build-client-oauth-response", async function () {
+      it("should post with journey/build-client-oauth-response and use ip address from header when not present in session", async function () {
         req = {
           id: "1",
           body: { journey: "build-client-oauth-response" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: { ipvSessionId: "ipv-session-id" },
+          headers: { forwarded: "1.1.1.1" },
           log: { info: sinon.fake(), error: sinon.fake() },
         };
 
@@ -467,6 +468,23 @@ describe("journey middleware", () => {
         expect(axiosStub.post.firstCall).to.have.been.calledWith(
           `${configStub.API_BASE_URL}/journey/build-client-oauth-response`
         );
+        expect(req.session.ipAddress).to.equal("1.1.1.1");
+      });
+
+      it("should post with journey/build-client-oauth-response and use ip address from session when it is present in session", async function () {
+        req = {
+          id: "1",
+          body: { journey: "build-client-oauth-response" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          headers: { forwarded: "1.1.1.1" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/build-client-oauth-response`
+        );
+        expect(req.session.ipAddress).to.equal("ip-address");
       });
 
       it("should post with journey/next by default", async function () {

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -2,8 +2,7 @@ const { API_BASE_URL, API_SESSION_INITIALISE } = require("../../lib/config");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const axios = require("axios");
-
-const IPV4_MATCH = "\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b";
+const { getIpAddress } = require("../shared/ipAddressHelper");
 
 module.exports = {
   setDebugJourneyType: (req, _res, next) => {
@@ -18,16 +17,7 @@ module.exports = {
   },
 
   setIpAddress: (req, res, next) => {
-    if (req.headers && req.headers["forwarded"]) {
-      const ipAddress = req.headers["forwarded"].match(IPV4_MATCH);
-      if (ipAddress) {
-        req.session.ipAddress = ipAddress[0];
-      } else {
-        req.session.ipAddress = "unknown";
-      }
-    } else {
-      req.session.ipAddress = "unknown";
-    }
+    req.session.ipAddress = getIpAddress(req);
     next();
   },
 

--- a/src/app/shared/ipAddressHelper.js
+++ b/src/app/shared/ipAddressHelper.js
@@ -1,0 +1,17 @@
+const unknown = "unknown";
+const IPV4_MATCH = "\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b";
+
+module.exports = {
+  getIpAddress: (req) => {
+    if (req.headers && req.headers["forwarded"]) {
+      const ipAddress = req.headers["forwarded"].match(IPV4_MATCH);
+      if (ipAddress) {
+        return ipAddress[0];
+      } else {
+        return unknown;
+      }
+    } else {
+      return unknown;
+    }
+  },
+};


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Added ip address to the  ipv journey request when it is not present, work around for the cross browser issue.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2660](https://govukverify.atlassian.net/browse/PYIC-2660)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2660]: https://govukverify.atlassian.net/browse/PYIC-2660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ