### PR TITLE
Change Metric Intervals after re-reading docs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -423,8 +423,7 @@ Resources:
         Cooldown: 300
         MinAdjustmentMagnitude: 3
         StepAdjustments:
-          - MetricIntervalLowerBound: 80
-            MetricIntervalUpperBound: 100
+          - MetricIntervalLowerBound: 20
             ScalingAdjustment: 100
 
 


### PR DESCRIPTION
The metric intervals are relative to the alarm threashold, not the metric itself... 