### PR TITLE
BAU: Save session before internal redirect

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -36,6 +36,7 @@ const axios = require("axios");
 const { getIpAddress } = require("../shared/ipAddressHelper");
 const fs = require("fs");
 const path = require("path");
+const { saveSessionAndRedirect } = require("../shared/redirectHelper");
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -119,7 +120,11 @@ async function handleBackendResponse(req, res, backendResponse) {
       requestId: req.requestId,
     });
     req.session.currentPage = backendResponse.page;
-    return res.redirect(`/ipv/page/${backendResponse.page}`);
+    return await saveSessionAndRedirect(
+      req,
+      res,
+      `/ipv/page/${backendResponse.page}`
+    );
   }
 }
 
@@ -245,7 +250,11 @@ module.exports = {
         );
 
         req.session.currentPage = "pyi-attempt-recovery";
-        return res.redirect(req.session.currentPage);
+        return await saveSessionAndRedirect(
+          req,
+          res,
+          `/ipv/page/pyi-attempt-recovery`
+        );
       }
 
       switch (pageId) {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -57,6 +57,7 @@ describe("journey middleware", () => {
           ipAddress: "ip-address",
           clientOauthSessionId: "fake-oauth-session-id",
           featureSet: "feature-set",
+          save: sinon.fake.yields(null),
         },
         log: { info: sinon.fake(), error: sinon.fake() },
       };
@@ -170,12 +171,17 @@ describe("journey middleware", () => {
       req = {
         id: "1",
         params: { pageId: "invalid-page-id" },
-        session: { currentPage: "../ipv/page-multiple-doc-check" },
+        session: {
+          currentPage: "../ipv/page-multiple-doc-check",
+          save: sinon.fake.yields(null),
+        },
         log: { info: sinon.fake(), error: sinon.fake() },
       };
 
       await middleware.handleJourneyPage(req, res);
-      expect(res.redirect).to.have.been.calledWith("pyi-attempt-recovery");
+      expect(res.redirect).to.have.been.calledWith(
+        "/ipv/page/pyi-attempt-recovery"
+      );
     });
 
     it("should raise an error when missing pageId", async () => {
@@ -479,7 +485,7 @@ describe("journey middleware", () => {
   );
 
   context("handling missing ipvSessionId before calling the backend", () => {
-    it("should redirect to the technical unrecoverable page", async function () {
+    it("should render the technical unrecoverable page", async function () {
       req = {
         id: "1",
         session: {
@@ -611,7 +617,7 @@ describe("journey middleware", () => {
   context(
     "handleMultipleDocCheck: handling missing ipvSessionId before calling the backend",
     () => {
-      it("should redirect to the technical unrecoverable page", async function () {
+      it("should render the technical unrecoverable page", async function () {
         req = {
           id: "1",
           session: {
@@ -674,7 +680,7 @@ describe("journey middleware", () => {
   context(
     "handleCriEscapeAction: handling missing ipvSessionId before calling the backend",
     () => {
-      it("should redirect to the technical unrecoverable page", async function () {
+      it("should render the technical unrecoverable page", async function () {
         req = {
           id: "1",
           session: {

--- a/src/app/shared/redirectHelper.js
+++ b/src/app/shared/redirectHelper.js
@@ -1,0 +1,13 @@
+const { logError } = require("./loggerHelper");
+
+module.exports = {
+  saveSessionAndRedirect: async (req, res, redirectUrl) => {
+    await req.session.save(function (err) {
+      if (err) {
+        logError(req, err, "Error saving session");
+        throw err;
+      }
+      return res.redirect(redirectUrl);
+    });
+  },
+};

--- a/src/app/shared/redirectHelper.test.js
+++ b/src/app/shared/redirectHelper.test.js
@@ -1,0 +1,39 @@
+const { expect } = require("chai");
+const { saveSessionAndRedirect } = require("./redirectHelper");
+
+describe("saveSessionAndRedirect", () => {
+  it("should redirect to given URL", () => {
+    const req = {
+      session: {
+        save: sinon.fake.yields(null),
+      },
+    };
+
+    const res = {
+      redirect: sinon.fake(),
+    };
+    saveSessionAndRedirect(req, res, "/somewhere");
+
+    expect(req.session.save).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledOnceWith("/somewhere");
+  });
+
+  it("should throw if saving session encounters error", async () => {
+    const error = new Error("Something went wrong saving session");
+
+    const req = {
+      session: {
+        save: sinon.fake.yields(error),
+      },
+    };
+
+    const res = {
+      redirect: sinon.fake(),
+    };
+
+    expect(saveSessionAndRedirect(req, res, "/somewhere")).to.eventually.throw(
+      error
+    );
+    expect(res.redirect).not.to.have.been.called;
+  });
+});


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Save session before internal redirect

### Why did it change

While getting core-back and core-front to run locally it was noticed that it's possible for core-front to issue a redirect, and it be followed, before the session has finished writing. This resulted in weird errors where the expected page didn't match the request page.

Whilst we've not knowingly seen this happen in production, probably due to the longer request times involved, it's a possibility and we should address it.

This updates core front to issue the redirect in the callback function of the session.save() method. This will mean the redirect will only be issued once the session is successfully stored.

This has only been applied to internal redirects - redirects that take the user to a different page on core front. We don't need to worry about this issue if we're sending the user off to do something elsewhere.

I had initially worried that implementing this would cause the users session to be saved twice - once when we explicitly call it with the changes, and once when the request-response cycle ends and express saves it automatically. I've dug through express-sessions and the lib does a check of the hash of the current state of the session against the hash the last time it saved it, and doesn't save again if they match. So that's good.