### PR TITLE
added govuk-frontend assets folder to zip

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -31,7 +31,8 @@ jobs:
           cd ${GITHUB_WORKSPACE} || exit 1
           yarn install
           yarn build
-          zip -r ./public.zip ./dist/public/*
+          cp -r ./node_modules/govuk-frontend/govuk/assets ./dist/assets
+          zip -r ./public.zip ./dist/public/* ./dist/assets/*
           md5sum ./public.zip | cut -c -32 > zipsum.txt
           aws kms sign --key-id $ZIP_SIGNING_KEY --message fileb://zipsum.txt --signing-algorithm RSASSA_PSS_SHA_256 --message-type RAW --output text --query Signature | base64 --decode > ZipSignature
           zip -r ./package.zip ./public.zip ./ZipSignature


### PR DESCRIPTION
This adds the assets from the govuk-frontend node module to the assets package which is uploaded to the cloudfront distribution. The assets will be availble under https://.assets.identity.<env>.account.gov.uk/assets 