### PR TITLE
PYIC-3185: Add sign out banner to all pages

### DIFF
--- a/src/views/ipv/page-ipv-reuse.njk
+++ b/src/views/ipv/page-ipv-reuse.njk
@@ -5,10 +5,6 @@
 {% set pageTitleName = 'pages.pageIpvReuse.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvReuse" %}
 
-{% block header %}
-    {% include 'shared/sign-out-header.njk' %}
-{% endblock %}
-
 {% block content %}
     <h1 class="govuk-heading-l" id="header"
         data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvReuse.header' | translate }}</h1>

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -37,9 +37,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({
-        homepageUrl: 'general.header.homepageHref' | translate
-    }) }}
+    {% include 'shared/sign-out-header.njk' %}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add sign out banner to all pages

### Why did it change

Soon the page-ipv-indentity-start page will be replaced, at the moment we only have the sign out banner on the soon to be old start page. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3185](https://govukverify.atlassian.net/browse/PYIC-3185)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3185]: https://govukverify.atlassian.net/browse/PYIC-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ