### PR TITLE
PYIC-3271 Remove reference to expired passports on start page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -354,7 +354,7 @@
         "list2": "heb ddod i ben",
         "paragraph2": "Gall fod yn drwydded yrru y DU llawn neu dros dro.",
         "subHeading2": "Pasbort y DU",
-        "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU. Os yw’ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi eich hunaniaeth hyd at 18 mis ar ôl ei ddyddiad dod i ben.",
+        "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU.",
         "subHeading3": "Pasbort o’r tu allan i’r DU gyda sglodion biometrig",
         "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU os:",
         "list3": "mae ganddo sglodyn biometrig",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -354,7 +354,7 @@
         "list2": "has not expired",
         "paragraph2": "It can be a full or provisional UK driving licence.",
         "subHeading2": "UK passport",
-        "paragraph3": "You can use any UK passport. If your UK passport has expired, you can still use it to prove your identity up to 18 months after its expiry date.",
+        "paragraph3": "You can use any UK passport.",
         "subHeading3": "Non-UK passport with a biometric chip",
         "paragraph4": "You can use a non-UK passport if it:",
         "list3": "has a biometric chip",


### PR DESCRIPTION
## Proposed changes

### What changed

Remove reference to expired passports on page-ipv-identity-document-start

### Why did it change

Changes required following UCD review

### Issue tracking
- [PYIC-3271](https://govukverify.atlassian.net/browse/PYIC-3271)



[PYIC-3271]: https://govukverify.atlassian.net/browse/PYIC-3271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ