### PR TITLE
PYIC-2886 Update face to face Post Office instructions page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -208,6 +208,32 @@
       "summaryText": "Sut rydym yn gwybod pa gwestiynau i’w gofyn i chi",
       "summaryHtml": "<p>Byddwn yn gweithio gyda <a class=\"govuk-link\"  target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services\">Experian (agor mewn tab newydd)</a> i wneud yn siwr ein bod yn gofyn cwestiynau i chi mai dim ond chi sy’n gallu eu hateb. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at lawer o wybodaeth y gallwn wirio’ch atebion yn eu herbyn.</p><p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://signin.account.gov.uk/privacy-statement\">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>"
     },
+    "pageF2fHandoff": {
+      "title": "Ewch i Swyddfa’r Post o fewn 10 diwrnod i orffen profi eich hunaniaeth",
+      "panelText": "Ewch i Swyddfa’r Post o fewn 10 diwrnod i orffen profi eich hunaniaeth",
+      "content": {
+        "paragraph1": "Anfonwyd e-bost cadarnhau atoch gyda dolen i lawrlwytho eich llythyr cwsmer Swyddfa’r Post.",
+        "paragraph2": "I orffen profi eich hunaniaeth, mae angen i chi fynd i Swyddfa’r Post o’ch dewis o fewn y 10 diwrnod nesaf.",
+        "subHeading1": "Beth sydd angen i chi fynd gyda chi i Swyddfa’r Post",
+        "paragraph3": "Pan fyddwch yn mynd i Swyddfa’r Post, gwnewch yn siwr eich bod yn mynd â’ch:",
+        "bullet1": "ID gyda llun a ddewiswyd",
+        "bullet2": "Llythyr cwsmer Swyddfa’r Post (gallwch lawrlwytho eich llythyr o’ch e-bost cadarnhau)",
+        "subHeading2": "Yn y Swyddfa Bost",
+        "paragraph4": "Bydd angen i chi ddangos eich llythyr cwsmer Swyddfa’r Post ar eich ffôn neu dabled, neu fynd â chopi wedi’i argraffu gyda chi.",
+        "paragraph5": "Bydd aelod o staff Swyddfa’r Post yn sganio’ch ID gyda llun ac yn tynnu llun ohonoch chi.",
+        "paragraph6": "Fe welwch fanylion eich Swyddfa’r Post dewisol yn eich llythyr cwsmer. Ond gallwch",
+        "paragraph6LinkText": "fynd i unrhyw Swyddfa’r Post sy’n cynnig dilysu mewn canghennau (agor mewn tab newydd)",
+        "paragraph6LinkHref": "https://www.postoffice.co.uk/identity/in-branch-verification-service#bf-full-width",
+        "insetText": "Os na fyddwch yn mynd i Swyddfa’r Post o fewn y 10 diwrnod nesaf, bydd angen i chi ddechrau profi eich hunaniaeth eto.",
+        "subHeading3": "Ar ôl i chi fynd i Swyddfa’r Post",
+        "paragraph7": "Fe gewch e-bost am ganlyniad eich gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
+        "subHeading4": "Os ydych angen help",
+        "paragraph8": "Cysylltwch â ni os:",
+        "bullet3": "ydych angen help i orffen profi eich hunaniaeth gyda Swyddfa’r Post",
+        "bullet4": "hoffech beidio â mynd i Swyddfa’r Post ac eisiau profi eich hunaniaeth mewn ffordd arall",
+        "contactLinkHrefF2fCustom": "https://signin.account.gov.uk/contact-us-questions?theme=proving_identity&referer="
+      }
+    },
     "pageDcmawSuccess": {
       "title": "Rydym wedi llwyddo i’ch paru chi â’r ID gyda llun",
       "header": "Rydym wedi llwyddo i’ch paru chi â’r ID gyda llun",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -223,11 +223,14 @@
         "paragraph5": "A member of Post Office staff will scan your photo ID and take a photo of you.",
         "paragraph6": "You’ll find details of your chosen Post Office in your customer letter. But you can",
         "paragraph6LinkText": "go to any Post Office that offers in-branch verification (opens in new tab)",
-        "paragraph6LinkHref": "https://www.postoffice.co.uk/identity/in-branch-verification-service#:~:text=Find%20your%20nearest%20branch",
+        "paragraph6LinkHref": "https://www.postoffice.co.uk/identity/in-branch-verification-service#bf-full-width",
         "insetText": "If you do not go to the Post Office within the next 10 days, you’ll need to start proving your identity again.",
         "subHeading3": "After you’ve been to the Post Office",
         "paragraph7": "You’ll get an email about the result of your identity check – usually within a day of going to the Post Office.",
         "subHeading4": "If you need help",
+        "paragraph8": "Contact us if you:",
+        "bullet3": "need help to finish proving your identity with the Post Office",
+        "bullet4": "would prefer not to go to the Post Office and want to prove your identity another way",
         "contactLinkHrefF2fCustom": "https://signin.account.gov.uk/contact-us-questions?theme=proving_identity&referer="
       }
     },

--- a/src/views/ipv/page-face-to-face-handoff.njk
+++ b/src/views/ipv/page-face-to-face-handoff.njk
@@ -34,6 +34,12 @@
   <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph7' | translate }}</p>
 
   <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageF2fHandoff.content.subHeading4' | translate }}</h2>
+
+  <p class="govuk-body">{{ 'pages.pageF2fHandoff.content.paragraph8' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{ 'pages.pageF2fHandoff.content.bullet3' | translate }}</li>
+    <li>{{ 'pages.pageF2fHandoff.content.bullet4' | translate }}</li>
+  </ul>
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ 'pages.pageF2fHandoff.content.contactLinkHrefF2fCustom' | translate }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
 
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Updates to the `page-face-to-face-handoff.njk` page content instructing users to go to the post office.

### What changed

<!-- Describe the changes in detail - the "what"-->
Additions to the existing English content and the addition of the Welsh translation in the content json files. The anchor link to the page on the Post Office website has been changed to support as many browsers as possible.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To support all users.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2886](https://govukverify.atlassian.net/browse/PYIC-2886)




[PYIC-2886]: https://govukverify.atlassian.net/browse/PYIC-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ