### PR TITLE
PYIC-3540: use render instead of redirect to handle technical error page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -245,8 +245,7 @@ module.exports = {
         );
 
         req.session.currentPage = "pyi-attempt-recovery";
-        // res.status(400);
-        return res.status(400).render(req.session.currentPage);
+        return res.redirect(req.session.currentPage);
       }
 
       switch (pageId) {
@@ -315,7 +314,8 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
+        res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
+        return res.render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "end") {
         await handleJourneyResponse(req, res, "journey/end");
@@ -346,7 +346,8 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
+        res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
+        return res.render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/passport") {
         await handleJourneyResponse(req, res, "journey/ukPassport");
@@ -368,7 +369,8 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
+        res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
+        return res.render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/f2f") {
         await handleJourneyResponse(req, res, "journey/f2f");
@@ -390,7 +392,8 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
+        res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
+        return res.render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/f2f") {
         await handleJourneyResponse(req, res, "journey/f2f");

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -245,7 +245,8 @@ module.exports = {
         );
 
         req.session.currentPage = "pyi-attempt-recovery";
-        return res.redirect(req.session.currentPage);
+        // res.status(400);
+        return res.status(400).render(req.session.currentPage);
       }
 
       switch (pageId) {
@@ -314,7 +315,7 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "end") {
         await handleJourneyResponse(req, res, "journey/end");
@@ -345,7 +346,7 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/passport") {
         await handleJourneyResponse(req, res, "journey/ukPassport");
@@ -367,7 +368,7 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/f2f") {
         await handleJourneyResponse(req, res, "journey/f2f");
@@ -389,7 +390,7 @@ module.exports = {
         logError(req, err);
 
         req.session.currentPage = "pyi-technical-unrecoverable";
-        return res.redirect(`/ipv/page/pyi-technical-unrecoverable`);
+        return res.status(HTTP_STATUS_CODES.UNAUTHORIZED).render("ipv/pyi-technical-unrecoverable.njk");
       }
       if (req.body?.journey === "next/f2f") {
         await handleJourneyResponse(req, res, "journey/f2f");

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -492,7 +492,9 @@ describe("journey middleware", () => {
 
       await middleware.handleJourneyAction(req, res, next);
       expect(res.status).to.have.been.calledWith(401);
-      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
     });
   });
 
@@ -622,7 +624,9 @@ describe("journey middleware", () => {
 
         await middleware.handleMultipleDocCheck(req, res, next);
         expect(res.status).to.have.been.calledWith(401);
-        expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+        expect(res.render).to.have.been.calledWith(
+          "ipv/pyi-technical-unrecoverable.njk"
+        );
       });
     }
   );
@@ -683,7 +687,9 @@ describe("journey middleware", () => {
 
         await middleware.handleCriEscapeAction(req, res, next);
         expect(res.status).to.have.been.calledWith(401);
-        expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+        expect(res.render).to.have.been.calledWith(
+          "ipv/pyi-technical-unrecoverable.njk"
+        );
       });
     }
   );

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -491,9 +491,8 @@ describe("journey middleware", () => {
       };
 
       await middleware.handleJourneyAction(req, res, next);
-      expect(res.redirect).to.have.been.calledWith(
-        "/ipv/page/pyi-technical-unrecoverable"
-      );
+      expect(res.status).to.have.been.calledWith(401);
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
     });
   });
 
@@ -622,9 +621,8 @@ describe("journey middleware", () => {
         };
 
         await middleware.handleMultipleDocCheck(req, res, next);
-        expect(res.redirect).to.have.been.calledWith(
-          "/ipv/page/pyi-technical-unrecoverable"
-        );
+        expect(res.status).to.have.been.calledWith(401);
+        expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
       });
     }
   );
@@ -684,9 +682,8 @@ describe("journey middleware", () => {
         };
 
         await middleware.handleCriEscapeAction(req, res, next);
-        expect(res.redirect).to.have.been.calledWith(
-          "/ipv/page/pyi-technical-unrecoverable"
-        );
+        expect(res.status).to.have.been.calledWith(401);
+        expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
       });
     }
   );

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -61,9 +61,7 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-technical-unrecoverable"
-      );
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
     });
 
     it("should render pyi-unrecoverable view when unexpected error", () => {
@@ -72,9 +70,7 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-technical-unrecoverable"
-      );
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
     });
 
     it("should render session-ended view when no session", () => {
@@ -97,9 +93,7 @@ describe("Error handlers", () => {
       expect(req.log.error.firstArg.message.errorMessageContext).to.equal(
         "Bad response - status is not a function"
       );
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-technical-unrecoverable"
-      );
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
     });
 
     it("should call next if headers sent", () => {

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -61,7 +61,9 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
     });
 
     it("should render pyi-unrecoverable view when unexpected error", () => {
@@ -70,7 +72,9 @@ describe("Error handlers", () => {
       serverErrorHandler(err, req, res, next);
 
       expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
     });
 
     it("should render session-ended view when no session", () => {
@@ -93,7 +97,9 @@ describe("Error handlers", () => {
       expect(req.log.error.firstArg.message.errorMessageContext).to.equal(
         "Bad response - status is not a function"
       );
-      expect(res.render).to.have.been.calledWith("ipv/pyi-technical-unrecoverable.njk");
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-technical-unrecoverable.njk"
+      );
     });
 
     it("should call next if headers sent", () => {

--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -130,9 +130,7 @@ describe("Error handlers", () => {
 
       journeyEventErrorHandler(err, req, res, next);
 
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-technical"
-      );
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical.njk");
     });
 
     it("should call next with error when there is no pageId", () => {
@@ -161,8 +159,8 @@ describe("Error handlers", () => {
       journeyEventErrorHandler(err, req, res, next);
       expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
 
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-timeout-recoverable"
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-timeout-recoverable.njk"
       );
     });
 

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -28,6 +28,6 @@ module.exports = {
     }
 
     req.session.currentPage = "pyi-technical-unrecoverable";
-    res.redirect("/ipv/page/pyi-technical-unrecoverable");
+    res.render("ipv/pyi-technical-unrecoverable.njk");
   },
 };

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,4 +1,5 @@
 const sanitize = require("sanitize-filename");
+const { HTTP_STATUS_CODES } = require("../app.constants");
 
 module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
@@ -23,7 +24,11 @@ module.exports = {
           res.err.response.data.clientOAuthSessionId;
       }
       req.session.currentPage = pageId;
-      return res.redirect(`/ipv/page/${pageId}`);
+      res.err?.status
+        ? res.status(res.err.status)
+        : res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+
+      return res.render(`ipv/${pageId}`);
     }
 
     next(err);

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -28,7 +28,7 @@ module.exports = {
         ? res.status(res.err.status)
         : res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
 
-      return res.render(`ipv/${pageId}`);
+      return res.render(`ipv/${pageId}.njk`);
     }
 
     next(err);

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -18,7 +18,7 @@ const logger = pino({
     },
     res: (res) => {
       return {
-        statusCode: res.statusCode,
+        statusCode: res.err?.response?.status || res?.statusCode,
         sessionId: res.locals.sessionId,
       };
     },
@@ -57,6 +57,7 @@ const loggerMiddleware = require("pino-http")({
     };
   },
   customErrorMessage: function (req, res) {
+    res.statusCode = res?.err?.response?.status;
     return `REQUEST ERRORED WITH STATUS CODE: ${res.statusCode}`;
   },
   customErrorObject: (req, res, error, val) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Replace technical error page redirection with render method.

### What changed

- Replaced redirection with page render method.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- At the moment front is not sending correct http status code to Analytics tools, because of redirections front is sending 302 and 200 status code instead of error codes like (400, 500 etc)

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3540](https://govukverify.atlassian.net/browse/PYIC-3540)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3540]: https://govukverify.atlassian.net/browse/PYIC-3540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ