### PR TITLE
PYIC-2855 Update IPV re-use page and typographical details

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -268,82 +268,82 @@
           "updateDetailsLabel": "Sut i ddiweddaru eich manylion",
           "updateDetailsHtml": "Cysylltwch â thîm cymorth <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">GOV.UK One Login (agor mewn tab newydd)</a>."
         }
-    },
-    "pageIpvPending": {
-      "title": "Nid ydych wedi gorffen profi eich hunaniaeth",
-      "header": "Nid ydych wedi gorffen profi eich hunaniaeth",
-      "content": {
-        "paragraph1": "Mae angen i chi fynd i Swyddfa’r Post sy’n cynnig dilysu mewn canghennau i orffen profi eich hunaniaeth.",
-        "paragraph2": "Dylech fod wedi derbyn e-bost cadarnhau yn esbonio beth i fynd gyda chi a beth fydd yn digwydd yn Swyddfa’r Post. Gwiriwch y llythyr yn eich e-bost cadarnhau.",
-        "subHeading": "Os ydych eisoes wedi bod i Swyddfa’r Post",
-        "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
-        "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
-        "subHeading2": "Os ydych angen help",
-        "paragraph5": "Contact us if you:",
-        "list1": "need help to finish proving your identity with the Post Office",
-        "list2": "would prefer not to go to the Post Office and want to prove your identity another way"
-      }
-    },
-    "pageIpvSuccess": {
-      "title": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
-      "header": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
-      "content": {
-        "paragraph1": "Rydych wedi profi pwy ydych chi’n llwyddiannus. Gallwch nawr barhau i’r gwasanaeth rydych eisiau ei ddefnyddio.",
-        "paragraph2": "Gallai rhywfaint o’r wybodaeth a rannwyd gennych pan wnaethoch brofi pwy ydych chi gael ei defnyddio i lenwi ffurflenni yn awtomatig o fewn y gwasanaeth."
-      }
-    },
-    "pageIpvIdentityDocumentStart": {
-      "title": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
-      "header": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
-      "content": {
-        "paragraph": "Bydd hyn yn ein helpu i ddod o hyd i’r ffordd orau i chi brofi eich hunaniaeth.",
-        "subHeading": "Trwydded yrru cerdyn gyda llun y DU",
-        "paragraph1": "Gallwch ddefnyddio trwydded yrru y DU os yw:",
-        "list1": "yn cynnwys eich llun",
-        "list2": "heb ddod i ben",
-        "paragraph2": "Gall fod yn drwydded yrru y DU llawn neu dros dro.",
-        "subHeading2": "Pasbort y DU",
-        "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU. Os yw’ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi eich hunaniaeth hyd at 18 mis ar ôl ei ddyddiad dod i ben.",
-        "subHeading3": "Pasbort o’r tu allan i’r DU gyda sglodion biometrig",
-        "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU os:",
-        "list3": "mae ganddo sglodyn biometrig",
-        "list4": "nid yw wedi dod i ben",
-        "paragraph5": "I wirio os oes gan eich pasbort sglodyn biometrig, edrychwch am y symbol sglodyn biometrig petryal ar y clawr blaen.",
-        "imgAltText": "Clawr blaen pasbort gyda’r symbol sglodyn biometrig. Mae’r symbol yn betryal gyda chylch yn y canol.",
-        "subHeading4": "Trwydded breswylio biometrig y DU",
-        "paragraph6": "Gallwch ddefnyddio trwydded breswylio biometrig (BRP) y DU sydd heb ddod i ben.",
-        "subHeading5": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
-        "formRadioButtons": {
-          "yes": "Oes",
-          "no": "Na"
+      },
+      "pageIpvPending": {
+        "title": "Nid ydych wedi gorffen profi eich hunaniaeth",
+        "header": "Nid ydych wedi gorffen profi eich hunaniaeth",
+        "content": {
+          "paragraph1": "Mae angen i chi fynd i Swyddfa’r Post sy’n cynnig dilysu mewn canghennau i orffen profi eich hunaniaeth.",
+          "paragraph2": "Dylech fod wedi derbyn e-bost cadarnhau yn esbonio beth i fynd gyda chi a beth fydd yn digwydd yn Swyddfa’r Post. Gwiriwch y llythyr yn eich e-bost cadarnhau.",
+          "subHeading": "Os ydych eisoes wedi bod i Swyddfa’r Post",
+          "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
+          "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
+          "subHeading2": "Os ydych angen help",
+          "paragraph5": "Contact us if you:",
+          "list1": "need help to finish proving your identity with the Post Office",
+          "list2": "would prefer not to go to the Post Office and want to prove your identity another way"
         }
-      }
-    },
-    "pageIpvIdentityPostofficeStart": {
-      "title": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
-      "header": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
-      "content": {
-        "paragraph1": "Yn seiliedig ar yr hyn a ddywedoch wrthym, ni allwch brofi eich hunaniaeth ar-lein.",
-        "paragraph2": "Os oes gennych unrhyw un o’r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa’r Post yn lle hynny.",
-        "subHeading": "Trwydded yrru cerdyn gyda llun yr Undeb Ewropeaidd (UE)",
-        "paragraph3": "Gallwch ddefnyddio trwydded yrru’r UE os:",
-        "list1": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
-        "list2": "nid yw wedi dod i ben",
-        "list3": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "subHeading2": "Pasbort o’r tu allan i’r DU",
-        "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU cyn belled nad yw wedi dod i ben.",
-        "subHeading3": "Cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd",
-        "paragraph5": "Gallwch ddefnyddio cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd os:",
-        "list4": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
-        "list5": "nid yw wedi dod i ben",
-        "list6": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "paragraph6": "Mae’r AEE yn cynnwys gwledydd yr UE, Norwy, Gwlad yr Iâ a Liechtenstein.",
-        "subHeading4": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
-        "formRadioButtons": {
-          "yes": "Oes",
-          "no": "Na"
+      },
+      "pageIpvSuccess": {
+        "title": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
+        "header": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
+        "content": {
+          "paragraph1": "Rydych wedi profi pwy ydych chi’n llwyddiannus. Gallwch nawr barhau i’r gwasanaeth rydych eisiau ei ddefnyddio.",
+          "paragraph2": "Gallai rhywfaint o’r wybodaeth a rannwyd gennych pan wnaethoch brofi pwy ydych chi gael ei defnyddio i lenwi ffurflenni yn awtomatig o fewn y gwasanaeth."
         }
-      }
+      },
+      "pageIpvIdentityDocumentStart": {
+        "title": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
+        "header": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
+        "content": {
+          "paragraph": "Bydd hyn yn ein helpu i ddod o hyd i’r ffordd orau i chi brofi eich hunaniaeth.",
+          "subHeading": "Trwydded yrru cerdyn gyda llun y DU",
+          "paragraph1": "Gallwch ddefnyddio trwydded yrru y DU os yw:",
+          "list1": "yn cynnwys eich llun",
+          "list2": "heb ddod i ben",
+          "paragraph2": "Gall fod yn drwydded yrru y DU llawn neu dros dro.",
+          "subHeading2": "Pasbort y DU",
+          "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU. Os yw’ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi eich hunaniaeth hyd at 18 mis ar ôl ei ddyddiad dod i ben.",
+          "subHeading3": "Pasbort o’r tu allan i’r DU gyda sglodion biometrig",
+          "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU os:",
+          "list3": "mae ganddo sglodyn biometrig",
+          "list4": "nid yw wedi dod i ben",
+          "paragraph5": "I wirio os oes gan eich pasbort sglodyn biometrig, edrychwch am y symbol sglodyn biometrig petryal ar y clawr blaen.",
+          "imgAltText": "Clawr blaen pasbort gyda’r symbol sglodyn biometrig. Mae’r symbol yn betryal gyda chylch yn y canol.",
+          "subHeading4": "Trwydded breswylio biometrig y DU",
+          "paragraph6": "Gallwch ddefnyddio trwydded breswylio biometrig (BRP) y DU sydd heb ddod i ben.",
+          "subHeading5": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
+          "formRadioButtons": {
+            "yes": "Oes",
+            "no": "Na"
+          }
+        }
+      },
+      "pageIpvIdentityPostofficeStart": {
+        "title": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
+        "header": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
+        "content": {
+          "paragraph1": "Yn seiliedig ar yr hyn a ddywedoch wrthym, ni allwch brofi eich hunaniaeth ar-lein.",
+          "paragraph2": "Os oes gennych unrhyw un o’r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa’r Post yn lle hynny.",
+          "subHeading": "Trwydded yrru cerdyn gyda llun yr Undeb Ewropeaidd (UE)",
+          "paragraph3": "Gallwch ddefnyddio trwydded yrru’r UE os:",
+          "list1": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
+          "list2": "nid yw wedi dod i ben",
+          "list3": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
+          "subHeading2": "Pasbort o’r tu allan i’r DU",
+          "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU cyn belled nad yw wedi dod i ben.",
+          "subHeading3": "Cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd",
+          "paragraph5": "Gallwch ddefnyddio cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd os:",
+          "list4": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
+          "list5": "nid yw wedi dod i ben",
+          "list6": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
+          "paragraph6": "Mae’r AEE yn cynnwys gwledydd yr UE, Norwy, Gwlad yr Iâ a Liechtenstein.",
+          "subHeading4": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
+          "formRadioButtons": {
+            "yes": "Oes",
+            "no": "Na"
+          }
+        }
       }
     }
   }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -280,9 +280,9 @@
         "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
         "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
         "subHeading2": "Os ydych angen help",
-        "paragraph5": "Contact us if you:",
-        "list1": "need help to finish proving your identity with the Post Office",
-        "list2": "would prefer not to go to the Post Office and want to prove your identity another way"
+        "paragraph5": "Cysylltwch â ni os:",
+        "list1": "ydych angen help i orffen profi eich hunaniaeth gyda Swyddfa’r Post",
+        "list2": "hoffech beidio â mynd i Swyddfa’r Post ac eisiau profi eich hunaniaeth mewn ffordd arall"
       }
     },
     "pageIpvSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -119,7 +119,7 @@
       "content": {
         "subHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "otherWayButtonText": "Mynd ymlaen i'r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
+          "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
           "restartButtonText": "Ceisio profi eich hunaniaeth gyda GOV.UK One Login eto"
         }
       }
@@ -253,9 +253,11 @@
       "title": "Rydych wedi profi pwy ydych chi yn barod",
       "header": "Rydych wedi profi pwy ydych chi yn barod",
       "content": {
-        "paragraph1": "Rydych wedi profi pwy ydych chi gyda GOV.UK One Login o’r blaen. Nid oes angen i chi wneud hyn eto i ddefnyddio’r gwasanaeth hwn.",
+        "paragraph1": "Rydych eisoes wedi profi eich hunaniaeth gyda GOV.UK One Login. Byddech wedi gwneud hyn ar-lein neu’n bersonol yn Swyddfa’r Post.",
+        "paragraph2": "Gallwch nawr barhau i’r gwasanaeth rydych angen ei ddefnyddio.",
         "subHeading": "Gwirio eich manylion",
-        "paragraph2": "Os nad ydych wedi mewngofnodi i’ch GOV.UK One Login am beth amser, efallai y byddwch eisiau edrych i weld os yw eich manylion yn dal yn gywir.",
+        "paragraph3": "Fe wnaethoch gyflwyno’r manylion canlynol pan wnaethoch brofi eich hunaniaeth. Efallai y byddwch am wirio bod eich manylion yn dal yn gywir os nad ydych wedi mewngofnodi i GOV.UK One Login ers peth amser.",
+        "paragraph4": "Efallai y bydd rhai o’r manylion hyn yn cael eu defnyddio i lenwi’r ffurflenni yn awtomatig yn y gwasanaeth rydych angen ei ddefnyddio.",
         "userDetailsInformation": {
           "fullName": "Enw",
           "dateOfBirth": "Dyddiad geni",
@@ -264,19 +266,18 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "Sut i ddiweddaru eich manylion",
-          "updateDetailsHtml": "Gallwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">gysylltu â’r tîm GOV.UK One Login (agor mewn tab newydd)</a> i ddiweddaru eich manylion."
+          "updateDetailsHtml": "Cysylltwch â thîm cymorth <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">GOV.UK One Login (agor mewn tab newydd)</a>."
         }
-      }
     },
     "pageIpvPending": {
       "title": "Nid ydych wedi gorffen profi eich hunaniaeth",
       "header": "Nid ydych wedi gorffen profi eich hunaniaeth",
       "content": {
-        "paragraph1": "Mae angen i chi fynd i Swyddfa'r Post sy'n cynnig dilysu mewn canghennau i orffen profi eich hunaniaeth.",
-        "paragraph2": "Dylech fod wedi derbyn e-bost cadarnhau yn esbonio beth i fynd gyda chi a beth fydd yn digwydd yn Swyddfa'r Post. Gwiriwch y llythyr yn eich e-bost cadarnhau.",
-        "subHeading": "Os ydych eisoes wedi bod i Swyddfa'r Post",
+        "paragraph1": "Mae angen i chi fynd i Swyddfa’r Post sy’n cynnig dilysu mewn canghennau i orffen profi eich hunaniaeth.",
+        "paragraph2": "Dylech fod wedi derbyn e-bost cadarnhau yn esbonio beth i fynd gyda chi a beth fydd yn digwydd yn Swyddfa’r Post. Gwiriwch y llythyr yn eich e-bost cadarnhau.",
+        "subHeading": "Os ydych eisoes wedi bod i Swyddfa’r Post",
         "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
-        "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i'ch gwiriad hunaniaeth - fel arfer o fewn diwrnod o fynd i Swyddfa'r Post.",
+        "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
         "subHeading2": "Os ydych angen help",
         "paragraph5": "Contact us if you:",
         "list1": "need help to finish proving your identity with the Post Office",
@@ -319,29 +320,30 @@
       }
     },
     "pageIpvIdentityPostofficeStart": {
-      "title": "Profi eich hunaniaeth mewn Swyddfa'r Post gydag un o'r mathau canlynol o ID gyda lun",
-      "header": "Profi eich hunaniaeth mewn Swyddfa'r Post gydag un o'r mathau canlynol o ID gyda lun",
+      "title": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
+      "header": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
       "content": {
         "paragraph1": "Yn seiliedig ar yr hyn a ddywedoch wrthym, ni allwch brofi eich hunaniaeth ar-lein.",
-        "paragraph2": "Os oes gennych unrhyw un o'r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa'r Post yn lle hynny.",
+        "paragraph2": "Os oes gennych unrhyw un o’r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa’r Post yn lle hynny.",
         "subHeading": "Trwydded yrru cerdyn gyda llun yr Undeb Ewropeaidd (UE)",
-        "paragraph3": "Gallwch ddefnyddio trwydded yrru'r UE os:",
-        "list1": "mae'n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
+        "paragraph3": "Gallwch ddefnyddio trwydded yrru’r UE os:",
+        "list1": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
         "list2": "nid yw wedi dod i ben",
-        "list3": "mae'r cyfeiriad arno yr un fath â'ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "subHeading2": "Pasbort o'r tu allan i'r DU",
-        "paragraph4": "Gallwch ddefnyddio pasbort o'r tu allan i'r DU cyn belled nad yw wedi dod i ben.",
+        "list3": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
+        "subHeading2": "Pasbort o’r tu allan i’r DU",
+        "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU cyn belled nad yw wedi dod i ben.",
         "subHeading3": "Cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd",
         "paragraph5": "Gallwch ddefnyddio cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd os:",
-        "list4": "mae'n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
+        "list4": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
         "list5": "nid yw wedi dod i ben",
-        "list6": "mae'r cyfeiriad arno yr un fath â'ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "paragraph6": "Mae'r AEE yn cynnwys gwledydd yr UE, Norwy, Gwlad yr Iâ a Liechtenstein.",
-        "subHeading4": "Oes gennych chi unrhyw un o'r mathau hyn o ID gyda llun?",
+        "list6": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
+        "paragraph6": "Mae’r AEE yn cynnwys gwledydd yr UE, Norwy, Gwlad yr Iâ a Liechtenstein.",
+        "subHeading4": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
         }
+      }
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -276,9 +276,11 @@
       "title": "You have already proved your identity",
       "header": "You have already proved your identity",
       "content": {
-        "paragraph1": "You proved your identity when you used GOV.UK One Login before. You will not need to do it again to use this service.",
+        "paragraph1": "You have already proved your identity with GOV.UK One Login. You would have done this online or in person at the Post Office.",
+        "paragraph2": "You can now continue to the service you need to use.",
         "subHeading": "Check your details",
-        "paragraph2": "If you have not signed in to GOV.UK One Login in a while, you might want to check your details are still correct.",
+        "paragraph3": "You submitted the following details when you proved your identity. You might want to check your details are still correct if you’ve not signed in to GOV.UK One Login in a while.",
+        "paragraph4": "Some of these details might be used to automatically fill in the forms within the service you need to use.",
         "userDetailsInformation": {
           "fullName": "Name",
           "dateOfBirth": "Date of birth",
@@ -287,7 +289,7 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "How to update your details",
-          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">contact the GOV.UK One Login team (opens in a new tab)</a> to update your details."
+          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/contact-us?supportType=PUBLIC\">contact the GOV.UK One Login team (opens in new tab)</a> to update your details."
         }
       }
     },
@@ -299,7 +301,7 @@
         "paragraph2": "You should have received a confirmation email explaining what to take with you and what will happen at the Post Office. Check the letter in your confirmation email.",
         "subHeading": "If you’ve already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
-        "paragraph4": "You’ll get an email when there's a result for your identity check - usually within a day of going to the Post Office.",
+        "paragraph4": "You’ll get an email when there’s a result for your identity check - usually within a day of going to the Post Office.",
         "subHeading2": "If you need help",
         "paragraph5": "Contact us if you:",
         "list1": "need help to finish proving your identity with the Post Office",

--- a/src/views/ipv/page-ipv-reuse.njk
+++ b/src/views/ipv/page-ipv-reuse.njk
@@ -13,8 +13,10 @@
     <h1 class="govuk-heading-l" id="header"
         data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvReuse.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph1' | translate }}</p>
-    <h2 class="govuk-heading-m">{{ 'pages.pageIpvReuse.content.subHeading' | translate }}</h2>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph2' | translate }}</p>
+    <h2 class="govuk-heading-m">{{ 'pages.pageIpvReuse.content.subHeading' | translate }}</h2>
+    <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph4' | translate }}</p>
 
     {% set rows = [
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR updates the content for the IPV re-use page and changes all use of ' in text strings to typographically correct apostrophes.

### What changed

The welsh and english translation.json files.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Links to wider content changes for the F2F journey

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2855](https://govukverify.atlassian.net/browse/PYIC-2855)




[PYIC-2855]: https://govukverify.atlassian.net/browse/PYIC-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ