### PR TITLE
PYIC-3477: Update Content-Security-Policy to use nonce

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ const {
   CDN_DOMAIN,
 } = require("./lib/config");
 
-const { getGTM } = require("./lib/locals");
+const { setLocals } = require("./lib/locals");
 
 const { loggerMiddleware, logger } = require("./lib/logger");
 const express = require("express");
@@ -64,6 +64,7 @@ app.use(function (req, res, next) {
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(setLocals);
 app.use(securityHeadersHandler);
 
 if (CDN_PATH) {
@@ -161,7 +162,6 @@ router.use((req, res, next) => {
   next();
 });
 
-router.use(getGTM);
 router.use("/oauth2", require("./app/oauth2/router"));
 router.use("/credential-issuer", require("./app/credential-issuer/router"));
 router.use("/ipv", require("./app/ipv/router"));

--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -2,7 +2,12 @@ module.exports = {
   securityHeadersHandler: (req, res, next) => {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy": "default-src 'self'",
+      // Adapted from https://csp.withgoogle.com/docs/strict-csp.html
+      "Content-Security-Policy":
+        "default-src 'self'; " +
+        "object-src 'none'; " +
+        `script-src 'nonce-${res.locals.cspNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",

--- a/src/handlers/security-headers-handler.test.js
+++ b/src/handlers/security-headers-handler.test.js
@@ -17,6 +17,7 @@ describe("Security headers handler", () => {
     };
 
     res = {
+      locals: {},
       set: sinon.fake(),
       removeHeader: sinon.fake(),
     };
@@ -29,22 +30,30 @@ describe("Security headers handler", () => {
   });
 
   it("should add security headers to response", () => {
+    const testNonce = "test-nonce";
+
+    res.locals.cspNonce = testNonce;
     securityHeadersHandler(req, res, next);
-    expect(res.set).to.be.have.been.calledOnce;
-    expect(res.set).to.be.have.been.calledWith({
+
+    expect(res.set).to.have.been.calledOnce;
+    expect(res.set).to.have.been.calledWith({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy": "default-src 'self'",
+      "Content-Security-Policy":
+        "default-src 'self'; " +
+        "object-src 'none'; " +
+        `script-src 'nonce-${testNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",
     });
-    expect(next).to.be.have.been.calledOnce;
+    expect(next).to.have.been.calledOnce;
   });
 
   it("should remove express powered by header from response", () => {
     securityHeadersHandler(req, res, next);
-    expect(res.removeHeader).to.be.have.been.calledOnce;
-    expect(res.removeHeader).to.be.have.been.calledWith("X-Powered-By");
-    expect(next).to.be.have.been.calledOnce;
+    expect(res.removeHeader).to.have.been.calledOnce;
+    expect(res.removeHeader).to.have.been.calledWith("X-Powered-By");
+    expect(next).to.have.been.calledOnce;
   });
 });

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -7,9 +7,9 @@ const {
 const { generateNonce } = require("./strings");
 
 module.exports = {
-  getGTM: function (req, res, next) {
+  setLocals: function (req, res, next) {
     res.locals.gtmId = GTM_ID;
-    res.locals.scriptNonce = generateNonce();
+    res.locals.cspNonce = generateNonce();
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.assetsCdnPath = CDN_PATH;
     res.locals.assetPath = CDN_DOMAIN + "/assets";

--- a/src/views/ipv/page-f2f-multiple-doc-check.njk
+++ b/src/views/ipv/page-f2f-multiple-doc-check.njk
@@ -33,7 +33,7 @@
 
   <h2 class="govuk-heading-m">{{'pages.pageF2FMultipleDockCheck.content.subHeading2' | translate }}</h2>
 
-  <form id="faceToFacetMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return faceToFacetMultipleDocCheckingFormSubmit()">
+  <form id="faceToFacetMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -62,15 +62,17 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function faceToFacetMultipleDocCheckingFormSubmit() {
+    function faceToFacetMultipleDocCheckingFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
-      return false;
     }
+    document.getElementById("faceToFacetMultipleDocCheckingForm")
+      .addEventListener("submit", faceToFacetMultipleDocCheckingFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -41,7 +41,7 @@
     </li>
   </ul>
   <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
-  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return identityDocumentStartPageOptionsFormSubmit()">
+  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -63,15 +63,17 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function identityDocumentStartPageOptionsFormSubmit() {
+    function identityDocumentStartPageOptionsFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
-      return false;
     }
+    document.getElementById("identityDocumentStartPageOptionsForm")
+      .addEventListener("submit", identityDocumentStartPageOptionsFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page-ipv-identity-postoffice-start.njk
@@ -42,8 +42,7 @@
     </li>
   </ul>
   <h2 class="govuk-heading-m">{{ 'pages.pageIpvIdentityPostofficeStart.content.subHeading4' | translate }}</h2>
-  <form id="identityPostofficeStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST"
-        onsubmit="return identityPostofficeStartPageOptionsFormSubmit()">
+  <form id="identityPostofficeStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
       idPrefix: "journey",
@@ -64,16 +63,17 @@
     </button>
   </form>
 
-  <script>
-      let disableSubmit = false;
-
-      function identityPostofficeStartPageOptionsFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
+  <script nonce='{{ cspNonce }}'>
+    let disableSubmit = false;
+    function identityPostofficeStartPageOptionsFormSubmit(event) {
+      if (!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+      } else {
+        event.preventDefault();
       }
+    }
+    document.getElementById("identityPostofficeStartPageOptionsForm")
+      .addEventListener("submit", identityPostofficeStartPageOptionsFormSubmit)
   </script>
 {% endblock %}

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -15,7 +15,7 @@
 
   <h2 class="govuk-heading-m">{{'pages.pageMultipleDocCheck.content.subHeading' | translate }}</h2>
 
-  <form id="passportMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return passportMultipleDocCheckingFormSubmit()">
+  <form id="passportMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -44,15 +44,17 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function passportMultipleDocCheckingFormSubmit() {
+    function passportMultipleDocCheckingFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
-      return false;
     }
+    document.getElementById("passportMultipleDocCheckingForm")
+      .addEventListener("submit", passportMultipleDocCheckingFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/page-passport-doc-check.njk
+++ b/src/views/ipv/page-passport-doc-check.njk
@@ -15,8 +15,7 @@
 
   <h2 class="govuk-heading-m">{{ 'pages.pagePassportDocCheck.content.subHeading' | translate }}</h2>
 
-  <form id="passportDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST"
-        onsubmit="return passportDocCheckingFormSubmit()">
+  <form id="passportDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
       idPrefix: "journey",
@@ -39,16 +38,17 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
       let disableSubmit = false;
-
-      function passportDocCheckingFormSubmit() {
+      function passportDocCheckingFormSubmit(event) {
           if (!disableSubmit) {
               disableSubmit = true;
               document.getElementById('submitButton').disabled = true;
-              return true
+          } else {
+            event.preventDefault();
           }
-          return false;
       }
+      document.getElementById("passportMultipleDocCheckingForm")
+        .addEventListener("submit", passportDocCheckingFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/pyi-attempt-recovery.njk
+++ b/src/views/ipv/pyi-attempt-recovery.njk
@@ -9,7 +9,7 @@
   <h2 class="govuk-heading-m">{{'pages.pyiAttemptRecovery.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph2' | translate }}</p>
 
-  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST" onsubmit="return attemptRecoveryFormSubmit()">
+  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="attempt-recovery">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
@@ -17,16 +17,18 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function attemptRecoveryFormSubmit() {
+    function attemptRecoveryFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
-      return false;
     }
+    document.getElementById("attemptRecoveryForm")
+      .addEventListener("submit", attemptRecoveryFormSubmit);
   </script>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>

--- a/src/views/ipv/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/pyi-cri-escape-no-f2f.njk
@@ -17,7 +17,7 @@
   </ul>
   <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscapeNoF2f.content.subHeading2' | translate }}</h2>
 
-  <form id="pyiCriEscapeNoF2fForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiCriEscapeNoF2fFormSubmit()">
+  <form id="pyiCriEscapeNoF2fForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -48,16 +48,17 @@
     </a>
   </p>
 
-  <script>
-      let disableSubmit = false;
-
-      function pyiCriEscapeNoF2fFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
+  <script nonce='{{ cspNonce }}'>
+    let disableSubmit = false;
+    function pyiCriEscapeNoF2fFormSubmit(event) {
+      if (!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+      } else {
+        event.preventDefault();
       }
+    }
+    document.getElementById("pyiCriEscapeNoF2fForm")
+      .addEventListener("submit", pyiCriEscapeNoF2fFormSubmit)
   </script>
 {% endblock %}

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -18,7 +18,7 @@
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph4' | translate | safe }}</p>
   <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscape.content.subHeading2' | translate }}</h2>
 
-  <form id="pyiCriEscapeForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiCriEscapeFormSubmit()">
+  <form id="pyiCriEscapeForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -49,16 +49,17 @@
     </a>
   </p>
 
-  <script>
-      let disableSubmit = false;
-
-      function pyiCriEscapeFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
+  <script nonce='{{ cspNonce }}'>
+    let disableSubmit = false;
+    function pyiCriEscapeFormSubmit(event) {
+      if (!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+      } else {
+        event.preventDefault();
       }
+    }
+    document.getElementById("pyiCriEscapeForm")
+      .addEventListener("submit", pyiCriEscapeFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/pyi-escape.njk
+++ b/src/views/ipv/pyi-escape.njk
@@ -9,7 +9,7 @@
 
   <h2 class="govuk-heading-m">{{ 'pages.pyiEscape.content.subHeading' | translate }}</h2>
 
-  <form id="pyiEscapeForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiEscapeFormSubmit()">
+  <form id="pyiEscapeForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
     idPrefix: "journey",
@@ -37,16 +37,17 @@
     </a>
   </p>
 
-  <script>
-      let disableSubmit = false;
-
-      function pyiEscapeFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
-      }
+  <script nonce='{{ cspNonce }}'>
+    let disableSubmit = false;
+    function pyiEscapeFormSubmit(event) {
+        if (!disableSubmit) {
+          disableSubmit = true;
+          document.getElementById('submitButton').disabled = true;
+        } else {
+          event.preventDefault();
+        }
+    }
+    document.getElementById("pyiEscapeForm")
+      .addEventListener("submit", pyiEscapeFormSubmit);
   </script>
 {% endblock %}

--- a/src/views/ipv/pyi-f2f-technical.njk
+++ b/src/views/ipv/pyi-f2f-technical.njk
@@ -10,7 +10,7 @@
 
   <h2 class="govuk-heading-m">{{ 'pages.pyiF2fTechnical.content.subHeading' | translate }}</h2>
 
-  <form id="pyiF2fTechnicalForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiF2fTechnicalFormSubmit()">
+  <form id="pyiF2fTechnicalForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios({
       idPrefix: "journey",
@@ -31,17 +31,18 @@
     </button>
   </form>
 
-  <script>
-      let disableSubmit = false;
-
-      function pyiF2fTechnicalFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
+  <script nonce='{{ cspNonce }}'>
+    let disableSubmit = false;
+    function pyiF2fTechnicalFormSubmit(event) {
+      if (!disableSubmit) {
+        disableSubmit = true;
+        document.getElementById('submitButton').disabled = true;
+      } else {
+        event.preventDefault();
       }
+    }
+    document.getElementById("pyiF2fTechnicalForm")
+      .addEventListener("submit", pyiF2fTechnicalFormSubmit);
   </script>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>

--- a/src/views/ipv/pyi-timeout-recoverable.njk
+++ b/src/views/ipv/pyi-timeout-recoverable.njk
@@ -13,7 +13,7 @@
   </ul>
   <h2 class="govuk-heading-m">{{'pages.pyiTimeoutRecoverable.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pyiTimeoutRecoverable.content.paragraph2' | translate }}</p>
-  <form id="timeoutRecoverableForm" action="/ipv/page/pyi-timeout-recoverable" method="POST" onsubmit="return timeoutRecoverableFormSubmit()">
+  <form id="timeoutRecoverableForm" action="/ipv/page/pyi-timeout-recoverable" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="build-client-oauth-response">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
@@ -21,16 +21,18 @@
     </button>
   </form>
 
-  <script>
+  <script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function timeoutRecoverableFormSubmit() {
+    function timeoutRecoverableFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
-      return false;
     }
+    document.getElementById("timeoutRecoverableForm")
+      .addEventListener("submit", timeoutRecoverableFormSubmit);
   </script>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.shared.contactLinkHref' | translate }}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -17,7 +17,7 @@
 
     {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
     <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
+    <script nonce='{{ cspNonce }}' src="/html5-shiv/html5shiv.js"></script>
     <![endif]-->
 
     {% block headMetaData %}{% endblock %}
@@ -103,6 +103,6 @@
 
 {% block bodyEnd %}
     {% block scripts %}{% endblock %}
-    <script type="text/javascript"  src="{{ assetsCdnPath }}/public/javascripts/application.js"></script>
-    <script type="text/javascript" nonce='{{ scriptNonce }}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ googleTagManagerPageId }}")</script>
+    <script nonce='{{ cspNonce }}' src="{{ assetsCdnPath }}/public/javascripts/application.js"></script>
+    <script nonce='{{ cspNonce }}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ googleTagManagerPageId }}")</script>
 {% endblock %}

--- a/src/views/shared/journey-next-form.njk
+++ b/src/views/shared/journey-next-form.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<form id="nextForm" action="/ipv/page/{{pageId}}" method="POST" onsubmit="return nextFormSubmit()">
+<form id="nextForm" action="/ipv/page/{{pageId}}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
       {% if customButtonLabel %}
@@ -11,14 +11,17 @@
     </button>
 </form>
 
-<script>
+<script nonce='{{ cspNonce }}'>
     let disableSubmit = false;
-    function nextFormSubmit() {
+    function nextFormSubmit(event) {
       if(!disableSubmit) {
         disableSubmit = true;
         document.getElementById('submitButton').disabled = true;
-        return true
+      } else {
+        event.preventDefault();
       }
       return false;
     }
+    document.getElementById("nextForm")
+      .addEventListener("submit", nextFormSubmit);
 </script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change updates the CSP to follow the guidelines at https://csp.withgoogle.com/docs/strict-csp.html, i.e. using a nonce applied to all scripts, and more permissive fallbacks for older browsers.

### Why did it change

A previous change introduced a Content-Security-Policy with the value `default-src 'self'`, which blocks all inline scripts. This includes tracking scripts and various others.

### Issue tracking

- [PYIC-3477](https://govukverify.atlassian.net/browse/PYIC-3477)

### Other considerations

An alternative solution would be to add `unsafe-inline` (without `strict-dynamic`) to the CSP, allowing all inline scripts to run - but this significantly reduces the value of using a CSP.


[PYIC-3477]: https://govukverify.atlassian.net/browse/PYIC-3477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ