### PR TITLE
fix the custom metrics for step scaling

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -468,8 +468,11 @@ Resources:
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "2"
       Dimensions:
-        - Name: AutoScalingGroupName
+        - Name: ClusterName
+          Value: !Ref CoreFrontCluster
+        - Name: ServiceName
           Value: !Ref CoreFrontService
+      Unit: "Percent"
       EvaluationPeriods: "2"
       MetricName: "CPUUtilization"
       Namespace: "AWS/EC2"
@@ -488,8 +491,11 @@ Resources:
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "2"
       Dimensions:
-        - Name: AutoScalingGroupName
+        - Name: ClusterName
+          Value: !Ref CoreFrontCluster
+        - Name: ServiceName
           Value: !Ref CoreFrontService
+      Unit: "Percent"
       EvaluationPeriods: "2"
       MetricName: "CPUUtilization"
       Namespace: "AWS/EC2"


### PR DESCRIPTION
This sets the alarms to pick up from the cluster and service name and fire based on the average CPU %