### PR TITLE
BAU: Don't use logging middleware for healthcheck

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -88,8 +88,6 @@ if (CDN_DOMAIN) {
   );
 }
 
-app.use(loggerMiddleware);
-
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
 i18next
@@ -152,6 +150,7 @@ app.use((req, res, next) => {
 app.set("etag", false);
 
 const router = express.Router();
+router.use(loggerMiddleware);
 
 router.use((req, res, next) => {
   req.log = logger.child({
@@ -166,10 +165,12 @@ router.use("/oauth2", require("./app/oauth2/router"));
 router.use("/credential-issuer", require("./app/credential-issuer/router"));
 router.use("/ipv", require("./app/ipv/router"));
 
-router.get("/healthcheck", (req, res) => {
+const healthcheckRouter = express.Router();
+healthcheckRouter.get("/healthcheck", (req, res) => {
   return res.status(200).send("OK");
 });
 
+app.use(healthcheckRouter);
 app.use(router);
 
 app.use(journeyEventErrorHandler);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Don't use logging middleware for healthcheck

### Why did it change

The logging middleware adds a custom message for each message received and each response. This is very noisy when you start pinging the app with healthchecks every 30 seconds.

This moves the middleware from being registered on the entire app to being registered on the router for the usual endpoints.

It also creates a brand new router for the healthcheck endpoint. This router doesn't have the logging middleware applied to it so we can avoid the spam.

IMPORTANT - the order that the routers are registered on the app with `app.use()` is important. The healthcheck router needs registering first, or the logging middleware will cascade down on to it. Very annoying.
