### PR TITLE
BAU: Changed to minor dependency updates and excluded node.js 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
     - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["17.x","18.x"]
+        versions: ["17.x","18.x","20.x"]
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     commit-message:
       prefix: BAU
   - package-ecosystem: docker


### PR DESCRIPTION
## Proposed changes

### What changed

Updated dependabot configuration:
* Updated to exclude Node.js version 20
* Updated to pick minor version changes, rather than every patch. Security patches will still be included.

### Why did it change

Reduce the number of dependabot PR's which were occurring due to minor patches.

### Issue tracking

None

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None