### PR TITLE
BAU Add 15-minute timeouts in GitHub workflow

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   RunCheckov:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -8,6 +8,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:


### PR DESCRIPTION
Set GitHub action timeouts to 15 minutes.

## Proposed changes

### What changed

Set GitHub action timeouts to 15 minutes.

### Why did it change

E-mail from Alex Wilson entitled “GitHub Actions Storage/Duration Limits” on 15th August 2023 to the whole of DI requests that all projects should “Include job timeouts on all your GitHub workflows of 15m (or more if appropriate for longer build processes)“ in order to control costs of GitHub Actions.

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
