### PR TITLE
PYIC-3086 Update pending page content

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -78,3 +78,24 @@
   color: govuk-colour("black");
   background-color: govuk-colour("light-grey");
 }
+
+// To style a form submit button as an inline link
+.govuk-btn-as-link {
+  vertical-align: inherit;
+  border: none;
+  outline: none;
+  background: none;
+  padding: 0;
+  color: $govuk-link-colour;
+  box-shadow: 0px 1px #ffffff;
+  margin: 0;
+  width: auto;
+}
+.govuk-btn-as-link:hover {
+  background: none;
+  color: $govuk-link-visited-colour;
+  text-decoration: underline;
+}
+.govuk-btn-link:hover {
+  background: none;
+}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -271,17 +271,13 @@
       "header": "You have not finished proving your identity",
       "content": {
         "paragraph1": "You need to go to a Post Office that offers in-branch verification to finish proving your identity.",
-        "paragraph2": "You should have received a confirmation email explaining what to take with you and what will happen at the Post Office.",
+        "paragraph2": "You should have received a confirmation email explaining what to take with you and what will happen at the Post Office. Check the letter attached to your confirmation email.",
+        "insetText": "If you'd prefer not to go to the Post Office, you can",
+        "linkText": " prove your identity another way.",
         "subHeading": "If you've already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You'll get an email when there's a result for your identity check - usually within a day of going to the Post Office.",
-        "subHeading2": "What would you like to do?",
-        "formRadioButtons": {
-          "continuePostOfficeButtonText": "Continue to the Post Office",
-          "signOutButtonText": "Sign out and come back when results are ready",
-          "separateOptionsInFormText": "or",
-          "restartButtonText": "Restart and prove your identity online"
-        }
+        "subHeading2": "If you need help"
       }
     },
     "pageIpvSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -294,17 +294,13 @@
       "header": "You have not finished proving your identity",
       "content": {
         "paragraph1": "You need to go to a Post Office that offers in-branch verification to finish proving your identity.",
-        "paragraph2": "You should have received a confirmation email explaining what to take with you and what will happen at the Post Office.",
+        "paragraph2": "You should have received a confirmation email explaining what to take with you and what will happen at the Post Office. Check the letter attached to your confirmation email.",
+        "insetText": "If you'd prefer not to go to the Post Office, you can",
+        "linkText": " prove your identity another way.",
         "subHeading": "If you've already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You'll get an email when there's a result for your identity check - usually within a day of going to the Post Office.",
-        "subHeading2": "What would you like to do?",
-        "formRadioButtons": {
-          "continuePostOfficeButtonText": "Continue to the Post Office",
-          "signOutButtonText": "Sign out and come back when results are ready",
-          "separateOptionsInFormText": "or",
-          "restartButtonText": "Restart and prove your identity online"
-        }
+        "subHeading2": "If you need help"
       }
     },
     "pageIpvSuccess": {

--- a/src/views/ipv/page-ipv-pending.njk
+++ b/src/views/ipv/page-ipv-pending.njk
@@ -1,6 +1,4 @@
 {% extends "shared/base.njk" %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% set pageTitleName = 'pages.pageIpvPending.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvPending" %}
 
@@ -9,52 +7,19 @@
 
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph2' | translate }}</p>
+  <form id="pendingPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <div class="govuk-inset-text">
+      {{'pages.pageIpvPending.content.insetText' | translate }}
+      <input type="hidden" name="journey" value="next">
+      <button id="otherWayLink" data-prevent-double-click="true" class="govuk-button govuk-link govuk-btn-as-link" data-module="govuk-button">{{ 'pages.pageIpvPending.content.linkText' | translate }}</button>
+    </div>
+  </form>
+
   <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph3' | translate }}</p>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph4' | translate }}</p>
 
   <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading2' | translate }}</h2>
-
-  <form id="pendingPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return pendingPageOptionsFormSubmit()">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next/continue",
-                text: 'pages.pageIpvPending.content.formRadioButtons.continuePostOfficeButtonText' | translate
-              },
-              {
-                value: "next/sign-out",
-                text: 'pages.pageIpvPending.content.formRadioButtons.signOutButtonText' | translate
-              },
-              {
-                divider: 'pages.pageIpvPending.content.formRadioButtons.separateOptionsInFormText' | translate
-              },
-              {
-                value: "next/restart",
-                text: 'pages.pageIpvPending.content.formRadioButtons.restartButtonText' | translate
-              }
-            ]
-      })
-    }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
-    </button>
-  </form>
-
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
-
-  <script>
-    let disableSubmit = false;
-    function pendingPageOptionsFormSubmit() {
-      if(!disableSubmit) {
-        disableSubmit = true;
-        document.getElementById('submitButton').disabled = true;
-        return true
-      }
-      return false;
-    }
-  </script>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

Update pending page content. The "prove your identity another way" link is a button styled as a link so we can wrap it in the required form submit for the action - borrowed this pattern from auth it's not ideal but works for now. Welsh translations still TBC.

### Why did it change

Updating content based on new design.

### Issue tracking
- [PYIC-3086](https://govukverify.atlassian.net/browse/PYIC-3086)


[PYIC-3086]: https://govukverify.atlassian.net/browse/PYIC-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ