### PR TITLE
PYIC-3420: Add new escape page when f2f is disabled

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -234,6 +234,7 @@ module.exports = {
         case "pyi-no-match":
         case "pyi-escape":
         case "pyi-cri-escape":
+        case "pyi-cri-escape-no-f2f":
         case "pyi-another-way":
         case "pyi-timeout-recoverable":
         case "pyi-timeout-unrecoverable":

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -125,41 +125,41 @@
       }
     },
     "pyiCriEscape": {
-      "title": "Find another way to prove your identity",
-      "header": "Find another way to prove your identity",
+      "title": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
-        "paragraph1": "We were not able to complete your identity check using security questions.",
-        "subHeading": "What you can do",
-        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
-        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
-        "bullet1": "an iPhone 7 or higher",
-        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
-        "paragraph4": "You can also prove your identity at a Post Office. This option takes longer. You’ll usually get an outcome within a day of going to the Post Office.",
-        "subHeading2": "What would you like to do?",
+        "paragraph1": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Yn seiliedig ar beth rydych wedi’i ddweud wrthym, mae gennych chi lun ID y gallwch ei ddefnyddio i brofi pwy ydych chi.",
+        "paragraph3": "Gallwch wneud hyn gyda’r ap GOV.UK ID Check os oes gennych:",
+        "bullet1": "iPhone 7 neu uwch",
+        "bullet2": "ffôn Android (er enghraifft, Samsung neu Google Pixel)",
+        "paragraph4": "Gallwch hefyd brofi eich hunaniaeth mewn Swyddfa’r Post. Mae’r opsiwn hwn yn cymryd mwy o amser. Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
+        "subHeading2": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
-          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
-          "continuePostOfficeButtonText": "Prove your identity at a Post Office",
-          "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+          "continueAppButtonText": "Profi eich hunaniaeth gyda’r ap GOV.UK ID Check",
+          "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
+          "continuePostOfficeButtonText": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
+          "continuePostOfficeButtonTextHint": "Byddwch yn rhoi manylion o’ch ID llun ar GOV.UK yn gyntaf."
         }
       }
     },
     "pyiCriEscapeNoF2f": {
-      "title": "Find another way to prove your identity",
-      "header": "Find another way to prove your identity",
+      "title": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
-        "paragraph1": "We were not able to complete your identity check using security questions.",
-        "subHeading": "What you can do",
-        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
-        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
-        "bullet1": "an iPhone 7 or higher",
-        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
-        "subHeading2": "What would you like to do?",
+        "paragraph1": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Yn seiliedig ar beth rydych wedi’i ddweud wrthym, mae gennych chi lun ID y gallwch ei ddefnyddio i brofi pwy ydych chi.",
+        "paragraph3": "Gallwch wneud hyn gyda’r ap GOV.UK ID Check os oes gennych:",
+        "bullet1": "iPhone 7 neu uwch",
+        "bullet2": "ffôn Android (er enghraifft, Samsung neu Google Pixel)",
+        "subHeading2": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
-          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
-          "otherWayButtonText": "Prove your identity another way",
-          "otherWayButtonTextHint": "Go to the service you want to use and look for other ways to prove your identity."
+          "continueAppButtonText": "Profi eich hunaniaeth gyda’r ap GOV.UK ID Check",
+          "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
+          "otherWayButtonText": "Profi eich hunaniaeth mewn ffordd arall",
+          "otherWayButtonTextHint": "Ewch i’r gwasanaeth rydych am ei ddefnyddio a chwilio am ffyrdd eraill o brofi eich hunaniaeth."
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -144,6 +144,25 @@
         }
       }
     },
+    "pyiCriEscapeNoF2f": {
+      "title": "Find another way to prove your identity",
+      "header": "Find another way to prove your identity",
+      "content": {
+        "paragraph1": "We were not able to complete your identity check using security questions.",
+        "subHeading": "What you can do",
+        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
+        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
+        "bullet1": "an iPhone 7 or higher",
+        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
+          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "otherWayButtonText": "Prove your identity another way",
+          "otherWayButtonTextHint": "Go to the service you want to use and look for other ways to prove your identity."
+        }
+      }
+    },
     "pyiAnotherWay": {
       "title": "Profi eich hunaniaeth mewn ffordd arall",
       "header": "Profi eich hunaniaeth mewn ffordd arall",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -144,6 +144,25 @@
         }
       }
     },
+    "pyiCriEscapeNoF2f": {
+      "title": "Find another way to prove your identity",
+      "header": "Find another way to prove your identity",
+      "content": {
+        "paragraph1": "We were not able to complete your identity check using security questions.",
+        "subHeading": "What you can do",
+        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
+        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
+        "bullet1": "an iPhone 7 or higher",
+        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
+        "subHeading2": "What would you like to do?",
+        "formRadioButtons": {
+          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
+          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "otherWayButtonText": "Prove your identity another way",
+          "otherWayButtonTextHint": "Go to the service you want to use and look for other ways to prove your identity."
+        }
+      }
+    },
     "pyiAnotherWay": {
       "title": "Prove your identity another way",
       "header": "Prove your identity another way",

--- a/src/views/ipv/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/pyi-cri-escape-no-f2f.njk
@@ -1,0 +1,63 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.pyiCriEscapeNoF2f.title' | translate %}
+{% set googleTagManagerPageId = "pyiCriEscapeNoF2f" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscapeNoF2f.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph1' | translate | safe }}</p>
+
+  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscapeNoF2f.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph2' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph3' | translate | safe }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.pyiCriEscapeNoF2f.content.bullet1' | translate | safe }}</li>
+    <li>{{'pages.pyiCriEscapeNoF2f.content.bullet2' | translate | safe }}</li>
+  </ul>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscapeNoF2f.content.subHeading2' | translate }}</h2>
+
+  <form id="pyiCriEscapeNoF2fForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiCriEscapeNoF2fFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukRadios({
+    idPrefix: "journey",
+    name: "journey",
+    items: [
+              {
+                value: "next",
+                text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonText' | translate,
+                hint: {text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonTextHint' | translate}
+
+              },
+              {
+                value: "end",
+                text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonText' | translate,
+                hint: { text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonTextHint' | translate }
+              }
+            ]
+      })
+    }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">
+      {{'general.shared.contactLinkText' | translate }}
+    </a>
+  </p>
+
+  <script>
+      let disableSubmit = false;
+
+      function pyiCriEscapeNoF2fFormSubmit() {
+          if (!disableSubmit) {
+              disableSubmit = true;
+              document.getElementById('submitButton').disabled = true;
+              return true
+          }
+          return false;
+      }
+  </script>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add new escape page when f2f is disabled

Subsequent core-back PR: https://github.com/alphagov/di-ipv-core-back/pull/1145

<img width="500" alt="Screenshot 2023-08-24 at 10 10 18" src="https://github.com/alphagov/di-ipv-core-front/assets/24409958/0dd29219-3860-46ae-a231-c6de15a34fcb">

### Why did it change

We need to handle F2F being disabled and send them to a page which only offers the DCMAW option in this case.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3420](https://govukverify.atlassian.net/browse/PYIC-3420)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3420]: https://govukverify.atlassian.net/browse/PYIC-3420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ