### PR TITLE
PYIC-3540: use render with csrf token for the jouney error handler

### DIFF
--- a/src/handlers/error-handler.test.js
+++ b/src/handlers/error-handler.test.js
@@ -19,6 +19,7 @@ describe("Error handlers", () => {
     req = {
       session: {},
       log: { info: sinon.fake(), error: sinon.fake() },
+      csrfToken: sinon.fake(),
     };
 
     res = {
@@ -130,9 +131,7 @@ describe("Error handlers", () => {
 
       journeyEventErrorHandler(err, req, res, next);
 
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-technical"
-      );
+      expect(res.render).to.have.been.calledWith("ipv/pyi-technical.njk");
     });
 
     it("should call next with error when there is no pageId", () => {
@@ -161,8 +160,8 @@ describe("Error handlers", () => {
       journeyEventErrorHandler(err, req, res, next);
       expect(req.session.clientOauthSessionId).to.eq("fake-session-id");
 
-      expect(res.redirect).to.have.been.calledOnceWith(
-        "/ipv/page/pyi-timeout-recoverable"
+      expect(res.render).to.have.been.calledWith(
+        "ipv/pyi-timeout-recoverable.njk"
       );
     });
 

--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -1,4 +1,5 @@
 const sanitize = require("sanitize-filename");
+const { HTTP_STATUS_CODES } = require("../app.constants");
 
 module.exports = {
   journeyEventErrorHandler(err, req, res, next) {
@@ -23,7 +24,13 @@ module.exports = {
           res.err.response.data.clientOAuthSessionId;
       }
       req.session.currentPage = pageId;
-      return res.redirect(`/ipv/page/${pageId}`);
+      res.err?.status
+        ? res.status(res.err.status)
+        : res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+
+      return res.render(`ipv/${pageId}.njk`, {
+        csrfToken: req.csrfToken(),
+      });
     }
 
     next(err);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Use render instead of redirect for `journey-event-error-handler` 

### What changed

- Using render instead of redirect with csrf token for `journey-event-error-handler` to send correct status code to google analytics.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To send correct status code to google analytics. At the moment redirect send 302, 200.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3540](https://govukverify.atlassian.net/browse/PYIC-3540)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3540]: https://govukverify.atlassian.net/browse/PYIC-3540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ