### PR TITLE
Added an assetsPath variable to be used by gov.uk frontend

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -11,6 +11,7 @@ module.exports = {
     res.locals.scriptNonce = generateNonce();
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.assetsCdnDomain = ASSETS_CDN_DOMAIN;
+    res.locals.assetPath = ASSETS_CDN_DOMAIN + "/assets";
     next();
   },
 };


### PR DESCRIPTION
see references in /node_modules/govuk-frontend/govuk/template.njk this will fallback to /assets if there is no ASSETS_CDN_DOMAIN env var

## Proposed changes

This will update relative path references in the default govuk-frontend templaste to use the CDN

### What changed

Added the optional assetsPath var

### Why did it change

To make the assets load from the CDN

### Issue tracking

PYIC-2652

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
