### PR TITLE
BAU: Validate JSON files as part of yarn lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     expect: true,
   },
   root: true,
-  extends: ["eslint:recommended", "prettier"],
+  extends: ["eslint:recommended", "prettier","plugin:jsonc/recommended-with-jsonc"],
   rules: {
     "no-console": 2,
     "padding-line-between-statements": [
@@ -19,4 +19,10 @@ module.exports = {
       { blankLine: "any", prev: "*", next: "*" },
     ],
   },
+  overrides: [
+    {
+      files: ["*.json"],
+      parser: "jsonc-eslint-parser",
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
   "devDependencies": {
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
-    "eslint": "8.46.0",
+    "eslint": "^8.46.0",
     "eslint-config-prettier": "8.8.0",
+    "eslint-plugin-jsonc": "^2.9.0",
     "eslint-plugin-prettier": "4.2.1",
     "husky": "8.0.3",
     "lint-staged": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "devDependencies": {
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
-    "eslint": "^8.46.0",
+    "eslint": "8.46.0",
     "eslint-config-prettier": "8.8.0",
-    "eslint-plugin-jsonc": "^2.9.0",
+    "eslint-plugin-jsonc": "2.9.0",
     "eslint-plugin-prettier": "4.2.1",
     "husky": "8.0.3",
     "lint-staged": "13.2.2",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

As part of the `yarn lint` pre-commit step, these changes check the `translation.json` files are valid.

### What changed

`package.json` and `.eslintrc.js` now use a new npm package, [eslint-plugin-jsonc](https://www.npmjs.com/package/eslint-plugin-jsonc).

### Why did it change

Some errors had crept into the translation files over time, so this change checks that a valid file structure is preserved as different team members work on the code.
