### PR TITLE
Rename all templates to preview, and enable with a query param

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -612,7 +612,7 @@ Resources:
               Value: !Sub
                 - "core-front-sessions-${Environment}"
                 - Environment: !Ref Environment
-            - Name: ENABLE_ALL_TEMPLATES_PAGE
+            - Name: ENABLE_PREVIEW
               Value: !If
                 - IsBuild
                 - "development"

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -3,7 +3,7 @@ const sanitize = require("sanitize-filename");
 const {
   API_BASE_URL,
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
-  ENABLE_ALL_TEMPLATES_PAGE,
+  ENABLE_PREVIEW,
 } = require("../../lib/config");
 const {
   buildCredentialIssuerRedirectURL,
@@ -200,7 +200,7 @@ module.exports = {
     try {
       const { pageId } = req.params;
 
-      if (ENABLE_ALL_TEMPLATES_PAGE && req.session.visitedAllTemplates) {
+      if (ENABLE_PREVIEW && req.query.preview) {
         if (pageId === "page-ipv-reuse") {
           const userDetails = generateUserDetails(
             samplePersistedUserDetails,
@@ -430,8 +430,6 @@ module.exports = {
         const templatesWithoutExtension = files.map(
           (file) => path.parse(file).name,
         );
-
-        req.session.visitedAllTemplates = true;
 
         res.render("ipv/all-templates.njk", {
           allTemplates: templatesWithoutExtension,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -2,7 +2,7 @@ const express = require("express");
 const csrf = require("csurf");
 const bodyParser = require("body-parser");
 const router = express.Router();
-const { ENABLE_ALL_TEMPLATES_PAGE } = require("../../lib/config");
+const { ENABLE_PREVIEW } = require("../../lib/config");
 
 const {
   renderAttemptRecoveryPage,
@@ -29,7 +29,7 @@ function checkLanguage(req, res, next) {
   next();
 }
 
-if (ENABLE_ALL_TEMPLATES_PAGE) {
+if (ENABLE_PREVIEW) {
   router.get("/all-templates", allTemplates);
 }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -17,8 +17,7 @@ module.exports = {
   API_CRI_CALLBACK: "/journey/cri/callback",
   API_SESSION_INITIALISE: "/session/initialise",
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS: "/user/proven-identity-details",
-  ENABLE_ALL_TEMPLATES_PAGE:
-    process.env.ENABLE_ALL_TEMPLATES_PAGE === "development",
+  ENABLE_PREVIEW: process.env.ENABLE_PREVIEW === "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/views/ipv/all-templates.njk
+++ b/src/views/ipv/all-templates.njk
@@ -9,7 +9,7 @@
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">{{ template }}</th>
           <td class="govuk-table__cell">
-            <a class="govuk-link" href="/ipv/page/{{ template }}?lng=en">English</a> / <a class="govuk-link" href="/ipv/page/{{ template }}?lng=cy">Welsh</a>
+            <a class="govuk-link" href="/ipv/page/{{ template }}?preview=true&amp;lng=en">English</a> / <a class="govuk-link" href="/ipv/page/{{ template }}?preview=true&amp;lng=cy">Welsh</a>
           </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
'All templates' mode is very useful for previewing pages, but is fragile as it relies on setting session state by visiting the template page first, and may interfere with 'real' functionality until you reset your session.

This changes it to use a 'preview' query parameter instead, allowing direct links to be shared with other parties and embedded in the journey map.

This will require everyone to update their `.env` file with the new environment variable name.