### PR TITLE
PYIC-2537: Added cookieDomain to i18n config

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -615,6 +615,14 @@ Resources:
                   - IsDev01
                   - !Sub "${Environment}.01.dev.identity.account.gov.uk"
                   - !If [IsDev02, !Sub "${Environment}.02.dev.identity.account.gov.uk", !Sub "${Environment}.account.gov.uk"]
+            - Name: SERVICE_DOMAIN
+              Value: !If
+                - IsProduction
+                - "account.gov.uk"
+                - !If
+                  - IsDev01
+                  - !Sub "${Environment}.01.dev.identity.account.gov.uk"
+                  - !If [IsDev02, !Sub "${Environment}.02.dev.identity.account.gov.uk", !Sub "${Environment}.account.gov.uk"]
             - Name: SESSION_SECRET
               Value: "no-secret"
             - Name: NODE_OPTIONS

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -4,6 +4,7 @@ const {
   API_BASE_URL,
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
   DEVELOPMENT_ENVIRONMENT,
+  getServiceDomain,
 } = require("../../lib/config");
 const {
   buildCredentialIssuerRedirectURL,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -4,7 +4,6 @@ const {
   API_BASE_URL,
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
   DEVELOPMENT_ENVIRONMENT,
-  getServiceDomain,
 } = require("../../lib/config");
 const {
   buildCredentialIssuerRedirectURL,

--- a/src/config/i18next.js
+++ b/src/config/i18next.js
@@ -1,4 +1,3 @@
-const { getAppEnv } = require("cfenv");
 const { getServiceDomain } = require("../lib/config");
 
 module.exports = {

--- a/src/config/i18next.js
+++ b/src/config/i18next.js
@@ -1,3 +1,6 @@
+const { getAppEnv } = require("cfenv");
+const { getServiceDomain } = require("../lib/config");
+
 module.exports = {
   i18nextConfigurationOptions: function (path) {
     return {
@@ -16,7 +19,7 @@ module.exports = {
         caches: ["cookie"],
         ignoreCase: true,
         cookieSecure: true,
-        cookieDomain: "", //getServiceDomain(),
+        cookieDomain: getServiceDomain(),
         cookieSameSite: "",
       },
     };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -28,5 +28,5 @@ module.exports = {
   GTM_ANALYTICS_COOKIE_DOMAIN: process.env.ANALYTICS_DOMAIN,
   CDN_PATH: process.env.CDN_PATH,
   CDN_DOMAIN: process.env.CDN_DOMAIN,
-  getServiceDomain
+  getServiceDomain,
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -8,6 +8,10 @@ if (!appEnv.isLocal) {
   serviceConfig.coreBackAPIUrl = appEnv.getServiceURL("core-back-api");
 }
 
+function getServiceDomain() {
+  return process.env.SERVICE_DOMAIN || "localhost";
+}
+
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_CRI_CALLBACK: "/journey/cri/callback",
@@ -24,4 +28,5 @@ module.exports = {
   GTM_ANALYTICS_COOKIE_DOMAIN: process.env.ANALYTICS_DOMAIN,
   CDN_PATH: process.env.CDN_PATH,
   CDN_DOMAIN: process.env.CDN_DOMAIN,
+  getServiceDomain
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added a cookieDomain parameter to i18n internationalisation config. This is defined using a TF parameter called SERVICE_DOMAIN to allow for environment specific cookies to be set.

### Why did it change

IPV Core needs to align it's language cookie domain approaches with other services, so that they can all access and modify a single unified cookie across all services within any given environment.

Prior to this change, IPV Core would only set a cookie for IPV core components, and any change wouldn't get picked up by any other service, and this would also result in multiple lng cookies being set at once but for different domains and sometimes different languages.

Technically a user cannot set a language once already in IPV Core, but it is theoretically possible to change the cookie value using the query parameters.

The cookie domain approach should definitely be aligned with other services nonetheless.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2537](https://govukverify.atlassian.net/browse/PYIC-2537)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository



[PYIC-2537]: https://govukverify.atlassian.net/browse/PYIC-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ