### PR TITLE
BAU Add missing route for F2F doc check page

### DIFF
--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -26,6 +26,12 @@ router.post(
   csrfProtection,
   handleMultipleDocCheck
 );
+router.post(
+  "/page/page-f2f-multiple-doc-check",
+  parseForm,
+  csrfProtection,
+  handleMultipleDocCheck
+);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add missing route for F2F doc check page

### Why did it change

The events for the passport/DL options weren't being recognised because we were missing the custom handler for this route

