### PR TITLE
BAU: update asset path for image to use .env value

### DIFF
--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -31,8 +31,8 @@
       </ul>
       <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph5' | translate }}</p>
       <picture>
-        <source srcset="/public/images/passport-icon.svg" />
-        <img width="174" height="121" loading="lazy" src="/public/images/passport-icon-1x.png" srcset="/public/images/passport-icon-2x.png 2x" alt="{{'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}" />
+        <source srcset="{{ assetsCdnDomain }}/public/images/passport-icon.svg" />
+        <img width="174" height="121" loading="lazy" src="{{ assetsCdnDomain }}/public/images/passport-icon-1x.png" srcset="{{ assetsCdnDomain }}/public/images/passport-icon-2x.png 2x" alt="{{'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}" />
       </picture>
     </li>
     <li>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add the environment variable to the path for the image asset on this page

### What changed

Path has been updated in the HTML

### Why did it change

So the image path is set to use the cached published assets.
