### PR TITLE
PYIC-3274 Correct 'start again' option on pyi-escape page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -120,7 +120,7 @@
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
-          "restartButtonText": "Start again and try to prove your identity online with GOV.UK One Login"
+          "restartButtonText": "Try proving your identity with GOV.UK One Login again"
         }
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Correct 'start again' option on pyi-escape page. Welsh already correct

### Why did it change

Updates required following UCD review

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3274](https://govukverify.atlassian.net/browse/PYIC-3274)



[PYIC-3274]: https://govukverify.atlassian.net/browse/PYIC-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ