### PR TITLE
Turned off the CDN for testing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -614,7 +614,7 @@ Resources:
                   "" ]
             - Name: CDN_PATH
               Value: !If [ IsBuild,
-                  !Sub "https://assets.${Environment}.account.gov.uk/core-front",
+                  "", #"!Sub "https://assets.${Environment}.account.gov.uk/core-front",
                   "" ]
               #!If [ IsNotDevelopment,
               #    !If [ IsProduction,


### PR DESCRIPTION
This is turning off the shared assets CDN for testing in the build environment