### PR TITLE
Set different redirects if request is for /assets

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -612,7 +612,7 @@ Resources:
               Value: !If [ IsNotDevelopment,
                   Fn::ImportValue: !Sub "CognitoPoolID-${Environment}",
                   "" ]
-            - Name: ASSETS_CDN_DOMAIN
+            - Name: CDN_PATH
               Value: !If [ IsBuild,
                   !Sub "https://assets.${Environment}.account.gov.uk/core-front",
                   "" ]
@@ -620,6 +620,15 @@ Resources:
               #    !If [ IsProduction,
               #      "https://assets.identity.account.gov.uk/core-front",
               #      !Sub "https://assets.identity.${Environment}.account.gov.uk/core-front" ],
+              #    "" ]
+            - Name: CDN_DOMAIN
+              Value: !If [ IsBuild,
+                           !Sub "https://assets.${Environment}.account.gov.uk",
+                           "" ]
+              #!If [ IsNotDevelopment,
+              #    !If [ IsProduction,
+              #      "https://assets.identity.account.gov.uk",
+              #      !Sub "https://assets.identity.${Environment}.account.gov.uk" ],
               #    "" ]
           PortMappings:
             - ContainerPort: 8080

--- a/src/app.js
+++ b/src/app.js
@@ -70,11 +70,11 @@ if (CDN_PATH) {
   app.use("/public", express.static(path.join(__dirname, "../dist/public")));
 }
 
-if(CDN_DOMAIN) {
+if (CDN_DOMAIN) {
   app.get(["/assets"], function (req, res) {
     res.redirect(301, CDN_DOMAIN + req.originalUrl);
   });
-}else{
+} else {
   app.use(
     "/assets",
     express.static(

--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,8 @@ const {
   PORT,
   SESSION_SECRET,
   SESSION_TABLE_NAME,
-  ASSETS_CDN_DOMAIN,
+  CDN_PATH,
+  CDN_DOMAIN,
 } = require("./lib/config");
 
 const { getGTM } = require("./lib/locals");
@@ -61,18 +62,25 @@ app.use(function (req, res, next) {
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-if (ASSETS_CDN_DOMAIN) {
-  app.get(["/assets", "/public"], function (req, res) {
-    res.redirect(301, ASSETS_CDN_DOMAIN + req.originalUrl);
+if (CDN_PATH) {
+  app.get(["/public"], function (req, res) {
+    res.redirect(301, CDN_PATH + req.originalUrl);
   });
 } else {
+  app.use("/public", express.static(path.join(__dirname, "../dist/public")));
+}
+
+if(CDN_DOMAIN) {
+  app.get(["/assets"], function (req, res) {
+    res.redirect(301, CDN_DOMAIN + req.originalUrl);
+  });
+}else{
   app.use(
     "/assets",
     express.static(
       path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")
     )
   );
-  app.use("/public", express.static(path.join(__dirname, "../dist/public")));
 }
 
 app.use(loggerMiddleware);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -21,5 +21,5 @@ module.exports = {
   GTM_ID: process.env.GTM_ID,
   GTM_ANALYTICS_COOKIE_DOMAIN: process.env.ANALYTICS_DOMAIN,
   CDN_PATH: process.env.CDN_PATH,
-  CDN_DOMAIN: process.env.CDN_DOMAIN
+  CDN_DOMAIN: process.env.CDN_DOMAIN,
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -20,5 +20,6 @@ module.exports = {
   SESSION_TABLE_NAME: process.env.SESSION_TABLE_NAME,
   GTM_ID: process.env.GTM_ID,
   GTM_ANALYTICS_COOKIE_DOMAIN: process.env.ANALYTICS_DOMAIN,
-  ASSETS_CDN_DOMAIN: process.env.ASSETS_CDN_DOMAIN,
+  CDN_PATH: process.env.CDN_PATH,
+  CDN_DOMAIN: process.env.CDN_DOMAIN
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -1,7 +1,8 @@
 const {
   GTM_ANALYTICS_COOKIE_DOMAIN,
   GTM_ID,
-  ASSETS_CDN_DOMAIN,
+  CDN_DOMAIN,
+  CDN_PATH
 } = require("./config");
 const { generateNonce } = require("./strings");
 
@@ -10,8 +11,8 @@ module.exports = {
     res.locals.gtmId = GTM_ID;
     res.locals.scriptNonce = generateNonce();
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
-    res.locals.assetsCdnDomain = ASSETS_CDN_DOMAIN;
-    res.locals.assetPath = ASSETS_CDN_DOMAIN + "/assets";
+    res.locals.assetsCdnPath = CDN_PATH;
+    res.locals.assetPath = CDN_DOMAIN + "/assets";
     next();
   },
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -2,7 +2,7 @@ const {
   GTM_ANALYTICS_COOKIE_DOMAIN,
   GTM_ID,
   CDN_DOMAIN,
-  CDN_PATH
+  CDN_PATH,
 } = require("./config");
 const { generateNonce } = require("./strings");
 

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -6,7 +6,7 @@
 {% block head %}
 
     <!--[if !IE 8]><!-->
-    <link href="{{ assetsCdnDomain }}/public/stylesheets/application.css" rel="stylesheet">
+    <link href="{{ assetsCdnPath }}/public/stylesheets/application.css" rel="stylesheet">
     <!--<![endif]-->
 
     {# For Internet Explorer 8, you need to compile specific stylesheet #}
@@ -105,6 +105,6 @@
 
 {% block bodyEnd %}
     {% block scripts %}{% endblock %}
-    <script type="text/javascript"  src="{{ assetsCdnDomain }}/public/javascripts/application.js"></script>
+    <script type="text/javascript"  src="{{ assetsCdnPath }}/public/javascripts/application.js"></script>
     <script type="text/javascript" nonce='{{ scriptNonce }}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ googleTagManagerPageId }}")</script>
 {% endblock %}


### PR DESCRIPTION
If the request is to /assets then we should redirect to the base domain of the CDN, if it's /public then we want domain+path for our app. This separates them and renames appropriately

