### PR TITLE
Added REST API per dev environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -798,9 +798,7 @@ Resources:
           - id: "CKV_AWS_120"
             comment: "API should have caching - not for our use case"
     Properties:
-      StageName: !Sub
-        - "${AWS::StackName}-RestApiStage-${StackId}"
-        - StackId: !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ]
+      StageName: !Sub ${Environment}
       DeploymentId: !Ref RestApiGwDeployment
       RestApiId: !Ref RestApiGateway
       AccessLogSetting:


### PR DESCRIPTION
This enables the REST API gateway for each developer with network load balancer each and a VPCEndpoint each.
Update the stage name to prevent the need for an import in the DNS stack