### PR TITLE
PYIC-3040: Add radio buttons for the different pathways on the pending page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -356,6 +356,29 @@ module.exports = {
     }
   },
 
+  handlePendingPageOptions: async (req, res, next) => {
+    try {
+      if (!req.session?.ipvSessionId) {
+        const err = new Error("req.ipvSessionId is missing");
+        err.status = HTTP_STATUS_CODES.UNAUTHORIZED;
+        logError(req, err);
+
+        req.session.currentPage = "pyi-technical-unrecoverable";
+        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+      }
+      if (req.body?.journey === "next/continue") {
+        await handleJourneyResponse(req, res, "journey/continue");
+      } else if (req.body?.journey === "next/restart") {
+        await handleJourneyResponse(req, res, "journey/restart");
+      } else if (req.body?.journey === "next/sign-out") {
+        return res.redirect("https://oidc.account.gov.uk/logout");
+      }
+    } catch (error) {
+      transformError(error, "error invoking handlePendingPageOptions");
+      next(error);
+    }
+  },
+
   renderFeatureSetPage: async (req, res) => {
     res.render("ipv/page-featureset.njk", {
       featureSet: req.session.featureSet,

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -670,6 +670,75 @@ describe("journey middleware", () => {
     }
   );
 
+  context(
+    "handlePendingPageOptions: handling journey action with journey/continue, journey/restart, journey/sign-out",
+    () => {
+      it("should post with journey/continue", async function () {
+        req = {
+          id: "1",
+          body: { journey: "next/continue" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handlePendingPageOptions(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/continue`
+        );
+      });
+
+      it("should post with journey/restart", async function () {
+        req = {
+          id: "1",
+          body: { journey: "next/restart" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handlePendingPageOptions(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/restart`
+        );
+      });
+
+      it("should post with journey/sign-out by default", async function () {
+        req = {
+          id: "1",
+          body: { journey: "next/sign-out" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+        await middleware.handlePendingPageOptions(req, res, next);
+
+        expect(res.redirect).to.have.been.calledWith(
+          "https://oidc.account.gov.uk/logout"
+        );
+      });
+    }
+  );
+
+  context(
+    "handlePendingPageOptions: handling missing ipvSessionId before calling the backend",
+    () => {
+      it("should redirect to the technical unrecoverable page", async function () {
+        req = {
+          id: "1",
+          session: {
+            currentPage: "page-ipv-pending",
+            ipvSessionId: null,
+            ipAddress: "ip-address",
+          },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handlePendingPageOptions(req, res, next);
+        expect(res.redirect).to.have.been.calledWith(
+          "/ipv/page/pyi-technical-unrecoverable"
+        );
+      });
+    }
+  );
+
   context("validateFeatureSet", () => {
     beforeEach(() => {
       req = {

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -11,6 +11,7 @@ const {
   handleMultipleDocCheck,
   renderFeatureSetPage,
   validateFeatureSet,
+  handlePendingPageOptions,
 } = require("./middleware");
 
 const csrfProtection = csrf({});
@@ -25,6 +26,12 @@ router.post(
   parseForm,
   csrfProtection,
   handleMultipleDocCheck
+);
+router.post(
+  "/page/page-ipv-pending",
+  parseForm,
+  csrfProtection,
+  handlePendingPageOptions
 );
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -264,7 +264,13 @@
         "subHeading": "If you've already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You'll get an email when there's a result for your identity check - usually within a day of going to the Post Office.",
-        "subHeading2": "If you need help"
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continuePostOfficeButtonText": "Continue to the Post Office",
+          "signOutButtonText": "Sign out and come back when results are ready",
+          "separateOptionsInFormText": "or",
+          "restartButtonText": "Restart and prove your identity online"
+        }
       }
     },
     "pageIpvSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -287,7 +287,13 @@
         "subHeading": "If you've already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You'll get an email when there's a result for your identity check - usually within a day of going to the Post Office.",
-        "subHeading2": "If you need help"
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continuePostOfficeButtonText": "Continue to the Post Office",
+          "signOutButtonText": "Sign out and come back when results are ready",
+          "separateOptionsInFormText": "or",
+          "restartButtonText": "Restart and prove your identity online"
+        }
       }
     },
     "pageIpvSuccess": {

--- a/src/views/ipv/page-ipv-pending.njk
+++ b/src/views/ipv/page-ipv-pending.njk
@@ -1,5 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% set pageTitleName = 'pages.pageIpvPending.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvPending" %}
 
@@ -11,10 +12,49 @@
   <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph3' | translate }}</p>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph4' | translate }}</p>
+
   <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading2' | translate }}</h2>
+
+  <form id="pendingPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return pendingPageOptionsFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    {{ govukRadios({
+    idPrefix: "journey",
+    name: "journey",
+    items: [
+              {
+                value: "next/continue",
+                text: 'pages.pageIpvPending.content.formRadioButtons.continuePostOfficeButtonText' | translate
+              },
+              {
+                value: "next/sign-out",
+                text: 'pages.pageIpvPending.content.formRadioButtons.signOutButtonText' | translate
+              },
+              {
+                divider: 'pages.pageIpvPending.content.formRadioButtons.separateOptionsInFormText' | translate
+              },
+              {
+                value: "next/restart",
+                text: 'pages.pageIpvPending.content.formRadioButtons.restartButtonText' | translate
+              }
+            ]
+      })
+    }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{'general.buttons.next' | translate }}
+    </button>
+  </form>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
 
-  {% include 'shared/journey-next-form.njk' %}
-
+  <script>
+    let disableSubmit = false;
+    function pendingPageOptionsFormSubmit() {
+      if(!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+        return true
+      }
+      return false;
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Below are the new actions from this form:
- journey/continue
- journey/restart

The third option takes the user directly to the sign-out url

Added unit tests to make sure the functionality works in a similar way to the multipleDocCheck

***DISCLAIMER***
The content/translations are still yet to be confirmed, but this will allow us to set up what needs to be done on the backend

<img width="500" alt="Screenshot 2023-06-27 at 15 37 09" src="https://github.com/alphagov/di-ipv-core-front/assets/24409958/63f879dd-6db8-4c84-a699-18e615ae3e5e">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

<!-- Delete/copy as appropriate -->

- [PYIC-3040](https://govukverify.atlassian.net/browse/PYIC-3040)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3040]: https://govukverify.atlassian.net/browse/PYIC-3040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ