### PR TITLE
PYIC-3642: Fix welsh translation json format

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -474,30 +474,30 @@
           "yes": "Oes",
           "no": "Na"
         }
-      },
-      "PyiPostofficeStart": {
-        "title": "Profwch eich hunaniaeth mewn Swyddfa’r Post - GOV.UK One Login",
-        "header": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
-        "content": {
-          "paragraph1": "Gallwch brofi pwy ydych chi mewn Swyddfa’r Post yn lle hynny.",
-          "paragraph2": "Gofynnir i chi:",
-          "list1": "rhoi manylion o’ch ID gyda llun ar GOV.UK",
-          "list2": "mynd i Swyddfa Bost lle byddant yn sganio’ch ID a thynnu llun ohonoch",
-          "paragraph3": "Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
-          "subHeading": "Mathau o ID gyda llun y gallwch eu defnyddio mewn Swyddfa Bost",
-          "paragraph4": "Byddwch angen un o’r canlynol:",
-          "list3": "trwydded yrru cerdyn-llun yn y DU (llawn neu dros dro)",
-          "list4": "pasbort y DU",
-          "list5": "pasbort o’r tu allan i’r DU",
-          "list6": "trwydded breswylio biometrig y DU (BRP)",
-          "list7": "trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)",
-          "list8": "cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)",
-          "insetText": "Ni allwch brofi eich hunaniaeth mewn Swyddfa Bost gyda thrwydded Gweithwyr Ffiniol (FWP) na cherdyn preswylio biometrig y DU (BRC), a elwir hefyd yn gerdyn preswylio yn y DU.",
-          "subHeading2": "Oes gennych chi ID gyda llun y gallwch ei ddefnyddio mewn Swyddfa’r Post?",
-          "formRadioButtons": {
-            "yes": "Oes",
-            "no": "Na"
-          }
+      }
+    },
+    "PyiPostofficeStart": {
+      "title": "Profwch eich hunaniaeth mewn Swyddfa’r Post - GOV.UK One Login",
+      "header": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
+      "content": {
+        "paragraph1": "Gallwch brofi pwy ydych chi mewn Swyddfa’r Post yn lle hynny.",
+        "paragraph2": "Gofynnir i chi:",
+        "list1": "rhoi manylion o’ch ID gyda llun ar GOV.UK",
+        "list2": "mynd i Swyddfa Bost lle byddant yn sganio’ch ID a thynnu llun ohonoch",
+        "paragraph3": "Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
+        "subHeading": "Mathau o ID gyda llun y gallwch eu defnyddio mewn Swyddfa Bost",
+        "paragraph4": "Byddwch angen un o’r canlynol:",
+        "list3": "trwydded yrru cerdyn-llun yn y DU (llawn neu dros dro)",
+        "list4": "pasbort y DU",
+        "list5": "pasbort o’r tu allan i’r DU",
+        "list6": "trwydded breswylio biometrig y DU (BRP)",
+        "list7": "trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)",
+        "list8": "cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)",
+        "insetText": "Ni allwch brofi eich hunaniaeth mewn Swyddfa Bost gyda thrwydded Gweithwyr Ffiniol (FWP) na cherdyn preswylio biometrig y DU (BRC), a elwir hefyd yn gerdyn preswylio yn y DU.",
+        "subHeading2": "Oes gennych chi ID gyda llun y gallwch ei ddefnyddio mewn Swyddfa’r Post?",
+        "formRadioButtons": {
+          "yes": "Oes",
+          "no": "Na"
         }
       }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Fix Json fromat for the welsh translation property PyiPostofficeStart

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3642](https://govukverify.atlassian.net/browse/PYIC-3642)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3642]: https://govukverify.atlassian.net/browse/PYIC-3642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ