### PR TITLE
Pyic 2652 create s 3 bucket cloufront distribution and lambda to upload items invalidate cf cache for build

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -32,11 +32,12 @@ jobs:
           yarn install
           yarn build
           cp -r ./node_modules/govuk-frontend/govuk/assets ./assets
+          cat ./node_modules/govuk-frontend/package.json | jq '.version' | tr -d '"' > ./govuk_fe_version.txt
           cp -r ./dist/public ./public
           zip -r ./public.zip ./public/* ./assets/*
           md5sum ./public.zip | cut -c -32 > zipsum.txt
           aws kms sign --key-id $ZIP_SIGNING_KEY --message fileb://zipsum.txt --signing-algorithm RSASSA_PSS_SHA_256 --message-type RAW --output text --query Signature | base64 --decode > ZipSignature
-          zip -r ./package.zip ./public.zip ./ZipSignature
+          zip -r ./package.zip ./public.zip ./ZipSignature ./gov_uk_version.txt
 
       - name: Push assets and md5sum to S3
         env:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -37,7 +37,7 @@ jobs:
           zip -r ./public.zip ./public/* ./assets/*
           md5sum ./public.zip | cut -c -32 > zipsum.txt
           aws kms sign --key-id $ZIP_SIGNING_KEY --message fileb://zipsum.txt --signing-algorithm RSASSA_PSS_SHA_256 --message-type RAW --output text --query Signature | base64 --decode > ZipSignature
-          zip -r ./package.zip ./public.zip ./ZipSignature ./gov_uk_version.txt
+          zip -r ./package.zip ./public.zip ./ZipSignature ./govuk_fe_version.txt
 
       - name: Push assets and md5sum to S3
         env:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -570,7 +570,7 @@ Resources:
                   "" ]
             - Name: ASSETS_CDN_DOMAIN
               Value: !If [ IsBuild,
-                  "", #"!Sub "https://assets.identity.${Environment}.account.gov.uk", Turned off while developing
+                  !Sub "https://assets.identity.${Environment}.account.gov.uk",
                   "" ]
               #!If [ IsNotDevelopment,
               #    !If [ IsProduction,


### PR DESCRIPTION
Added the version of the govuk-frontend node library to  the uploaded assets artifact to enable version pinning

## Proposed changes
Will upload the assets to a folder like <version>/assets/ 

### What changed
Updated the github action to include a text file of the version number

### Why did it change
To allow version pinning
