### PR TITLE
Turn down the scaling cooldown period to scale faster

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -423,7 +423,7 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 420
+        Cooldown: 120
         MinAdjustmentMagnitude: 5
         StepAdjustments:
           - MetricIntervalUpperBound: -40


### PR DESCRIPTION
This setting makes the ECS service wait for less time to bring in more tasks