### PR TITLE
PYIC-2874 Remove blank lines from address formatting

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -529,7 +529,7 @@ describe("journey middleware", () => {
           {
             label: "Some label",
             addressDetailHtml:
-              "My deparment My company Room 5 my building<br>1 My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode",
+              "My deparment, My company, Room 5, my building<br>1 My outter street my inner street<br>My double dependant town my dependant town my town<br>myCode",
           },
         ],
       };

--- a/src/app/shared/addressHelper.js
+++ b/src/app/shared/addressHelper.js
@@ -1,10 +1,12 @@
-// functions duplicated from address cri
+// functions duplicated from address CRI
+// updated Jul 2023 to remove blank lines in content
+
 module.exports = {
   generateHTMLofAddress: function (address) {
     const { buildingNames, streetNames, localityNames } =
       extractAddressFields(address);
 
-    const fullBuildingName = buildingNames.join(" ");
+    const fullBuildingName = buildingNames.join(", ");
     let fullStreetName;
     if (streetNames) {
       fullStreetName = streetNames.join(" ");
@@ -13,9 +15,13 @@ module.exports = {
     const fullLocality = localityNames.join(" ");
 
     if (fullStreetName) {
-      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}`;
+      if (fullBuildingName) {
+        return `${fullBuildingName}<br>${fullStreetName}<br>${fullLocality}<br>${address.postalCode}`;
+      } else {
+        return `${fullStreetName}<br>${fullLocality}<br>${address.postalCode}`;
+      }
     } else {
-      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}`;
+      return `${fullBuildingName}<br>${fullLocality}<br>${address.postalCode}`;
     }
   },
 };

--- a/src/app/shared/addressHelper.test.js
+++ b/src/app/shared/addressHelper.test.js
@@ -19,7 +19,7 @@ describe("Address Helper", () => {
             addressLocality: "my town",
             postalCode: "myCode",
           },
-          text: "My department My company Room 5 my building<br>1 My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode",
+          text: "My department, My company, Room 5, my building<br>1 My outter street my inner street<br>My double dependant town my dependant town my town<br>myCode",
         },
       ];
 
@@ -45,7 +45,7 @@ describe("Address Helper", () => {
             addressLocality: "my town",
             postalCode: "myCode",
           },
-          text: "My department My company Room 5 my building,<br>My double dependant town my dependant town my town,<br>myCode",
+          text: "My department, My company, Room 5, my building<br>My double dependant town my dependant town my town<br>myCode",
         },
       ];
 

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -15,7 +15,7 @@ module.exports = {
     });
 
     nunjucksEnv.addFilter("GDSDate", function (formatDate) {
-      let dateTransform = new Date(formatDate);
+      const dateTransform = new Date(formatDate);
       let dateFormat = "en-GB"; // only using 'en' uses American month-first date formatting
       if (this.ctx.i18n.language === "cy") {
         dateFormat = "cy";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Updates to `ipv-reuse` to improve address formatting

### What changed

<!-- Describe the changes in detail - the "what"-->
The `addressHelper.js` and associated tests have been modified to remove blank lines from the output, and to better match [the GDS style guide for address formatting](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#addresses-in-the-uk). The date formatting code has also been modified to match best practice when declaring variables in JavaScript.

Screenshot:
![IPV reuse page showing three addresses, each address is separated by a rule, and the spacing between addresses is identical](https://github.com/alphagov/di-ipv-core-front/assets/101639632/7ac2f6d6-0450-41fc-8a70-8e761041ec8f)


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To provide a better user experience and match usage elsewhere in GDS.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2874](https://govukverify.atlassian.net/browse/PYIC-2874)

[PYIC-2874]: https://govukverify.atlassian.net/browse/PYIC-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ