### PR TITLE
PYIC-3427 Create toggleable error state on page-ipv-identity-start DO NOT MERGE

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -188,34 +188,34 @@ module.exports = {
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;
-      if (req.session?.ipvSessionId === null) {
-        logError(
-          req,
-          {
-            pageId: pageId,
-            expectedPage: req.session.currentPage,
-          },
-          "req.ipvSessionId is null"
-        );
-
-        req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.render(`ipv/${req.session.currentPage}.njk`);
-      } else if (pageId === "pyi-timeout-unrecoverable") {
-        req.session.currentPage = "pyi-timeout-unrecoverable";
-        return res.render(`ipv/${req.session.currentPage}.njk`);
-      } else if (req.session.currentPage !== pageId) {
-        logError(
-          req,
-          {
-            pageId: pageId,
-            expectedPage: req.session.currentPage,
-          },
-          "page :pageId doesn't match expected session page :expectedPage"
-        );
-
-        req.session.currentPage = "pyi-attempt-recovery";
-        return res.redirect(req.session.currentPage);
-      }
+      // if (req.session?.ipvSessionId === null) {
+      //   logError(
+      //     req,
+      //     {
+      //       pageId: pageId,
+      //       expectedPage: req.session.currentPage,
+      //     },
+      //     "req.ipvSessionId is null"
+      //   );
+      //
+      //   req.session.currentPage = "pyi-technical-unrecoverable";
+      //   return res.render(`ipv/${req.session.currentPage}.njk`);
+      // } else if (pageId === "pyi-timeout-unrecoverable") {
+      //   req.session.currentPage = "pyi-timeout-unrecoverable";
+      //   return res.render(`ipv/${req.session.currentPage}.njk`);
+      // } else if (req.session.currentPage !== pageId) {
+      //   logError(
+      //     req,
+      //     {
+      //       pageId: pageId,
+      //       expectedPage: req.session.currentPage,
+      //     },
+      //     "page :pageId doesn't match expected session page :expectedPage"
+      //   );
+      //
+      //   req.session.currentPage = "pyi-attempt-recovery";
+      //   return res.redirect(req.session.currentPage);
+      // }
 
       switch (pageId) {
         case "page-ipv-identity-document-start":

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -188,34 +188,35 @@ module.exports = {
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;
-      // if (req.session?.ipvSessionId === null) {
-      //   logError(
-      //     req,
-      //     {
-      //       pageId: pageId,
-      //       expectedPage: req.session.currentPage,
-      //     },
-      //     "req.ipvSessionId is null"
-      //   );
-      //
-      //   req.session.currentPage = "pyi-technical-unrecoverable";
-      //   return res.render(`ipv/${req.session.currentPage}.njk`);
-      // } else if (pageId === "pyi-timeout-unrecoverable") {
-      //   req.session.currentPage = "pyi-timeout-unrecoverable";
-      //   return res.render(`ipv/${req.session.currentPage}.njk`);
-      // } else if (req.session.currentPage !== pageId) {
-      //   logError(
-      //     req,
-      //     {
-      //       pageId: pageId,
-      //       expectedPage: req.session.currentPage,
-      //     },
-      //     "page :pageId doesn't match expected session page :expectedPage"
-      //   );
-      //
-      //   req.session.currentPage = "pyi-attempt-recovery";
-      //   return res.redirect(req.session.currentPage);
-      // }
+
+      if (req.session?.ipvSessionId === null) {
+        logError(
+          req,
+          {
+            pageId: pageId,
+            expectedPage: req.session.currentPage,
+          },
+          "req.ipvSessionId is null"
+        );
+
+        req.session.currentPage = "pyi-technical-unrecoverable";
+        return res.render(`ipv/${req.session.currentPage}.njk`);
+      } else if (pageId === "pyi-timeout-unrecoverable") {
+        req.session.currentPage = "pyi-timeout-unrecoverable";
+        return res.render(`ipv/${req.session.currentPage}.njk`);
+      } else if (req.session.currentPage !== pageId) {
+        logError(
+          req,
+          {
+            pageId: pageId,
+            expectedPage: req.session.currentPage,
+          },
+          "page :pageId doesn't match expected session page :expectedPage"
+        );
+
+        req.session.currentPage = "pyi-attempt-recovery";
+        return res.redirect(req.session.currentPage);
+      }
 
       switch (pageId) {
         case "page-ipv-identity-document-start":
@@ -242,6 +243,7 @@ module.exports = {
         case "pyi-technical-unrecoverable":
           return res.render(`ipv/${sanitize(pageId)}.njk`, {
             pageId,
+            pageErrorState: req.query.errorState,
             csrfToken: req.csrfToken(),
           });
         case "page-ipv-reuse": {

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -19,11 +19,18 @@ const parseForm = bodyParser.urlencoded({ extended: false });
 
 function checkLanguage(req, res, next) {
   const lang = req.cookies.lng;
-
   // Set the flag "isWelsh" to true if the language is Welsh, otherwise set to false
   res.locals.isWelsh = lang === "cy";
-
   next();
+}
+
+// redirect the user if they haven’t chosen a radio button option
+function formRadioButtonChecked(req, res, next) {
+  if (req.method === "POST" && req.body.journey === undefined) {
+    return res.redirect(req.originalUrl+'?errorState=true');
+  } else {
+    next();
+  }
 }
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
@@ -48,7 +55,13 @@ router.post(
   csrfProtection,
   handleCriEscapeAction
 );
-router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
+router.post(
+  "/page/:pageId",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
 router.get("/*", updateJourneyState);
 
 module.exports = router;

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -27,7 +27,7 @@ function checkLanguage(req, res, next) {
 // redirect the user if they haven’t chosen a radio button option
 function formRadioButtonChecked(req, res, next) {
   if (req.method === "POST" && req.body.journey === undefined) {
-    return res.redirect(req.originalUrl+'?errorState=true');
+    return res.redirect(req.originalUrl + "?errorState=true");
   } else {
     next();
   }

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -55,11 +55,19 @@ router.post(
   csrfProtection,
   handleCriEscapeAction
 );
+
+router.post(
+  "/page/page-ipv-identity-document-start",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
+
 router.post(
   "/page/:pageId",
   parseForm,
   csrfProtection,
-  formRadioButtonChecked,
   handleJourneyAction
 );
 router.get("/*", updateJourneyState);

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -247,3 +247,26 @@ window.GOVSignIn.Cookies = cookies;
   w.disableAfterClick = disableAfterClick;
 
 })(window);
+
+
+// globally disable second clicks on the continue button for radio button pages
+
+// first, check if we have radio buttons and no inline form onSubmit action
+
+const checkForOnSubmit = document.querySelector('form[onsubmit]');
+const checkForRadio =  document.querySelector('input[type="radio"]');
+let disableSubmit = false;
+
+// if that is true, set up the form listener with the same code used on other pages
+
+if(checkForOnSubmit===null && checkForRadio!==null){
+  const manageFormClicks = document.querySelector('form');
+  manageFormClicks.addEventListener('submit',()=>{
+    if (!disableSubmit) {
+      disableSubmit = true;
+      document.getElementById('submitButton').disabled = true;
+      return true
+    }
+    return false;
+  })
+}

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -223,10 +223,12 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
 window.GOVSignIn = window.GOVSignIn || {};
 window.GOVSignIn.Cookies = cookies;
 
+
 (function(w) {
   "use strict";
   function appInit(trackingId, analyticsCookieDomain, journeyState) {
     window.GOVUKFrontend.initAll();
+
     var cookies = window.GOVSignIn.Cookies(trackingId, analyticsCookieDomain, journeyState);
     if (cookies.hasConsentForAnalytics()) {
       cookies.initAnalytics();

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -14,6 +14,12 @@ module.exports = {
       return translate(key, options);
     });
 
+    // allow pushing or adding another attribute to an Object
+    nunjucksEnv.addFilter("setAttribute", function(dictionary, key, value) {
+      dictionary[key] = value;
+      return dictionary;
+    });
+
     nunjucksEnv.addFilter("GDSDate", function (formatDate) {
       const dateTransform = new Date(formatDate);
       let dateFormat = "en-GB"; // only using 'en' uses American month-first date formatting

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -15,7 +15,7 @@ module.exports = {
     });
 
     // allow pushing or adding another attribute to an Object
-    nunjucksEnv.addFilter("setAttribute", function(dictionary, key, value) {
+    nunjucksEnv.addFilter("setAttribute", function (dictionary, key, value) {
       dictionary[key] = value;
       return dictionary;
     });

--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -3,7 +3,7 @@ module.exports = {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
       "Content-Security-Policy":
-        "default-src 'self' identity.gov.uk *.identity.gov.uk",
+        "default-src 'self' identity.gov.uk *.identity.gov.uk; script-src 'self' 'unsafe-inline'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",

--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -3,7 +3,7 @@ module.exports = {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
       "Content-Security-Policy":
-        "default-src 'self' identity.gov.uk *.identity.gov.uk; script-src 'self' 'unsafe-inline'",
+        "default-src 'self' identity.gov.uk *.identity.gov.uk",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -121,6 +121,12 @@
         "formRadioButtons": {
           "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
           "restartButtonText": "Ceisio profi eich hunaniaeth gyda GOV.UK One Login eto"
+        },
+        "formErrorMessage": {
+          "errorPageTitle": "TEMP Gwall: dewiswch opsiwn",
+          "errorSummaryTitleText":"TEMP Mae yna broblem",
+          "errorSummaryDescriptionText": "TEMP Dewiswch ffordd arall i brofi pwy ydych chi",
+          "errorRadioMessage": "TEMP Dewiswch opsiwn"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -124,7 +124,7 @@
         },
         "formErrorMessage": {
           "errorPageTitle": "TEMP Gwall: dewiswch opsiwn",
-          "errorSummaryTitleText":"TEMP Mae yna broblem",
+          "errorSummaryTitleText": "TEMP Mae yna broblem",
           "errorSummaryDescriptionText": "TEMP Dewiswch ffordd arall i brofi pwy ydych chi",
           "errorRadioMessage": "TEMP Dewiswch opsiwn"
         }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -401,39 +401,6 @@
         "paragraph2": "Gallai rhywfaint o’r wybodaeth a rannwyd gennych pan wnaethoch brofi pwy ydych chi gael ei defnyddio i lenwi ffurflenni yn awtomatig o fewn y gwasanaeth."
       }
     },
-    "pageIpvIdentityDocumentStart": {
-      "title": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
-      "header": "Dywedwch wrthym os oes gennych un o’r mathau canlynol o ID gyda llun",
-      "content": {
-        "paragraph": "Bydd hyn yn ein helpu i ddod o hyd i’r ffordd orau i chi brofi eich hunaniaeth.",
-        "subHeading": "Trwydded yrru cerdyn gyda llun y DU",
-        "paragraph1": "Gallwch ddefnyddio trwydded yrru y DU os yw:",
-        "list1": "yn cynnwys eich llun",
-        "list2": "heb ddod i ben",
-        "paragraph2": "Gall fod yn drwydded yrru y DU llawn neu dros dro.",
-        "subHeading2": "Pasbort y DU",
-        "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU.",
-        "subHeading3": "Pasbort o’r tu allan i’r DU gyda sglodion biometrig",
-        "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU os:",
-        "list3": "mae ganddo sglodyn biometrig",
-        "list4": "nid yw wedi dod i ben",
-        "paragraph5": "I wirio os oes gan eich pasbort sglodyn biometrig, edrychwch am y symbol sglodyn biometrig petryal ar y clawr blaen.",
-        "imgAltText": "Clawr blaen pasbort gyda’r symbol sglodyn biometrig. Mae’r symbol yn betryal gyda chylch yn y canol.",
-        "subHeading4": "Trwydded breswylio biometrig y DU",
-        "paragraph6": "Gallwch ddefnyddio trwydded breswylio biometrig (BRP) y DU sydd heb ddod i ben.",
-        "subHeading5": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
-        "formRadioButtons": {
-          "yes": "Oes",
-          "no": "Na"
-        },
-        "formErrorMessage": {
-          "errorPageTitle": "There has been an error",
-          "errorSummaryTitleText": "There is a problem",
-          "errorSummaryErrorText": "Please tell us if you have Photo ID",
-          "errorMessage": "Please choose an option"
-        }
-      }
-    },
     "pageIpvIdentityPostofficeStart": {
       "title": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
       "header": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
@@ -459,29 +426,6 @@
           "yes": "Oes",
           "no": "Na"
         }
-      }
-    },
-    "pageIpvPending": {
-      "title": "Nid ydych wedi gorffen profi eich hunaniaeth",
-      "header": "Nid ydych wedi gorffen profi eich hunaniaeth",
-      "content": {
-        "paragraph1": "Mae angen i chi fynd i Swyddfa’r Post sy’n cynnig dilysu mewn canghennau i orffen profi eich hunaniaeth.",
-        "paragraph2": "Dylech fod wedi derbyn e-bost cadarnhau yn esbonio beth i fynd gyda chi a beth fydd yn digwydd yn Swyddfa’r Post. Gwiriwch y llythyr yn eich e-bost cadarnhau.",
-        "subHeading": "Os ydych eisoes wedi bod i Swyddfa’r Post",
-        "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
-        "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth - fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
-        "subHeading2": "Os ydych angen help",
-        "paragraph5": "Cysylltwch â ni os :",
-        "list1": "ydych angen help i orffen profi eich hunaniaeth gyda Swyddfa’r Post",
-        "list2": "hoffech beidio â mynd i Swyddfa’r Post ac eisiau profi eich hunaniaeth mewn ffordd arall"
-      }
-    },
-    "pageIpvSuccess": {
-      "title": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
-      "header": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
-      "content": {
-        "paragraph1": "Rydych wedi profi pwy ydych chi’n llwyddiannus. Gallwch nawr barhau i’r gwasanaeth rydych eisiau ei ddefnyddio.",
-        "paragraph2": "Gallai rhywfaint o’r wybodaeth a rannwyd gennych pan wnaethoch brofi pwy ydych chi gael ei defnyddio i lenwi ffurflenni yn awtomatig o fewn y gwasanaeth."
       }
     },
     "pageIpvIdentityDocumentStart": {
@@ -514,33 +458,6 @@
           "errorSummaryTitleText": "TEMP Mae yna broblem",
           "errorSummaryErrorText": "TEMP Dywedwch wrthym os oes gennych ID Llun",
           "errorMessage": "TEMP Dewiswch opsiwn"
-        }
-      }
-    },
-    "pageIpvIdentityPostofficeStart": {
-      "title": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
-      "header": "Profi eich hunaniaeth mewn Swyddfa’r Post gydag un o’r mathau canlynol o ID gyda lun",
-      "content": {
-        "paragraph1": "Yn seiliedig ar yr hyn a ddywedoch wrthym, ni allwch brofi eich hunaniaeth ar-lein.",
-        "paragraph2": "Os oes gennych unrhyw un o’r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa’r Post yn lle hynny.",
-        "insetText": "Nid yw’r opsiwn hwn ar gael yn Gymraeg eto",
-        "subHeading": "Trwydded yrru cerdyn gyda llun yr Undeb Ewropeaidd (UE)",
-        "paragraph3": "Gallwch ddefnyddio trwydded yrru’r UE os:",
-        "list1": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
-        "list2": "nid yw wedi dod i ben",
-        "list3": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "subHeading2": "Pasbort o’r tu allan i’r DU",
-        "paragraph4": "Gallwch ddefnyddio pasbort o’r tu allan i’r DU cyn belled nad yw wedi dod i ben.",
-        "subHeading3": "Cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd",
-        "paragraph5": "Gallwch ddefnyddio cerdyn hunaniaeth genedlaethol o wlad Ardal Economaidd Ewropeaidd os:",
-        "list4": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",
-        "list5": "nid yw wedi dod i ben",
-        "list6": "mae’r cyfeiriad arno yr un fath â’ch cyfeiriad cyfredol (os oes ganddo gyfeiriad)",
-        "paragraph6": "Mae’r AEE yn cynnwys gwledydd yr UE, Norwy, Gwlad yr Iâ a Liechtenstein.",
-        "subHeading4": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
-        "formRadioButtons": {
-          "yes": "Oes",
-          "no": "Na"
         }
       }
     }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -451,13 +451,16 @@
         "subHeading5": "Oes gennych chi unrhyw un o’r mathau hyn o ID gyda llun?",
         "formRadioButtons": {
           "yes": "Oes",
-          "no": "Na"
+          "yesAccessibleContextText": "TEMP Mae gen i un o’r mathau hyn o ID llun",
+          "no": "Na",
+          "noAccessibleContextText": "TEMP Nid oes gennyf un o’r mathau hyn o ID llun"
         },
         "formErrorMessage": {
           "errorPageTitle": "TEMP Mae gwall wedi bod",
           "errorSummaryTitleText": "TEMP Mae yna broblem",
-          "errorSummaryErrorText": "TEMP Dywedwch wrthym os oes gennych ID Llun",
-          "errorMessage": "TEMP Dewiswch opsiwn"
+          "errorSummaryDescriptionText": "TEMP Dywedwch wrthym os oes gennych ID Llun",
+          "errorRadioMessageErrorLabel": "TEMP Gwall",
+          "errorRadioMessage": "TEMP Dewiswch opsiwn"
         }
       }
     }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -125,22 +125,41 @@
       }
     },
     "pyiCriEscape": {
-      "title": "Find another way to prove your identity",
-      "header": "Find another way to prove your identity",
+      "title": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
-        "paragraph1": "We were not able to complete your identity check using security questions.",
-        "subHeading": "What you can do",
-        "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
-        "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
-        "bullet1": "an iPhone 7 or higher",
-        "bullet2": "an Android phone (for example, Samsung or Google Pixel)",
-        "paragraph4": "You can also prove your identity at a Post Office. This option takes longer. You’ll usually get an outcome within a day of going to the Post Office.",
-        "subHeading2": "What would you like to do?",
+        "paragraph1": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Yn seiliedig ar beth rydych wedi’i ddweud wrthym, mae gennych chi lun ID y gallwch ei ddefnyddio i brofi pwy ydych chi.",
+        "paragraph3": "Gallwch wneud hyn gyda’r ap GOV.UK ID Check os oes gennych:",
+        "bullet1": "iPhone 7 neu uwch",
+        "bullet2": "ffôn Android (er enghraifft, Samsung neu Google Pixel)",
+        "paragraph4": "Gallwch hefyd brofi eich hunaniaeth mewn Swyddfa’r Post. Mae’r opsiwn hwn yn cymryd mwy o amser. Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
+        "subHeading2": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "continueAppButtonText": "Prove your identity with the GOV.UK ID Check app",
-          "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
-          "continuePostOfficeButtonText": "Prove your identity at a Post Office",
-          "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+          "continueAppButtonText": "Profi eich hunaniaeth gyda’r ap GOV.UK ID Check",
+          "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
+          "continuePostOfficeButtonText": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
+          "continuePostOfficeButtonTextHint": "Byddwch yn rhoi manylion o’ch ID llun ar GOV.UK yn gyntaf."
+        }
+      }
+    },
+    "pyiCriEscapeNoF2f": {
+      "title": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "content": {
+        "paragraph1": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Yn seiliedig ar beth rydych wedi’i ddweud wrthym, mae gennych chi lun ID y gallwch ei ddefnyddio i brofi pwy ydych chi.",
+        "paragraph3": "Gallwch wneud hyn gyda’r ap GOV.UK ID Check os oes gennych:",
+        "bullet1": "iPhone 7 neu uwch",
+        "bullet2": "ffôn Android (er enghraifft, Samsung neu Google Pixel)",
+        "subHeading2": "Beth hoffech chi ei wneud?",
+        "formRadioButtons": {
+          "continueAppButtonText": "Profi eich hunaniaeth gyda’r ap GOV.UK ID Check",
+          "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
+          "otherWayButtonText": "Profi eich hunaniaeth mewn ffordd arall",
+          "otherWayButtonTextHint": "Ewch i’r gwasanaeth rydych am ei ddefnyddio a chwilio am ffyrdd eraill o brofi eich hunaniaeth."
         }
       }
     },
@@ -402,10 +421,10 @@
           "no": "Na"
         },
         "formErrorMessage": {
-          "errorPageTitle": "CY There has been an error",
-          "errorSummaryTitleText": "CY There is a problem",
-          "errorSummaryErrorText": "CY Please tell us if you have Photo ID",
-          "errorMessage": "CY Please choose an option"
+          "errorPageTitle": "There has been an error",
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryErrorText": "Please tell us if you have Photo ID",
+          "errorMessage": "Please choose an option"
         }
       }
     },
@@ -483,6 +502,12 @@
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
+        },
+        "formErrorMessage": {
+          "errorPageTitle": "TEMP Mae gwall wedi bod",
+          "errorSummaryTitleText": "TEMP Mae yna broblem",
+          "errorSummaryErrorText": "TEMP Dywedwch wrthym os oes gennych ID Llun",
+          "errorMessage": "TEMP Dewiswch opsiwn"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -400,6 +400,12 @@
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
+        },
+        "formErrorMessage": {
+          "errorPageTitle": "CY There has been an error",
+          "errorSummaryTitleText": "CY There is a problem",
+          "errorSummaryErrorText": "CY Please tell us if you have Photo ID",
+          "errorMessage": "CY Please choose an option"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -400,6 +400,12 @@
         "formRadioButtons": {
           "yes": "Yes",
           "no": "No"
+        },
+        "formErrorMessage": {
+          "errorPageTitle": "There has been an error",
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryErrorText": "Please tell us if you have Photo ID",
+          "errorMessage": "Please choose an option"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -124,7 +124,7 @@
         },
         "formErrorMessage": {
           "errorPageTitle": "Error: please choose an option",
-          "errorSummaryTitleText":"There is a problem",
+          "errorSummaryTitleText": "There is a problem",
           "errorSummaryDescriptionText": "Please choose another way to prove your identity",
           "errorRadioMessage": "Please choose an option"
         }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -121,6 +121,12 @@
         "formRadioButtons": {
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
           "restartButtonText": "Try proving your identity with GOV.UK One Login again"
+        },
+        "formErrorMessage": {
+          "errorPageTitle": "Error: please choose an option",
+          "errorSummaryTitleText":"There is a problem",
+          "errorSummaryDescriptionText": "Please choose another way to prove your identity",
+          "errorRadioMessage": "Please choose an option"
         }
       }
     },
@@ -404,8 +410,8 @@
         "formErrorMessage": {
           "errorPageTitle": "There has been an error",
           "errorSummaryTitleText": "There is a problem",
-          "errorSummaryErrorText": "Please tell us if you have Photo ID",
-          "errorMessage": "Please choose an option"
+          "errorSummaryDescriptionText": "Please tell us if you have Photo ID",
+          "errorRadioMessage": "Please choose an option"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -413,7 +413,9 @@
           "errorPageTitle": "Error: ",
           "errorSummaryTitleText": "There is a problem",
           "errorSummaryDescriptionText": "Please tell us if you have Photo ID",
+          "errorRadioMessageErrorText": "Error",
           "errorRadioMessage": "Please choose an option"
+
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -405,10 +405,12 @@
         "subHeading5": "Do you have any of these types of photo ID?",
         "formRadioButtons": {
           "yes": "Yes",
-          "no": "No"
+          "yesAccessibleContextText": "I have one of these types of photo ID",
+          "no": "No",
+          "noAccessibleContextText": "I do not have one of these types of photo ID"
         },
         "formErrorMessage": {
-          "errorPageTitle": "There has been an error",
+          "errorPageTitle": "Error: ",
           "errorSummaryTitleText": "There is a problem",
           "errorSummaryDescriptionText": "Please tell us if you have Photo ID",
           "errorRadioMessage": "Please choose an option"

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -65,8 +65,7 @@
     </li>
   </ul>
   <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
-  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST"
-        onsubmit="return identityDocumentStartPageOptionsFormSubmit()">
+  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {# build the radio button object contents outside of the nunjucks macro #}
@@ -100,16 +99,5 @@
     </button>
   </form>
 
-  <script>
-      let disableSubmit = false;
 
-      function identityDocumentStartPageOptionsFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
-      }
-  </script>
 {% endblock %}

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -19,7 +19,7 @@
       titleText: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate,
       errorList: [
         {
-          text: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryErrorText' | translate,
+          text: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
           href: "#identityDocumentStartPageOptionsForm"
         }
       ]
@@ -88,7 +88,7 @@
 
     {# if there was an error, add another key to the Object with the error message #}
     {% if errorState == 'true' %}
-      {% set errorMessageObject = {'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorMessage' | translate} %}
+      {% set errorMessageObject = {'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorRadioMessage' | translate} %}
       {% set radioButtonForm = radioButtonForm | setAttribute('errorMessage',errorMessageObject) %}
     {% endif %}
 

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -1,77 +1,115 @@
 {% extends "shared/base.njk" %}
+{% set ErrorState = true %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
+
+{% if ErrorState == true %}
+  {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorPageTitle' | translate +' – '+'pages.pageIpvIdentityDocumentStart.title' | translate %}
+  {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% else %}
+  {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
+{% endif %}
 {% set googleTagManagerPageId = "pageIpvIdentityDocumentStart" %}
 
+
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageIpvIdentityDocumentStart.header' | translate }}</h1>
-  <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>
+
+  {% if ErrorState == true %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryErrorText' | translate,
+          href: "#identityDocumentStartPageOptionsForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-l" id="header"
+      data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvIdentityDocumentStart.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>
 
   <ul class="govuk-list" role="list">
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading' | translate }}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">{{'pages.pageIpvIdentityDocumentStart.content.paragraph1' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph1' | translate }}</p>
       <ul class="govuk-list govuk-list--bullet ">
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list1' | translate }}</li>
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list2' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list1' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list2' | translate }}</li>
       </ul>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph2' | translate }}</p>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph2' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading2' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph3' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading2' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph3' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading3' | translate }}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">{{'pages.pageIpvIdentityDocumentStart.content.paragraph4' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading3' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph4' | translate }}</p>
       <ul class="govuk-list  govuk-list--bullet">
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list3' | translate }}</li>
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list4' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list3' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list4' | translate }}</li>
       </ul>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph5' | translate }}</p>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph5' | translate }}</p>
       <picture>
-        <source srcset="{{ assetsCdnPath }}/public/images/passport-icon.svg" />
-        <img width="174" height="121" loading="lazy" src="{{ assetsCdnPath }}/public/images/passport-icon-1x.png" srcset="{{ assetsCdnPath }}/public/images/passport-icon-2x.png 2x" alt="{{'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}" />
+        <source srcset="{{ assetsCdnPath }}/public/images/passport-icon.svg"/>
+        <img width="174" height="121" loading="lazy" src="{{ assetsCdnPath }}/public/images/passport-icon-1x.png"
+             srcset="{{ assetsCdnPath }}/public/images/passport-icon-2x.png 2x"
+             alt="{{ 'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}"/>
       </picture>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading4' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph6' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading4' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph6' | translate }}</p>
     </li>
   </ul>
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
-  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return identityDocumentStartPageOptionsFormSubmit()">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next",
-                text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate
-              },
-              {
-                value: "end",
-                text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate
-              }
-            ]
-      })
-    }}
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
+  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST"
+        onsubmit="return identityDocumentStartPageOptionsFormSubmit()">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    {# build the radio button object contents outside of the nunjucks macro #}
+
+    {% set radioButtonForm = {
+      idPrefix: "journey",
+      name: "journey",
+      items: [
+        {
+          value: "next",
+          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate
+        }
+      ]
+    } %}
+
+    {# if there was an error, add another key to the Object with the error message #}
+    {% if ErrorState == true %}
+      {% set errorMessageObject = {'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorMessage' | translate} %}
+      {% set radioButtonForm = radioButtonForm | setAttribute('errorMessage',errorMessageObject) %}
+    {% endif %}
+
+    {# Use the design system macro to output the radio button HTML #}
+    {{ govukRadios(radioButtonForm) }}
+
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
+      {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <script>
-    let disableSubmit = false;
-    function identityDocumentStartPageOptionsFormSubmit() {
-      if(!disableSubmit) {
-        disableSubmit = true;
-        document.getElementById('submitButton').disabled = true;
-        return true
+      let disableSubmit = false;
+
+      function identityDocumentStartPageOptionsFormSubmit() {
+          if (!disableSubmit) {
+              disableSubmit = true;
+              document.getElementById('submitButton').disabled = true;
+              return true
+          }
+          return false;
       }
-      return false;
-    }
   </script>
 {% endblock %}

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -1,9 +1,9 @@
 {% extends "shared/base.njk" %}
-{% set ErrorState = true %}
+{% set errorState = pageErrorState %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% if ErrorState == true %}
+{% if errorState == 'true' %}
   {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorPageTitle' | translate +' – '+'pages.pageIpvIdentityDocumentStart.title' | translate %}
   {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% else %}
@@ -14,7 +14,7 @@
 
 {% block content %}
 
-  {% if ErrorState == true %}
+  {% if errorState == 'true' %}
     {{ govukErrorSummary({
       titleText: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate,
       errorList: [
@@ -87,7 +87,7 @@
     } %}
 
     {# if there was an error, add another key to the Object with the error message #}
-    {% if ErrorState == true %}
+    {% if errorState == 'true' %}
       {% set errorMessageObject = {'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorMessage' | translate} %}
       {% set radioButtonForm = radioButtonForm | setAttribute('errorMessage',errorMessageObject) %}
     {% endif %}

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% if errorState == 'true' %}
-  {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorPageTitle' | translate +' – '+'pages.pageIpvIdentityDocumentStart.title' | translate %}
+  {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorPageTitle' | translate + 'pages.pageIpvIdentityDocumentStart.title' | translate %}
   {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% else %}
   {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
@@ -77,11 +77,11 @@
       items: [
         {
           value: "next",
-          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate
+          html: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate + '<span class="govuk-visually-hidden"> '+ 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yesAccessibleContextText' | translate + '</span>'
         },
         {
           value: "end",
-          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate
+          html: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate + '<span class="govuk-visually-hidden"> '+ 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.noAccessibleContextText' | translate + '</span>'
         }
       ]
     } %}

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -87,7 +87,12 @@
 
     {# if there was an error, add another key to the Object with the error message #}
     {% if errorState == 'true' %}
-      {% set errorMessageObject = {'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorRadioMessage' | translate} %}
+      {% set errorMessageObject = {
+        'visuallyHiddenText': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorRadioMessageErrorLabel' | translate,
+        'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorRadioMessage' | translate
+
+
+      } %}
       {% set radioButtonForm = radioButtonForm | setAttribute('errorMessage',errorMessageObject) %}
     {% endif %}
 

--- a/src/views/ipv/pyi-escape.njk
+++ b/src/views/ipv/pyi-escape.njk
@@ -1,31 +1,59 @@
 {% extends "shared/base.njk" %}
+{% set errorState = pageErrorState %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleName = 'pages.pyiEscape.title' | translate %}
+{% if errorState == 'true' %}
+  {% set pageTitleName = 'pages.pyiEscape.content.formErrorMessage.errorPageTitle' | translate + ' – ' + 'pages.pyiEscape.title' | translate %}
+  {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% else %}
+  {% set pageTitleName = 'pages.pyiEscape.title' | translate %}
+{% endif %}
+
 {% set googleTagManagerPageId = "pyiEscape" %}
 
 {% block content %}
+  {% if errorState == 'true' %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiEscape.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiEscapeForm"
+        }
+      ]
+    }) }}
+  {% endif %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiEscape.header' | translate }}</h1>
 
   <h2 class="govuk-heading-m">{{ 'pages.pyiEscape.content.subHeading' | translate }}</h2>
 
   <form id="pyiEscapeForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiEscapeFormSubmit()">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "end",
-                text: 'pages.pyiEscape.content.formRadioButtons.otherWayButtonText' | translate
-              },
-              {
-                value: "next",
-                text: 'pages.pyiEscape.content.formRadioButtons.restartButtonText' | translate
-              }
-            ]
-      })
-    }}
+
+    {% set radioButtonForm = {
+      idPrefix: "journey",
+      name: "journey",
+      items: [
+        {
+          value: "end",
+          text: 'pages.pyiEscape.content.formRadioButtons.otherWayButtonText' | translate
+        },
+        {
+          value: "next",
+          text: 'pages.pyiEscape.content.formRadioButtons.restartButtonText' | translate
+        }
+      ]
+    } %}
+
+    {# if there was an error, add another key to the Object with the error message #}
+    {% if errorState == 'true' %}
+      {% set errorMessageObject = {'text': 'pages.pyiEscape.content.formErrorMessage.errorRadioMessage' | translate} %}
+      {% set radioButtonForm = radioButtonForm | setAttribute('errorMessage',errorMessageObject) %}
+    {% endif %}
+
+    {# Use the design system macro to output the radio button HTML #}
+    {{ govukRadios(radioButtonForm) }}
+
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

These changes create a toggeable form error state on page-ipv-identity-start using the design system components.

### What changed

<!-- Describe the changes in detail - the "what"-->
So far:

* the `en/translation.json` file has extra test content added to feed into the error state components, `govukErrorSummary` and the `errorMessage` option in `govukRadios`
* the nunjucks file creates a radio button object and adds code to create the HTML required, controlled by an `errorState` boolean
* there is an extra nunjucks filter to push more keys into an object
* `middleware.js` has had some checking temporarily removed during development.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To improve the user experience and reduce uncertainty for `core-back`.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3427](https://govukverify.atlassian.net/browse/PYIC-3427)



[PYIC-3427]: https://govukverify.atlassian.net/browse/PYIC-3427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ