### PR TITLE
PYIC-2701: Create endpoint for featureSet

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -59,4 +59,18 @@ module.exports = {
 
     next();
   },
+
+  validateFeatureSet: async (req, res, next) => {
+    try {
+      const featureSet = req.query.featureSet;
+      const isValidFeatureSet = /^[a-zA-Z0-9_]{1,32}$/.test(featureSet);
+      if (!isValidFeatureSet) {
+        throw new Error("Invalid feature set ID");
+      }
+      req.session.featureSet = featureSet;
+      next();
+    } catch (error) {
+      return next(error);
+    }
+  },
 };

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -63,7 +63,7 @@ module.exports = {
   validateFeatureSet: async (req, res, next) => {
     try {
       const featureSet = req.query.featureSet;
-      const isValidFeatureSet = /^[a-zA-Z0-9_]{1,32}$/.test(featureSet);
+      const isValidFeatureSet = /^\w{1,32}$/.test(featureSet);
       if (!isValidFeatureSet) {
         throw new Error("Invalid feature set ID");
       }

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -207,7 +207,7 @@ describe("oauth middleware", () => {
     });
   });
 
-  describe("validateFeatureSet", () => {  
+  describe("validateFeatureSet", () => {
     beforeEach(() => {
       req = {
         query: {},
@@ -216,14 +216,14 @@ describe("oauth middleware", () => {
       res = {};
       next = sinon.stub();
     });
-  
+
     it("should call next if featureSet is valid", async () => {
       req.query.featureSet = "F01";
       await middleware.validateFeatureSet(req, res, next);
       expect(req.session.featureSet).to.equal("F01");
       expect(next).to.have.been.calledOnce;
     });
-  
+
     it("should throw an error if featureSet is invalid", async () => {
       req.query.featureSet = "invalid-featureset";
       await middleware.validateFeatureSet(req, res, next);

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -206,4 +206,33 @@ describe("oauth middleware", () => {
       });
     });
   });
+
+  describe("validateFeatureSet", () => {  
+    beforeEach(() => {
+      req = {
+        query: {},
+        session: {},
+      };
+      res = {};
+      next = sinon.stub();
+    });
+  
+    it("should call next if featureSet is valid", async () => {
+      req.query.featureSet = "F01";
+      await middleware.validateFeatureSet(req, res, next);
+      expect(req.session.featureSet).to.equal("F01");
+      expect(next).to.have.been.calledOnce;
+    });
+  
+    it("should throw an error if featureSet is invalid", async () => {
+      req.query.featureSet = "invalid-featureset";
+      await middleware.validateFeatureSet(req, res, next);
+      expect(next).to.have.been.calledWith(
+        sinon.match
+          .instanceOf(Error)
+          .and(sinon.match.has("message", "Invalid feature set ID"))
+      );
+      expect(req.session.featureSet).to.be.undefined;
+    });
+  });
 });

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -7,6 +7,7 @@ const {
   setDebugJourneyType,
   setRealJourneyType,
   setIpAddress,
+  validateFeatureSet,
 } = require("./middleware");
 
 const { handleJourneyAction } = require("../ipv/middleware");
@@ -25,6 +26,11 @@ router.get(
   setIpAddress,
   setIpvSessionId,
   handleJourneyAction
+);
+
+router.get(
+  "/usefeatureset",
+  validateFeatureSet
 );
 
 module.exports = router;

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -28,9 +28,6 @@ router.get(
   handleJourneyAction
 );
 
-router.get(
-  "/usefeatureset",
-  validateFeatureSet
-);
+router.get("/usefeatureset", validateFeatureSet);
 
 module.exports = router;


### PR DESCRIPTION
## Proposed changes

### What changed

Implemented an endpoint on core front that when called will set the id in the session. 
Validates that the value is a string of regex word chars - [a-zA-Z0-9_], max 32 chars.

### Why did it change

We want to be able to selectively enable and disable features of the system in different environments. We also want the ability to do that on a user by user basis. We will do that by setting a feature set id in the session and using the value of that to activate various flags and overrides.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2701](https://govukverify.atlassian.net/browse/PYIC-2701)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2701]: https://govukverify.atlassian.net/browse/PYIC-2701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ