### PR TITLE
PYIC-3591: Set up catalogue of core-front pages

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -85,7 +85,7 @@ Mappings:
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
       nodeOldSpaceLimit: "1896"
-      nodeEnv: "production"
+      nodeEnv: "development"
       desiredTaskCount: 2
       assetsDomain: "https://assets.build.account.gov.uk"
       assetsPath: "https://assets.build.account.gov.uk/core-front"

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -195,7 +195,10 @@ module.exports = {
       const currentEnvironment = process.env.NODE_ENV;
       const { pageId } = req.params;
 
-      if (currentEnvironment === "development") {
+      if (
+        currentEnvironment === "development" &&
+        req.session.visitedAllTemplates
+      ) {
         if (pageId === "page-ipv-reuse") {
           let userDetailsResponse = samplePersistedUserDetails;
           const i18n = req.i18n;
@@ -412,6 +415,8 @@ module.exports = {
         const templatesWithoutExtension = files.map(
           (file) => path.parse(file).name
         );
+
+        req.session.visitedAllTemplates = true;
 
         res.render("ipv/all-templates.njk", {
           allTemplates: templatesWithoutExtension,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -3,6 +3,7 @@ const sanitize = require("sanitize-filename");
 const {
   API_BASE_URL,
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
+  DEVELOPMENT_ENVIRONMENT,
 } = require("../../lib/config");
 const {
   buildCredentialIssuerRedirectURL,
@@ -196,13 +197,14 @@ module.exports = {
       const { pageId } = req.params;
 
       if (
-        currentEnvironment === "development" &&
+        currentEnvironment === DEVELOPMENT_ENVIRONMENT &&
         req.session.visitedAllTemplates
       ) {
         if (pageId === "page-ipv-reuse") {
-          let userDetailsResponse = samplePersistedUserDetails;
-          const i18n = req.i18n;
-          const userDetails = generateUserDetails(userDetailsResponse, i18n);
+          const userDetails = generateUserDetails(
+            samplePersistedUserDetails,
+            req.i18n
+          );
 
           return res.render(`ipv/${sanitize(pageId)}.njk`, {
             userDetails,
@@ -277,12 +279,14 @@ module.exports = {
             csrfToken: req.csrfToken(),
           });
         case "page-ipv-reuse": {
-          let userDetailsResponse = await axios.get(
+          const userDetailsResponse = await axios.get(
             `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
             generateAxiosConfig(req)
           );
-          const i18n = req.i18n;
-          const userDetails = generateUserDetails(userDetailsResponse, i18n);
+          const userDetails = generateUserDetails(
+            userDetailsResponse,
+            req.i18n
+          );
 
           return res.render(`ipv/${sanitize(pageId)}.njk`, {
             userDetails,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -13,6 +13,7 @@ const {
   handleCimitEscapeAction,
   renderFeatureSetPage,
   validateFeatureSet,
+  allTemplates,
 } = require("./middleware");
 
 const csrfProtection = csrf({});
@@ -25,6 +26,11 @@ function checkLanguage(req, res, next) {
   res.locals.isWelsh = lang === "cy";
 
   next();
+}
+
+const currentEnvironment = process.env.NODE_ENV;
+if (currentEnvironment !== "development") {
+  router.get("/all-templates", allTemplates, handleJourneyPage);
 }
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -2,6 +2,7 @@ const express = require("express");
 const csrf = require("csurf");
 const bodyParser = require("body-parser");
 const router = express.Router();
+const { DEVELOPMENT_ENVIRONMENT } = require("../../lib/config");
 
 const {
   renderAttemptRecoveryPage,
@@ -29,7 +30,7 @@ function checkLanguage(req, res, next) {
 }
 
 const currentEnvironment = process.env.NODE_ENV;
-if (currentEnvironment === "development") {
+if (currentEnvironment === DEVELOPMENT_ENVIRONMENT) {
   router.get("/all-templates", allTemplates);
 }
 

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -29,8 +29,8 @@ function checkLanguage(req, res, next) {
 }
 
 const currentEnvironment = process.env.NODE_ENV;
-if (currentEnvironment !== "development") {
-  router.get("/all-templates", allTemplates, handleJourneyPage);
+if (currentEnvironment === "development") {
+  router.get("/all-templates", allTemplates);
 }
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);

--- a/src/app/shared/reuseHelper.js
+++ b/src/app/shared/reuseHelper.js
@@ -1,3 +1,5 @@
+const { generateHTMLofAddress } = require("./addressHelper");
+
 module.exports = {
   samplePersistedUserDetails: {
     data: {
@@ -46,5 +48,24 @@ module.exports = {
         },
       ],
     },
+  },
+  generateUserDetails: (userDetailsResponse, i18n) => {
+    return {
+      name: userDetailsResponse.data?.name,
+      dateOfBirth: userDetailsResponse.data?.dateOfBirth,
+      addresses: userDetailsResponse.data?.addresses.map((address, idx) => {
+        const addressDetailHtml = generateHTMLofAddress(address);
+        const label =
+          idx === 0
+            ? i18n.t(
+                "pages.pageIpvReuse.content.userDetailsInformation.currentAddress"
+              )
+            : `${i18n.t(
+                "pages.pageIpvReuse.content.userDetailsInformation.previousAddress"
+              )} ${idx}`;
+
+        return { label, addressDetailHtml };
+      }),
+    };
   },
 };

--- a/src/app/shared/reuseHelper.test.js
+++ b/src/app/shared/reuseHelper.test.js
@@ -1,0 +1,95 @@
+const { expect } = require("chai");
+const {
+  samplePersistedUserDetails,
+  generateUserDetails,
+} = require("./reuseHelper");
+
+describe("Sample Persisted User Details", () => {
+  it("should have the expected structure", () => {
+    expect(samplePersistedUserDetails).to.deep.equal({
+      data: {
+        addresses: [
+          {
+            departmentName: "Room 25",
+            organisationName: "Turing House",
+            subBuildingName: "Block 4b",
+            buildingName: "Vital Living",
+            buildingNumber: "1",
+            dependentStreetName: "Circular Square",
+            streetName: "7 O'Reilly Way",
+            doubleDependentAddressLocality: "Oxford Lane",
+            dependentAddressLocality: "University Quarter",
+            addressLocality: "Lancaster",
+            postalCode: "M12 7LU",
+          },
+          {
+            subBuildingName: "Flat 24",
+            buildingName: "Wollatorn House",
+            buildingNumber: "7",
+            streetName: "Batchelor Street",
+            addressLocality: "London",
+            postalCode: "N15 0EY",
+          },
+          {
+            subBuildingName: "Flat 18",
+            buildingName: "The Paper Apartments",
+            buildingNumber: "162",
+            streetName: "Offord Road",
+            addressLocality: "London",
+            postalCode: "N2 1NS",
+          },
+          {
+            buildingNumber: "7",
+            streetName: "Acorne Terrace",
+            addressLocality: "London",
+            postalCode: "N16 4QF",
+          },
+        ],
+        dateOfBirth: "1984-02-29",
+        name: "Alessandro Cholmondeley-Featherstonehaugh",
+      },
+    });
+  });
+});
+
+describe("Generate User Details", () => {
+  it("should generate user details correctly", () => {
+    const userDetailsResponse = samplePersistedUserDetails;
+
+    const i18n = {
+      t: (key) => key,
+    };
+
+    const userDetails = generateUserDetails(userDetailsResponse, i18n);
+
+    expect(userDetails).to.deep.equal({
+      name: "Alessandro Cholmondeley-Featherstonehaugh",
+      dateOfBirth: "1984-02-29",
+      addresses: [
+        {
+          label:
+            "pages.pageIpvReuse.content.userDetailsInformation.currentAddress",
+          addressDetailHtml:
+            "Room 25, Turing House, Block 4b, Vital Living<br>1 Circular Square 7 O'Reilly Way<br>Oxford Lane University Quarter Lancaster<br>M12 7LU",
+        },
+        {
+          label:
+            "pages.pageIpvReuse.content.userDetailsInformation.previousAddress 1",
+          addressDetailHtml:
+            "Flat 24, Wollatorn House<br>7 Batchelor Street<br>London<br>N15 0EY",
+        },
+        {
+          label:
+            "pages.pageIpvReuse.content.userDetailsInformation.previousAddress 2",
+          addressDetailHtml:
+            "Flat 18, The Paper Apartments<br>162 Offord Road<br>London<br>N2 1NS",
+        },
+        {
+          label:
+            "pages.pageIpvReuse.content.userDetailsInformation.previousAddress 3",
+          addressDetailHtml: "7 Acorne Terrace<br>London<br>N16 4QF",
+        },
+      ],
+    });
+  });
+});

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,6 +14,7 @@ module.exports = {
   API_SESSION_INITIALISE: "/session/initialise",
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS:
     "/journey/build-proven-user-identity-details",
+  DEVELOPMENT_ENVIRONMENT: "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/views/ipv/all-templates.njk
+++ b/src/views/ipv/all-templates.njk
@@ -3,13 +3,7 @@
 
 {% block content %}
   <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--l"></caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">List of all pages in di-ipv-core-front</th>
-        <th scope="col" class="govuk-table__header"></th>
-      </tr>
-    </thead>
+    <caption class="govuk-table__caption govuk-table__caption--l">List of all pages in di-ipv-core-front</caption>
     <tbody class="govuk-table__body">
       {% for template in allTemplates %}
         <tr class="govuk-table__row">

--- a/src/views/ipv/all-templates.njk
+++ b/src/views/ipv/all-templates.njk
@@ -1,0 +1,24 @@
+{% extends "shared/base.njk" %}
+{% set pageTitleName = "All templates" %}
+
+{% block content %}
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--l"></caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">List of all pages in di-ipv-core-front</th>
+        <th scope="col" class="govuk-table__header"></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for template in allTemplates %}
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">{{ template }}</th>
+          <td class="govuk-table__cell">
+            <a class="govuk-link" href="/ipv/page/{{ template }}?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/{{ template }}?lng=cy">Welsh</a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set up catalogue of core-front pages

Use the NODE_ENV to determine whether we are in a non-production environment to display the new route
Repurposed the existing unused data we already had defined
Moved the reuse code into the helper as it is now used in two places
<img width="400" alt="Screenshot 2023-09-28 at 09 49 19" src="https://github.com/alphagov/di-ipv-core-front/assets/24409958/cc05966a-715a-42d3-a0a4-8cd48d0bc7e5">

### Why did it change

We’d like devs/testers/UCD/any non-technical stakeholders to be able to view a catalogue of all the pages served by core-front, labelled by their path slug/file name with each page clickable to view. This is also important so we develop a common language around page names with UCD

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3591](https://govukverify.atlassian.net/browse/PYIC-3591)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changes


[PYIC-3591]: https://govukverify.atlassian.net/browse/PYIC-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ