### PR TITLE
BAU Remove identity.gov.uk from CSP

### DIFF
--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -2,8 +2,7 @@ module.exports = {
   securityHeadersHandler: (req, res, next) => {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy":
-        "default-src 'self' identity.gov.uk *.identity.gov.uk",
+      "Content-Security-Policy": "default-src 'self'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",

--- a/src/handlers/security-headers-handler.test.js
+++ b/src/handlers/security-headers-handler.test.js
@@ -33,8 +33,7 @@ describe("Security headers handler", () => {
     expect(res.set).to.be.have.been.calledOnce;
     expect(res.set).to.be.have.been.calledWith({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy":
-        "default-src 'self' identity.gov.uk *.identity.gov.uk",
+      "Content-Security-Policy": "default-src 'self'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",


### PR DESCRIPTION
Assets aren't being hosted on a different domain to the site so we shouldn't allow this domain
