### PR TITLE
PYIC-2873 Show date of birth on ipv-reuse in GDS standard format

### DIFF
--- a/src/app/shared/debugJourneyHelper.js
+++ b/src/app/shared/debugJourneyHelper.js
@@ -1,0 +1,32 @@
+module.exports = {
+  samplePersistedUserDetails: {
+    data: {
+      name: "Alessandro Cholmondeley-Featherstonehaugh",
+      dateOfBirth: "1984-02-29",
+      addresses: [
+        {
+          subBuildingName: "Flat 24",
+          buildingName: "Wollatorn House",
+          buildingNumber: "7",
+          streetName: "Batchelor Street",
+          addressLocality: "London",
+          postalCode: "N15 0EY",
+        },
+        {
+          subBuildingName: "Flat 18",
+          buildingName: "The Paper Apartments",
+          buildingNumber: "162",
+          streetName: "Offord Road",
+          addressLocality: "London",
+          postalCode: "N2 1NS",
+        },
+        {
+          buildingNumber: "7",
+          streetName: "Acorne Terrace",
+          addressLocality: "London",
+          postalCode: "N16 4QF",
+        },
+      ],
+    },
+  },
+};

--- a/src/app/shared/debugJourneyHelper.js
+++ b/src/app/shared/debugJourneyHelper.js
@@ -4,6 +4,24 @@ module.exports = {
       name: "Alessandro Cholmondeley-Featherstonehaugh",
       dateOfBirth: "1984-02-29",
       addresses: [
+        // all possible address parts
+        // for explanations of each part
+        // https://alliescomputing.com/knowledge-base/glossary-of-address-terms
+        // https://docs.ideal-postcodes.co.uk/docs/data/paf
+        {
+          departmentName: "Room 25",
+          organisationName: "Turing House",
+          subBuildingName: "Block 4b",
+          buildingName: "Vital Living",
+          buildingNumber: "1",
+          dependentStreetName: "Circular Square",
+          streetName: "7 O'Reilly Way",
+          doubleDependentAddressLocality: "Oxford Lane",
+          dependentAddressLocality: "University Quarter",
+          addressLocality: "Lancaster",
+          postalCode: "M12 7LU",
+        },
+        // example addresses
         {
           subBuildingName: "Flat 24",
           buildingName: "Wollatorn House",

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -14,6 +14,19 @@ module.exports = {
       return translate(key, options);
     });
 
+    nunjucksEnv.addFilter("GDSDate", function (formatDate) {
+      let dateTransform = new Date(formatDate);
+      let dateFormat = "en-GB"; // only using 'en' uses American month-first date formatting
+      if (this.ctx.i18n.language === "cy") {
+        dateFormat = "cy";
+      }
+      return dateTransform.toLocaleDateString(dateFormat, {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      });
+    });
+
     return nunjucksEnv;
   },
 };

--- a/src/views/ipv/page-ipv-reuse.njk
+++ b/src/views/ipv/page-ipv-reuse.njk
@@ -28,7 +28,7 @@
                 text: 'pages.pageIpvReuse.content.userDetailsInformation.dateOfBirth' | translate
             },
             value: {
-                text: userDetails.dateOfBirth
+                text: userDetails.dateOfBirth | GDSDate
             }
         }
     ] %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change shows birth dates in the [standard GDS style guide format](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) which are both easier to read and are easier to parse when announced by a screenreader.

### What changed

A new nunjucks filter for dates is available, called `GDSDate`, and there is an updated sample date that tests a leap year is formatted correctly.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Using this format makes it easier for users to identify if we have recorded their data correctly: see date example screenshot which transforms `1984-02-29` into `29 February 1984`.
<img width="1810" alt="Screenshot 2023-07-19 at 11 07 12" src="https://github.com/alphagov/di-ipv-core-front/assets/101639632/991557e4-0572-4daa-97d2-d5e1a472578c">


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2873](https://govukverify.atlassian.net/browse/PYIC-2873)


[PYIC-2873]: https://govukverify.atlassian.net/browse/PYIC-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ