### PR TITLE
BAU: fix broken favicon paths

### DIFF
--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -3,6 +3,9 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+{# The GOV.UK design system uses the assetPath variable in the head block for favicons #}
+{# So set it to the same value as our assetsCdnDomain #}
+{% set assetPath = assetsCdnDomain %}
 {% block head %}
 
     <!--[if !IE 8]><!-->


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change ensures that the paths created by the design system nunjucks include the environment variables we set.

### What changed

<!-- Describe the changes in detail - the "what"-->
`assetPath` used by the design system to build paths is set to the same value as our `assetsCndDomain`.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Without this change local previews of pages do not correctly link to all the assets specified by the design system.
