### PR TITLE
Alarm dimension requires a Name not an ARN

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -471,7 +471,7 @@ Resources:
         - Name: ClusterName
           Value: !Ref CoreFrontCluster
         - Name: ServiceName
-          Value: !Ref CoreFrontService
+          Value: !GetAtt CoreFrontService.Name
       Unit: "Percent"
       EvaluationPeriods: "2"
       MetricName: "CPUUtilization"
@@ -494,7 +494,7 @@ Resources:
         - Name: ClusterName
           Value: !Ref CoreFrontCluster
         - Name: ServiceName
-          Value: !Ref CoreFrontService
+          Value: !GetAtt CoreFrontService.Name
       Unit: "Percent"
       EvaluationPeriods: "2"
       MetricName: "CPUUtilization"


### PR DESCRIPTION
This is a tweak to the custom metric configuration to use a correct reference for the ECS