### PR TITLE
PYIC-3369: Add CRI escape page

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -629,6 +629,68 @@ describe("journey middleware", () => {
     }
   );
 
+  context(
+    "handleCriEscapeAction: handling journey action with journey/f2f, journey/dcmaw, journey/end",
+    () => {
+      it("should post with journey/f2f", async function () {
+        req = {
+          id: "1",
+          body: { journey: "next/f2f" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleCriEscapeAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/f2f`
+        );
+      });
+
+      it("should post with journey/dcmaw", async function () {
+        req = {
+          id: "1",
+          body: { journey: "next/dcmaw" },
+          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleCriEscapeAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/dcmaw`
+        );
+      });
+
+      it("should post with journey/end by default", async function () {
+        await middleware.handleCriEscapeAction(req, res, next);
+        expect(axiosStub.post.firstCall).to.have.been.calledWith(
+          `${configStub.API_BASE_URL}/journey/end`
+        );
+      });
+    }
+  );
+
+  context(
+    "handleCriEscapeAction: handling missing ipvSessionId before calling the backend",
+    () => {
+      it("should redirect to the technical unrecoverable page", async function () {
+        req = {
+          id: "1",
+          session: {
+            currentPage: "page-ipv-identity-document-start",
+            ipvSessionId: null,
+            ipAddress: "ip-address",
+          },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleCriEscapeAction(req, res, next);
+        expect(res.redirect).to.have.been.calledWith(
+          "/ipv/page/pyi-technical-unrecoverable"
+        );
+      });
+    }
+  );
+
   context("validateFeatureSet", () => {
     beforeEach(() => {
       req = {

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -9,6 +9,7 @@ const {
   handleJourneyPage,
   handleJourneyAction,
   handleMultipleDocCheck,
+  handleCriEscapeAction,
   renderFeatureSetPage,
   validateFeatureSet,
 } = require("./middleware");
@@ -40,6 +41,12 @@ router.post(
   parseForm,
   csrfProtection,
   handleMultipleDocCheck
+);
+router.post(
+  "/page/pyi-cri-escape",
+  parseForm,
+  csrfProtection,
+  handleCriEscapeAction
 );
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -124,6 +124,26 @@
         }
       }
     },
+    "pyiCriEscape": {
+      "title": "Find another way to prove your identity",
+      "header": "Find another way to prove your identity",
+      "content": {
+        "paragraph1": "We were not able to complete your identity check using security questions.",
+        "subHeading": "What you can do",
+        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
+        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
+        "bullet1": "an iPhone 7 or higher",
+        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
+        "paragraph4": "You can also prove your identity at a Post Office. This option takes longer. You’ll usually get an outcome within a day of going to the Post Office.",
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
+          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "continuePostOfficeButtonText": "Prove your identity at a Post Office",
+          "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+        }
+      }
+    },
     "pyiAnotherWay": {
       "title": "Profi eich hunaniaeth mewn ffordd arall",
       "header": "Profi eich hunaniaeth mewn ffordd arall",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -124,6 +124,26 @@
         }
       }
     },
+    "pyiCriEscape": {
+      "title": "Find another way to prove your identity",
+      "header": "Find another way to prove your identity",
+      "content": {
+        "paragraph1": "We were not able to complete your identity check using security questions.",
+        "subHeading": "What you can do",
+        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
+        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
+        "bullet1": "an iPhone 7 or higher",
+        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
+        "paragraph4": "You can also prove your identity at a Post Office. This option takes longer. You’ll usually get an outcome within a day of going to the Post Office.",
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
+          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "continuePostOfficeButtonText": "Prove your identity at a Post Office",
+          "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+        }
+      }
+    },
     "pyiAnotherWay": {
       "title": "Prove your identity another way",
       "header": "Prove your identity another way",

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -1,0 +1,64 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.pyiCriEscape.title' | translate %}
+{% set googleTagManagerPageId = "pyiCriEscape" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscape.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph1' | translate | safe }}</p>
+
+  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscape.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph2' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph3' | translate | safe }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.pyiCriEscape.content.bullet1' | translate | safe }}</li>
+    <li>{{'pages.pyiCriEscape.content.bullet2' | translate | safe }}</li>
+  </ul>
+  <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph4' | translate | safe }}</p>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscape.content.subHeading2' | translate }}</h2>
+
+  <form id="pyiCriEscapeForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiCriEscapeFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukRadios({
+    idPrefix: "journey",
+    name: "journey",
+    items: [
+              {
+                value: "next",
+                text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonText' | translate,
+                hint: {text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonTextHint' | translate}
+
+              },
+              {
+                value: "end",
+                text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonText' | translate,
+                hint: { text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
+              }
+            ]
+      })
+    }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">
+      {{'general.shared.contactLinkText' | translate }}
+    </a>
+  </p>
+
+  <script>
+      let disableSubmit = false;
+
+      function pyiCriEscapeFormSubmit() {
+          if (!disableSubmit) {
+              disableSubmit = true;
+              document.getElementById('submitButton').disabled = true;
+              return true
+          }
+          return false;
+      }
+  </script>
+{% endblock %}

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -25,13 +25,13 @@
     name: "journey",
     items: [
               {
-                value: "next",
+                value: "next/dcmaw",
                 text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonText' | translate,
                 hint: {text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonTextHint' | translate}
 
               },
               {
-                value: "end",
+                value: "next/f2f",
                 text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonText' | translate,
                 hint: { text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
               }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add CRI escape page

![Screenshot 2023-08-18 at 12 24 51](https://github.com/alphagov/di-ipv-core-front/assets/24409958/8c11d6a3-df09-4053-aff5-d5e001db61e2)

### Why did it change

If the user has a thin file or abandons KBV (selects ‘cannot answer the questions’) KBV CRI returns to us a fail VC with no CI. Currently we redirect the user to the pyi-kbv-thin-file page. We need to send them to a new ‘escape’ page which will offer DCMAW as an alternative route to prove their identity. We should redirect to the DCMAW CRI.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3369](https://govukverify.atlassian.net/browse/PYIC-3369)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

[PYIC-3369]: https://govukverify.atlassian.net/browse/PYIC-3369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ