### PR TITLE
PYIC-3495: Make Driving licence document requirement clearer

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -377,7 +377,7 @@
       "header": "Parhau profi eich hunaniaeth ar-lein",
       "content": {
         "paragraph1": "Gallwch barhau i brofi’ch hunaniaeth ar-lein os:",
-        "bullet1": "oes gennych basbort y DU neu drwydded yrru y DU",
+        "bullet1": "have a UK passport or UK photocard driving licence",
         "bullet2": "rydych yn gallu ateb rhai cwestiynau diogelwch am bethau fel eich contract ffôn symudol, ac unrhyw gyfrifon banc, cardiau credyd, benthyciadau neu forgeisi sydd gennych o bosibl",
         "paragraph2": "Mae’n cymryd tua 10 munud i brofi eich hunaniaeth fel hyn.",
         "subHeading": "Os nad ydych yn siwr y byddwch yn gallu profi eich hunaniaeth ar-lein",
@@ -390,7 +390,7 @@
         "insetText": "Nid yw’r opsiwn hwn ar gael yn Gymraeg eto. Dewiswch un o’r opsiynau ar-lein os ydych am barhau yn Gymraeg.",
         "subHeading2": "Sut ydych chi am barhau?",
         "formRadioButtons": {
-          "continueDrivingLicenceButtonText": "Rhowch fanylion eich trwydded yrru y DU ac atebwch y cwestiynau diogelwch ar-lein",
+          "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",
           "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "separateOptionsInFormText": "neu",
           "otherWayButtonText": "Rhowch fanylion o’ch ID gyda llun ac ewch i Swyddfa’r Post"
@@ -474,10 +474,9 @@
       "content": {
         "paragraph": "Bydd hyn yn ein helpu i ddod o hyd i’r ffordd orau i chi brofi eich hunaniaeth.",
         "subHeading": "Trwydded yrru cerdyn gyda llun y DU",
-        "paragraph1": "Gallwch ddefnyddio trwydded yrru y DU os yw:",
-        "list1": "yn cynnwys eich llun",
+        "paragraph1": "You can use a full or provisional UK driving licence if it:",
+        "list1": "is a plastic photocard, not a paper licence",
         "list2": "heb ddod i ben",
-        "paragraph2": "Gall fod yn drwydded yrru y DU llawn neu dros dro.",
         "subHeading2": "Pasbort y DU",
         "paragraph3": "Gallwch ddefnyddio unrhyw pasbort y DU. Os yw’ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi eich hunaniaeth hyd at 18 mis ar ôl ei ddyddiad dod i ben.",
         "subHeading3": "Pasbort o’r tu allan i’r DU gyda sglodion biometrig",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -377,7 +377,7 @@
       "header": "Continue proving your identity online",
       "content": {
         "paragraph1": "You can continue proving your identity online if you:",
-        "bullet1": "have a UK passport or UK driving licence",
+        "bullet1": "have a UK passport or UK photocard driving licence",
         "bullet2": "can answer some security questions about things like your mobile phone contract, and any bank accounts, credit cards, loans or mortgages you may have",
         "paragraph2": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "If you’re not sure you’ll be able to prove your identity online",
@@ -390,7 +390,7 @@
         "insetText": "This option is not available in Welsh yet. Choose one of the online options if you want to continue in Welsh.",
         "subHeading2": "How do you want to continue?",
         "formRadioButtons": {
-          "continueDrivingLicenceButtonText": "Enter your UK driving licence details and answer security questions online",
+          "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",
           "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
           "separateOptionsInFormText": "or",
           "otherWayButtonText": "Enter details from your photo ID and go to a Post Office"
@@ -447,10 +447,9 @@
       "content": {
         "paragraph": "This will help us find the best way for you to prove your identity.",
         "subHeading": "UK photocard driving licence",
-        "paragraph1": "You can use a UK driving licence if it:",
-        "list1": "has your photo",
+        "paragraph1": "You can use a full or provisional UK driving licence if it:",
+        "list1": "is a plastic photocard, not a paper licence",
         "list2": "has not expired",
-        "paragraph2": "It can be a full or provisional UK driving licence.",
         "subHeading2": "UK passport",
         "paragraph3": "You can use any UK passport.",
         "subHeading3": "Non-UK passport with a biometric chip",

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -16,7 +16,6 @@
         <li>{{'pages.pageIpvIdentityDocumentStart.content.list1' | translate }}</li>
         <li>{{'pages.pageIpvIdentityDocumentStart.content.list2' | translate }}</li>
       </ul>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph2' | translate }}</p>
     </li>
     <li>
       <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading2' | translate }}</h2>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make Driving licence document requirement clearer

**_Welsh translations to come_**

### Why did it change

It was recently discovered that a small number of users have been attempting to use a paper driving licence in the web journey. 

We need to make it clear that users can only use plastic photocard driving licences — and not paper driving licences — to prove their identity 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3495](https://govukverify.atlassian.net/browse/PYIC-3495)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3495]: https://govukverify.atlassian.net/browse/PYIC-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ