### PR TITLE
PYIC-3257: Add new f2f error page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -146,7 +146,7 @@ module.exports = {
       const allowedActions = [
         "/journey/next",
         "/journey/error",
-        "/journey/fail-with-no-ci",
+        "/journey/fail",
         "/journey/attempt-recovery",
         "/journey/cri/build-oauth-request/ukPassport",
         "/journey/cri/build-oauth-request/stubUkPassport",

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -146,7 +146,7 @@ module.exports = {
       const allowedActions = [
         "/journey/next",
         "/journey/error",
-        "/journey/fail",
+        "/journey/fail-with-no-ci",
         "/journey/attempt-recovery",
         "/journey/cri/build-oauth-request/ukPassport",
         "/journey/cri/build-oauth-request/stubUkPassport",
@@ -236,6 +236,7 @@ module.exports = {
         case "pyi-another-way":
         case "pyi-timeout-recoverable":
         case "pyi-timeout-unrecoverable":
+        case "pyi-f2f-technical":
         case "pyi-technical":
         case "pyi-technical-unrecoverable":
           return res.render(`ipv/${sanitize(pageId)}.njk`, {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -195,6 +195,18 @@
         "paragraph3": "Ewch yn eich blaen i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     },
+    "pyiF2fTechnical": {
+      "title": "Sorry, there is a problem with the service",
+      "header": "Sorry, there is a problem with the service",
+      "content": {
+        "paragraph1": "We cannot prove your identity right now.",
+        "subHeading": "What would you like to do?",
+        "formRadioButtons": {
+          "tryAgainButtonText": "Try proving your identity with GOV.UK One Login again",
+          "continueButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity"
+        }
+      }
+    },
     "pagePreKbvTransition": {
       "title": "Ateb cwestiynau diogelwch",
       "header": "Ateb cwestiynau diogelwch",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -196,14 +196,14 @@
       }
     },
     "pyiF2fTechnical": {
-      "title": "Sorry, there is a problem with the service",
-      "header": "Sorry, there is a problem with the service",
+      "title": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "header": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
       "content": {
-        "paragraph1": "We cannot prove your identity right now.",
-        "subHeading": "What would you like to do?",
+        "paragraph1": "We could not confirm your identity.",
+        "subHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "tryAgainButtonText": "Try proving your identity with GOV.UK One Login again",
-          "continueButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity"
+          "tryAgainButtonText": "Ceisio profi eich hunaniaeth gyda GOV.UK One Login eto",
+          "continueButtonText": "Parhau i'r gwasanaeth roeddech chi'n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -196,10 +196,10 @@
       }
     },
     "pyiF2fTechnical": {
-      "title": "Sorry, there is a problem with the service",
-      "header": "Sorry, there is a problem with the service",
+      "title": "Sorry, there is a problem",
+      "header": "Sorry, there is a problem",
       "content": {
-        "paragraph1": "We cannot prove your identity right now.",
+        "paragraph1": "We could not confirm your identity.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "tryAgainButtonText": "Try proving your identity with GOV.UK One Login again",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -195,6 +195,18 @@
         "paragraph3": "Continue to the service you were trying to use and look for other ways to prove your identity."
       }
     },
+    "pyiF2fTechnical": {
+      "title": "Sorry, there is a problem with the service",
+      "header": "Sorry, there is a problem with the service",
+      "content": {
+        "paragraph1": "We cannot prove your identity right now.",
+        "subHeading": "What would you like to do?",
+        "formRadioButtons": {
+          "tryAgainButtonText": "Try proving your identity with GOV.UK One Login again",
+          "continueButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity"
+        }
+      }
+    },
     "pagePreKbvTransition": {
       "title": "Answer security questions",
       "header": "Answer security questions",

--- a/src/views/ipv/pyi-f2f-technical.njk
+++ b/src/views/ipv/pyi-f2f-technical.njk
@@ -1,0 +1,48 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.pyiF2fTechnical.title' | translate %}
+{% set googleTagManagerPageId = "pyiF2fTechnical" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiF2fTechnical.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiF2fTechnical.content.paragraph1' | translate | safe }}</p>
+
+  <h2 class="govuk-heading-m">{{ 'pages.pyiF2fTechnical.content.subHeading' | translate }}</h2>
+
+  <form id="pyiF2fTechnicalForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiF2fTechnicalFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukRadios({
+      idPrefix: "journey",
+      name: "journey",
+      items: [
+        {
+          value: "next",
+          text: 'pages.pyiF2fTechnical.content.formRadioButtons.tryAgainButtonText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pyiF2fTechnical.content.formRadioButtons.continueButtonText' | translate
+        }
+      ]
+    }) }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <script>
+      let disableSubmit = false;
+
+      function pyiF2fTechnicalFormSubmit() {
+          if (!disableSubmit) {
+              disableSubmit = true;
+              document.getElementById('submitButton').disabled = true;
+              return true
+          }
+          return false;
+      }
+  </script>
+
+  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added new f2f technical error page
Currently has interim welsh translations 
By having this page now it will allow us to wire everything up in the backend.

### Why did it change

This is the new error page that will be used for f2f. It has specific actions compared to our generic technical error pages.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3257](https://govukverify.atlassian.net/browse/PYIC-3257)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3257]: https://govukverify.atlassian.net/browse/PYIC-3257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ