### PR TITLE
PYIC-3171 Update F2F start page to use 'next' and 'end' values

### DIFF
--- a/src/views/ipv/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page-ipv-identity-postoffice-start.njk
@@ -37,11 +37,11 @@
     name: "journey",
     items: [
               {
-                value: "yes",
+                value: "next",
                 text: 'pages.pageIpvIdentityPostofficeStart.content.formRadioButtons.yes' | translate
               },
               {
-                value: "no",
+                value: "end",
                 text: 'pages.pageIpvIdentityPostofficeStart.content.formRadioButtons.no' | translate
               }
             ]


### PR DESCRIPTION
## Proposed changes

### What changed

Update F2F start page to use 'next' and 'end' values

### Why did it change

We can make use of the 'next' and 'end' form values that are already handled rather than having to create a custom handler for this page

### Issue tracking
- [PYIC-3171](https://govukverify.atlassian.net/browse/PYIC-3171)


[PYIC-3171]: https://govukverify.atlassian.net/browse/PYIC-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ