### PR TITLE
Added step scaling policy to double instances if >80% CPU

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -405,6 +405,30 @@ Resources:
         ScaleInCooldown: 300
         ScaleOutCooldown: 5
 
+  CoreFrontStepScalingPolicy:
+    DependsOn: CoreFrontAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: CoreFrontStepScalingPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref CoreFrontCluster
+          - !GetAtt CoreFrontService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 3
+        StepAdjustments:
+          - MetricIntervalLowerBound: 80
+            MetricIntervalUpperBound: 100
+            ScalingAdjustment: 100
+
+
+
   ECSAccessLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/PYIC-2811

## Proposed changes
This adds a new scaling policy to implement step scaling
It adds a minimum of 3 new instances if >80% cpu is reached, and doubles the instances if there are already >3 running.

### What changed
Added another scaling policy to the ECS task definition

### Why did it change
To reach our performance NFRs
