### PR TITLE
PYIC-3276: Update contact link

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -231,7 +231,7 @@
         "paragraph8": "Contact us if you:",
         "bullet3": "need help to finish proving your identity with the Post Office",
         "bullet4": "would prefer not to go to the Post Office and want to prove your identity another way",
-        "contactLinkHrefF2fCustom": "https://signin.account.gov.uk/contact-us-questions?theme=proving_identity&referer="
+        "contactLinkHrefF2fCustom": "https://signin.account.gov.uk/contact-us?supportType=PUBLIC"
       }
     },
     "pageDcmawSuccess": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The ‘Contact the [GOV.UK](http://gov.uk/) One Login team’ link at the bottom should link to the [Contact Us landing page](https://signin.account.gov.uk/contact-us?supportType=PUBLIC), NOT the ‘[A problem proving your identity’ page](https://signin.account.gov.uk/contact-us-questions?theme=proving_identity&referer=https%3A%2F%2Fsignin.account.gov.uk%2Fsign-in-or-create). This is so it’s consistent with all other instances of this link in our service, we think it’s best to keep it like this for now as we don’t know enough about it to make this change in all instances - in some cases it might be useful for them to choose another option from the list.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3276](https://govukverify.atlassian.net/browse/PYIC-3276)


[PYIC-3276]: https://govukverify.atlassian.net/browse/PYIC-3276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ