### PR TITLE
PYIC-2840: English-only version of F2F Go to Post Office page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -234,6 +234,7 @@ module.exports = {
           return res.redirect("/debug");
         case "page-ipv-identity-start":
         case "page-ipv-success":
+        case "page-face-to-face-handoff":
         case "page-pre-kbv-transition":
         case "page-dcmaw-success":
         case "page-passport-doc-check":

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -70,3 +70,10 @@
     margin-bottom: 0;
   }
 }
+
+// Style the DS Panel component to indicate a waypoint rather than successful completion of a task
+
+.di-f2f-panel {
+  color: govuk-colour("black");
+  background-color: govuk-colour("light-grey");
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -194,6 +194,29 @@
       "summaryText": "How we know what questions to ask you",
       "summaryHtml": "<p>We’ll work with <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services\">Experian (opens in a new tab)</a> to make sure we ask you questions that only you can answer. This is because companies like Experian have access to lots of information that we can check your answers against.</p><p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/privacy-statement\">Read our privacy notice (opens in a new tab)</a> if you’d like to know more about how your details will be used to prove your identity.</p>"
     },
+    "pageF2fHandoff": {
+      "title": "Go to the Post Office within 10 days to finish proving your identity",
+      "panelText": "Go to the Post Office within 10 days to finish proving your identity",
+      "content": {
+        "paragraph1": "You’ve been sent a confirmation email with a link to download your Post Office customer letter.",
+        "paragraph2": "To finish proving your identity, you need to go to your chosen Post Office within the next 10 days.",
+        "subHeading1": "What you need to take to the Post Office",
+        "paragraph3": "When you go to the Post Office, make sure to take your:",
+        "bullet1": "chosen photo ID",
+        "bullet2": "Post Office customer letter (you can download your letter from your confirmation email)",
+        "subHeading2": "At the Post Office",
+        "paragraph4": "You’ll need to show your Post Office customer letter on your phone or tablet, or take a printed copy with you.",
+        "paragraph5": "A member of Post Office staff will scan your photo ID and take a photo of you.",
+        "paragraph6": "You’ll find details of your chosen Post Office in your customer letter. But you can",
+        "paragraph6LinkText": "go to any Post Office that offers in-branch verification (opens in new tab)",
+        "paragraph6LinkHref": "https://www.postoffice.co.uk/identity/in-branch-verification-service#:~:text=Find%20your%20nearest%20branch",
+        "insetText": "If you do not go to the Post Office within the next 10 days, you’ll need to start proving your identity again.",
+        "subHeading3": "After you’ve been to the Post Office",
+        "paragraph7": "You’ll get an email about the result of your identity check – usually within a day of going to the Post Office.",
+        "subHeading4": "If you need help",
+        "contactLinkHrefF2fCustom": "https://signin.account.gov.uk/contact-us-questions?theme=proving_identity&referer="
+      }
+    },
     "pageDcmawSuccess": {
       "title": "We’ve successfully matched you to the photo on your ID",
       "header": "We’ve successfully matched you to the photo on your ID",

--- a/src/views/ipv/page-face-to-face-handoff.njk
+++ b/src/views/ipv/page-face-to-face-handoff.njk
@@ -1,0 +1,39 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.pageF2fHandoff.title' | translate %}
+{% set googleTagManagerPageId = "pageF2fHandoff" %}
+
+{% block content %}
+
+  {{ govukPanel({
+    titleText: 'pages.pageF2fHandoff.panelText' | translate,
+    classes:"di-f2f-panel govuk-!-margin-bottom-7"
+  }) }}
+
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph2' | translate }}</p>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.subHeading1' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.paragraph3' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{ 'pages.pageF2fHandoff.content.bullet1' | translate }}</li>
+    <li>{{ 'pages.pageF2fHandoff.content.bullet2' | translate }}</li>
+  </ul>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph4' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph5' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph6' | translate }} <a href="{{ 'pages.pageF2fHandoff.content.paragraph6LinkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ 'pages.pageF2fHandoff.content.paragraph6LinkText' | translate }}</a>.</p>
+  {{ govukInsetText({
+    text: 'pages.pageF2fHandoff.content.insetText' | translate
+  }) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.subHeading3' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph7' | translate }}</p>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.subHeading4' | translate }}</h2>
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ 'pages.pageF2fHandoff.content.contactLinkHrefF2fCustom' | translate }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Users taking the F2F route should have their next steps summarised on this page in the journey before they move to their email client to collect the information they need to take to the post office.

### What changed

<!-- Describe the changes in detail - the "what"-->
The new page is named `page-face-to-face-handoff.njk` and can be previewed locally at [http://localhost:3000/ipv/page/page-face-to-face-handoff](http://localhost:3000/ipv/page/page-face-to-face-handoff)

* A new page `page-face-to-face-handoff.njk` has been created. This uses [the DS Panel component](https://design-system.service.gov.uk/components/panel/) for the first time in Core
* `translation.json` is updated with the English content for testing. Setting the language to Welsh will show the English content
* `application.scss` applies more subtle styling to the DS Panel component as designed
* `middleware.js` is updated so that the page can be served

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Part of the updates to core for the F2F journey testing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2840](https://govukverify.atlassian.net/browse/PYIC-2840)


[PYIC-2840]: https://govukverify.atlassian.net/browse/PYIC-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ