### PR TITLE
PYIC-3690: Add bank account page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -251,6 +251,7 @@ module.exports = {
       switch (pageId) {
         case "page-ipv-identity-document-start":
         case "page-ipv-identity-postoffice-start":
+        case "page-ipv-bank-account-start":
         case "page-ipv-success":
         case "page-face-to-face-handoff":
         case "page-ipv-pending":

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -438,6 +438,28 @@
         }
       }
     },
+    "pageIpvBankAccountStart": {
+      "title": "Prove your identity with bank or building society details and security questions",
+      "header": "Prove your identity with bank or building society details and security questions",
+      "content": {
+        "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
+        "subHeading": "Provide some personal details",
+        "paragraph2": "We'll ask you for your:",
+        "list1": "name",
+        "list2": "date of birth",
+        "list3": "sort code and account number",
+        "list4": "recent address history",
+        "list5": "National Insurance number",
+        "subHeading2": "Answer some security questions",
+        "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
+        "paragraph4": "You can use a non-UK passport as long as it has not expired.",
+        "subHeading3": "How do you want to continue?",
+        "formRadioButtons": {
+          "continueBankDetailsButtonText": "Prove my identity with bank or building society details and security questions",
+          "otherWayButtonText": "Prove my identity another way"
+        }
+      }
+    },
     "pageIpvSuccess": {
       "title": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",
       "header": "Parhau i’r gwasanaeth rydych am ei ddefnyddio",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -476,6 +476,28 @@
         }
       }
     },
+    "pageIpvBankAccountStart": {
+      "title": "Prove your identity with bank or building society details and security questions",
+      "header": "Prove your identity with bank or building society details and security questions",
+      "content": {
+        "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
+        "subHeading": "Provide some personal details",
+        "paragraph2": "We'll ask you for your:",
+        "list1": "name",
+        "list2": "date of birth",
+        "list3": "sort code and account number",
+        "list4": "recent address history",
+        "list5": "National Insurance number",
+        "subHeading2": "Answer some security questions",
+        "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
+        "paragraph4": "You can use a non-UK passport as long as it has not expired.",
+        "subHeading3": "How do you want to continue?",
+        "formRadioButtons": {
+          "continueBankDetailsButtonText": "Prove my identity with bank or building society details and security questions",
+          "otherWayButtonText": "Prove my identity another way"
+        }
+      }
+    },
     "PyiPostofficeStart": {
       "title": "Prove your identity at a Post Office - GOV.UK One Login",
       "header": "Prove your identity at a Post Office",

--- a/src/views/ipv/page-ipv-bank-account-start.njk
+++ b/src/views/ipv/page-ipv-bank-account-start.njk
@@ -1,0 +1,50 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.pageIpvBankAccountStart.title' | translate %}
+{% set googleTagManagerPageId = "pageIpvBankAccountStart" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvBankAccountStart.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph1' | translate }}</p>
+
+  <ul class="govuk-list" role="list">
+    <li>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvBankAccountStart.content.paragraph2' | translate }}</p>
+      <ul class="govuk-list govuk-list--bullet ">
+        <li>{{ 'pages.pageIpvBankAccountStart.content.list1' | translate }}</li>
+        <li>{{ 'pages.pageIpvBankAccountStart.content.list2' | translate }}</li>
+        <li>{{ 'pages.pageIpvBankAccountStart.content.list3' | translate }}</li>
+        <li>{{ 'pages.pageIpvBankAccountStart.content.list4' | translate }}</li>
+        <li>{{ 'pages.pageIpvBankAccountStart.content.list5' | translate }}</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph3' | translate }}</p>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading3' | translate }}</h2>
+  <form id="pageIpvBankAccountStartOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukRadios({
+    idPrefix: "journey",
+    name: "journey",
+    items: [
+              {
+                value: "next",
+                text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.continueBankDetailsButtonText' | translate
+              },
+              {
+                value: "end",
+                text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.otherWayButtonText' | translate
+              }
+            ]
+      })
+    }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added new bank account page

***Welsh translations and finalised designs still yet to be confirmed***

<img width="400" alt="Screenshot 2023-10-12 at 14 23 30" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/18bfbcd0-a5e3-4873-b0a1-6394fa7bc714">


### Why did it change

An additional page is needed that asks if the use wants to prove their identity with a bank account if they are unable to provide photo id.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3690](https://govukverify.atlassian.net/browse/PYIC-3690)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-3690]: https://govukverify.atlassian.net/browse/PYIC-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ