### PR TITLE
IPS-267 SonarCloud to govuk-one-login

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-json
     -   id: end-of-file-fixer
@@ -9,12 +9,12 @@ repos:
         args: [ --allow-missing-credentials ]
     -   id: detect-private-key
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.68.1 # The version of cfn-lint to use
+    rev: v0.80.4 # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
         files: .template\.yaml$
 - repo: https://github.com/bridgecrewio/checkov.git
-  rev: '2.1.294'
+  rev: '2.5.4'
   hooks:
   - id: checkov
     verbose: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=alphagov_di-ipv-core-front
-sonar.organization=alphagov
+sonar.organization=govuk-one-login
 
 sonar.sources=src/
 sonar.exclusions=**/assets/**,**/*.test.js,**/service-unavailable-s3/**,**/config/**,**/lib/**,**/*router.js,**/axiosHelper.js,**/app.js


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
IPS-267 SonarCloud to govuk-one-login
<!-- Describe the changes in detail - the "what"-->

### Why did it change
IPS-267 SonarCloud to govuk-one-login
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-267](https://govukverify.atlassian.net/browse/IPS-267)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-267]: https://govukverify.atlassian.net/browse/IPS-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ