### PR TITLE
PYIC-3810: Update /all-templates route to use env_var over nodeEnv

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -33,6 +33,7 @@ Conditions:
     - !Equals [ !Ref AWS::AccountId, "175872367215"]
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
   IsDev02: !Equals [ !Ref AWS::AccountId, "175872367215"]
+  IsBuild: !Equals [ !Ref AWS::AccountId, "457601271792"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, production ]
   IsSubscriptionEnviroment: !Or
@@ -611,6 +612,11 @@ Resources:
               Value: !Sub
                 - "core-front-sessions-${Environment}"
                 - Environment: !Ref Environment
+            - Name: ENABLE_ALL_TEMPLATES_PAGE
+              Value: !If
+                - IsBuild
+                - "development"
+                - !If [IsDevelopment, !Sub "development", !Ref "AWS::NoValue"]
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
             - Name: GTM_ID

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -4,10 +4,6 @@ const cfenv = require("cfenv");
 const appEnv = cfenv.getAppEnv();
 const serviceConfig = {};
 
-// We need to limit this dev/debug page to development environments
-const ENABLE_ALL_TEMPLATES_PAGE =
-  process.env.NODE_ENV === "development" || process.env.NODE_ENV === "local";
-
 if (!appEnv.isLocal) {
   serviceConfig.coreBackAPIUrl = appEnv.getServiceURL("core-back-api");
 }
@@ -21,7 +17,8 @@ module.exports = {
   API_CRI_CALLBACK: "/journey/cri/callback",
   API_SESSION_INITIALISE: "/session/initialise",
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS: "/user/proven-identity-details",
-  ENABLE_ALL_TEMPLATES_PAGE: ENABLE_ALL_TEMPLATES_PAGE,
+  ENABLE_ALL_TEMPLATES_PAGE:
+    process.env.ENABLE_ALL_TEMPLATES_PAGE === "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Created a new env_var called ENABLE_ALL_TEMPLATES_PAGE which is set to "development" if we are in either dev or build environments. 

### Why did it change

the nodeEnv has been switched back to 'production' for the build account as its used for load testing so we wanted to keep it as prod like as possible

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3810](https://govukverify.atlassian.net/browse/PYIC-3810)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3810]: https://govukverify.atlassian.net/browse/PYIC-3810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ