### PR TITLE
PYIC-3090 Create new cannot prove identity page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -245,6 +245,7 @@ module.exports = {
         case "pyi-kbv-thin-file":
         case "pyi-no-match":
         case "pyi-escape":
+        case "pyi-another-way":
         case "pyi-timeout-recoverable":
         case "pyi-timeout-unrecoverable":
         case "pyi-technical":

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -124,6 +124,15 @@
         }
       }
     },
+    "pyiAnotherWay": {
+      "title": "Profi eich hunaniaeth mewn ffordd arall",
+      "header": "Profi eich hunaniaeth mewn ffordd arall",
+      "content": {
+        "paragraph1": "Yn seiliedig beth rydych wedi'i ddweud wrthym, ni allwch brofi eich hunaniaeth ar-lein gyda GOV.UK One Login.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Ewch yn eich blaen i'r gwasanaeth roeddech chi'n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
+      }
+    },
     "pyiTimeoutRecoverable": {
       "title": "Rydych wedi allgofnodi o’ch GOV.UK One Login",
       "header": "Rydych wedi allgofnodi o’ch GOV.UK One Login",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -124,6 +124,15 @@
         }
       }
     },
+    "pyiAnotherWay": {
+      "title": "Prove your identity another way",
+      "header": "Prove your identity another way",
+      "content": {
+        "paragraph1": "Based on what you told us, you cannot prove your identity online with GOV.UK One Login.",
+        "subHeading": "What you can do",
+        "paragraph2": "Continue to the service you were trying to use and look for other ways to prove your identity."
+      }
+    },
     "pyiTimeoutRecoverable": {
       "title": "You have been signed out of your GOV.UK One Login",
       "header": "You have been signed out of your GOV.UK One Login",

--- a/src/views/ipv/pyi-another-way.njk
+++ b/src/views/ipv/pyi-another-way.njk
@@ -1,0 +1,15 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.pyiAnotherWay.title' | translate %}
+{% set googleTagManagerPageId = "pyiAnotherWay" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pyiAnotherWay.header' | translate }}</h1>
+  <p class="govuk-body">{{'pages.pyiAnotherWay.content.paragraph1' | translate }}</p>
+  <h2 class="govuk-heading-m">{{'pages.pyiAnotherWay.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{'pages.pyiAnotherWay.content.paragraph2' | translate }}</p>
+
+  {% include 'shared/journey-next-form.njk' %}
+
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+{% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

Create new page including Welsh translations, under handle `pyi-another-way`

### Why did it change

New page will follow the 'no' option from the new document start page when F2F is off (and for all journeys initially)

### Issue tracking
- [PYIC-3090](https://govukverify.atlassian.net/browse/PYIC-3090)


[PYIC-3090]: https://govukverify.atlassian.net/browse/PYIC-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1053" alt="Screenshot 2023-07-07 at 11 28 26" src="https://github.com/alphagov/di-ipv-core-front/assets/32681701/86350633-06e8-4a68-8427-7b411289c05e">
