### PR TITLE
BAU: Switch nodeEnv for build back to production

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -89,7 +89,7 @@ Mappings:
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
       nodeOldSpaceLimit: "1896"
-      nodeEnv: "development"
+      nodeEnv: "production"
       desiredTaskCount: 2
       assetsDomain: "https://assets.build.account.gov.uk"
       assetsPath: "https://assets.build.account.gov.uk/core-front"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This was changed to determine what env we are in to be able to display pages on core-front 
However this is It’s used for load testing so we wanted to keep it as prod like as possible.
