### PR TITLE
PYIC-3429: Add validation to radio buttons

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -283,6 +283,7 @@ module.exports = {
         case "pyi-technical-unrecoverable":
           return res.render(`ipv/${sanitize(pageId)}.njk`, {
             pageId,
+            pageErrorState: req.query.errorState,
             csrfToken: req.csrfToken(),
           });
         case "page-ipv-reuse": {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -449,35 +449,16 @@ module.exports = {
     }
   },
   formRadioButtonChecked: async (req, res, next) => {
-    const allowedPathRule = {
-      pattern: /^\/ipv\/page\/[^/]+$/,
-      methods: ["GET", "POST"],
-    };
-
-    const isPathAllowed = (url, method) => {
-      const path = new URL(
-        url,
-        `https://${req.headers.host}`,
-      ).pathname.toLowerCase();
-      if (!method || allowedPathRule.methods.includes(method)) {
-        if (path.match(allowedPathRule.pattern)) {
-          return true;
-        }
-        throw new Error("Path is not allowed");
-      }
-      return false;
-    };
     try {
-      if (
-        req.method === "POST" &&
-        req.body.journey === undefined &&
-        isPathAllowed(req.originalUrl, req.method)
-      ) {
-        const redirectUrl = `${req.baseUrl}${req.path}?errorState=true`;
-        return res.redirect(redirectUrl);
+      if (req.method === "POST" && req.body.journey === undefined) {
+        res.render(`ipv/${sanitize(req.session.currentPage)}.njk`, {
+          pageId: req.session.currentPage,
+          csrfToken: req.csrfToken(),
+          pageErrorState: true,
+        });
+      } else {
+        next();
       }
-
-      next();
     } catch (error) {
       next(error);
     }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -441,6 +441,13 @@ module.exports = {
       next(error);
     }
   },
+  formRadioButtonChecked: async (req, res, next) => {
+    if (req.method === "POST" && req.body.journey === undefined) {
+      return res.redirect(req.originalUrl + "?errorState=true");
+    } else {
+      next();
+    }
+  },
   validateFeatureSet: async (req, res, next) => {
     try {
       const featureSet = req.query.featureSet;

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -280,16 +280,18 @@ module.exports = {
         case "pyi-timeout-unrecoverable":
         case "pyi-f2f-technical":
         case "pyi-technical":
-        case "pyi-technical-unrecoverable":
+        case "pyi-technical-unrecoverable": {
           const renderOptions = {
             pageId,
             csrfToken: req.csrfToken(),
           };
+
           if (req.query?.errorState !== undefined) {
             renderOptions.pageErrorState = req.query.errorState;
           }
 
           return res.render(`ipv/${sanitize(pageId)}.njk`, renderOptions);
+        }
         case "page-ipv-reuse": {
           const userDetailsResponse = await axios.get(
             `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
@@ -447,20 +449,30 @@ module.exports = {
     }
   },
   formRadioButtonChecked: async (req, res, next) => {
-    const allowedPathRule = { pattern: /^\/ipv\/page\/[^\/]+$/, methods: ['GET', 'POST'] };
+    const allowedPathRule = {
+      pattern: /^\/ipv\/page\/[^/]+$/,
+      methods: ["GET", "POST"],
+    };
 
     const isPathAllowed = (url, method) => {
-      const path = new URL(url, `https://${req.headers.host}`).pathname.toLowerCase();
+      const path = new URL(
+        url,
+        `https://${req.headers.host}`,
+      ).pathname.toLowerCase();
       if (!method || allowedPathRule.methods.includes(method)) {
         if (path.match(allowedPathRule.pattern)) {
           return true;
         }
-        throw new Error('Path is not allowed');
+        throw new Error("Path is not allowed");
       }
       return false;
     };
     try {
-      if (req.method === 'POST' && req.body.journey === undefined && isPathAllowed(req.originalUrl, req.method)) {
+      if (
+        req.method === "POST" &&
+        req.body.journey === undefined &&
+        isPathAllowed(req.originalUrl, req.method)
+      ) {
         const redirectUrl = `${req.baseUrl}${req.path}?errorState=true`;
         return res.redirect(redirectUrl);
       }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -735,4 +735,38 @@ describe("journey middleware", () => {
       expect(res.render).to.have.been.calledWith("ipv/page-featureset.njk");
     });
   });
+
+  context('formRadioButtonChecked', () => {
+    beforeEach(() => {
+      req = {
+        method: 'POST',
+        body: {},
+        originalUrl: '/some/url',
+      };
+      res = {
+        redirect: sinon.fake(),
+      };
+      next = sinon.stub();
+    });
+
+    it('should redirect with errorState=true if journey is undefined in POST request', () => {
+      middleware.formRadioButtonChecked(req, res, next);
+      expect(res.redirect).to.have.been.calledWith('/some/url?errorState=true');
+      expect(next).to.not.have.been.called;
+    });
+
+    it('should call next if journey is defined in POST request', () => {
+      req.body.journey = 'next';
+      middleware.formRadioButtonChecked(req, res, next);
+      expect(res.redirect).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it('should not redirect for non-POST requests', () => {
+      req.method = 'GET';
+      middleware.formRadioButtonChecked(req, res, next);
+      expect(res.redirect).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+  });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -746,11 +746,11 @@ describe("journey middleware", () => {
         log: { info: sinon.fake(), error: sinon.fake() },
       };
       req = {
-        method: 'POST',
-        originalUrl: '/ipv/page/somePage',
-        baseUrl: '',
-        path: '/page/somePage',
-        headers: { host: 'localhost:3000' },
+        method: "POST",
+        originalUrl: "/ipv/page/somePage",
+        baseUrl: "",
+        path: "/page/somePage",
+        headers: { host: "localhost:3000" },
         session: {
           ipvSessionId: "ipv-session-id",
           ipAddress: "ip-address",
@@ -771,7 +771,7 @@ describe("journey middleware", () => {
     });
 
     it("should not redirect if method is not POST", async function () {
-      req.method = 'GET';
+      req.method = "GET";
       req.body.journey = undefined;
       await middleware.formRadioButtonChecked(req, res, next);
 
@@ -788,7 +788,7 @@ describe("journey middleware", () => {
     });
 
     it("should not redirect if path is not allowed", async function () {
-      req.originalUrl = '/invalid/path';
+      req.originalUrl = "/invalid/path";
       req.body.journey = undefined;
       await middleware.formRadioButtonChecked(req, res, next);
 

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -738,62 +738,35 @@ describe("journey middleware", () => {
 
   context("formRadioButtonChecked middleware", () => {
     beforeEach(() => {
-      res = {
-        status: sinon.fake(),
-        redirect: sinon.fake(),
-        send: sinon.fake(),
-        render: sinon.fake(),
-        log: { info: sinon.fake(), error: sinon.fake() },
-      };
       req = {
-        method: "POST",
-        originalUrl: "/ipv/page/somePage",
-        baseUrl: "",
-        path: "/page/somePage",
-        headers: { host: "localhost:3000" },
-        session: {
-          ipvSessionId: "ipv-session-id",
-          ipAddress: "ip-address",
-          featureSet: "feature-set",
-        },
         body: {},
-        csrfToken: sinon.fake(),
-        log: { info: sinon.fake(), error: sinon.fake() },
       };
     });
 
-    it("should redirect if method is POST, journey is not defined, and path is allowed", async function () {
+    it("should render if method is POST, journey is not defined", async function () {
       req.body.journey = undefined;
+      req.method = "POST";
       await middleware.formRadioButtonChecked(req, res, next);
 
-      const redirectUrl = `${req.baseUrl}${req.path}?errorState=true`;
-      expect(res.redirect).to.have.been.calledWith(redirectUrl);
+      expect(res.render).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
     });
 
-    it("should not redirect if method is not POST", async function () {
+    it("should not render if method is not POST", async function () {
       req.method = "GET";
       req.body.journey = undefined;
       await middleware.formRadioButtonChecked(req, res, next);
 
-      expect(res.redirect).to.not.have.been.called;
+      expect(res.render).to.not.have.been.called;
       expect(next).to.have.been.calledOnce;
     });
 
-    it("should not redirect if journey is defined", async function () {
+    it("should not render if journey is defined", async function () {
       req.body.journey = "someJourney";
       await middleware.formRadioButtonChecked(req, res, next);
 
-      expect(res.redirect).to.not.have.been.called;
+      expect(res.render).to.not.have.been.called;
       expect(next).to.have.been.calledOnce;
-    });
-
-    it("should not redirect if path is not allowed", async function () {
-      req.originalUrl = "/invalid/path";
-      req.body.journey = undefined;
-      await middleware.formRadioButtonChecked(req, res, next);
-
-      expect(res.redirect).to.not.have.been.called;
-      expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
     });
 
     it("should call next in case of a successful execution", async function () {
@@ -801,7 +774,7 @@ describe("journey middleware", () => {
 
       await middleware.formRadioButtonChecked(req, res, next);
 
-      expect(res.redirect).to.not.have.been.called;
+      expect(res.render).to.not.have.been.called;
       expect(next).to.have.been.calledOnce;
     });
   });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -740,6 +740,9 @@ describe("journey middleware", () => {
     beforeEach(() => {
       req = {
         body: {},
+        params: { pageId: "page-ipv-identity-document-start" },
+        csrfToken: sinon.fake(),
+        session: { currentPage: "page-ipv-identity-document-start" },
       };
     });
 
@@ -748,8 +751,8 @@ describe("journey middleware", () => {
       req.method = "POST";
       await middleware.formRadioButtonChecked(req, res, next);
 
-      expect(res.render).to.not.have.been.called;
-      expect(next).to.have.been.calledOnce;
+      expect(res.render).to.have.been.called;
+      expect(next).to.have.not.been.calledOnce;
     });
 
     it("should not render if method is not POST", async function () {

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -116,6 +116,13 @@ router.post(
   formRadioButtonChecked,
   handleJourneyAction,
 );
+router.post(
+  "/page/page-ipv-bank-account-start",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction,
+);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);
 

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -46,7 +46,13 @@ router.post(
   formRadioButtonChecked,
   handleJourneyAction
 );
-
+router.post(
+  "/page/page-ipv-identity-postoffice-start",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
 router.post(
   "/page/page-multiple-doc-check",
   parseForm,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -89,6 +89,13 @@ router.post(
   handleJourneyAction
 );
 router.post(
+  "/page/pyi-f2f-technical",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction,
+);
+router.post(
   "/page/pyi-suggest-other-options",
   parseForm,
   csrfProtection,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -109,6 +109,13 @@ router.post(
   formRadioButtonChecked,
   handleJourneyAction,
 );
+router.post(
+  "/page/pyi-post-office",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction,
+);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);
 

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -44,35 +44,35 @@ router.post(
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleJourneyAction
+  handleJourneyAction,
 );
 router.post(
   "/page/page-ipv-identity-postoffice-start",
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleJourneyAction
+  handleJourneyAction,
 );
 router.post(
   "/page/page-multiple-doc-check",
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleMultipleDocCheck
+  handleMultipleDocCheck,
 );
 router.post(
   "/page/page-f2f-multiple-doc-check",
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleMultipleDocCheck
+  handleMultipleDocCheck,
 );
 router.post(
   "/page/pyi-escape",
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleJourneyAction
+  handleJourneyAction,
 );
 router.post(
   "/page/pyi-cri-escape",
@@ -86,7 +86,7 @@ router.post(
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  handleJourneyAction
+  handleJourneyAction,
 );
 router.post(
   "/page/pyi-f2f-technical",

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -57,7 +57,8 @@ router.post(
   "/page/page-multiple-doc-check",
   parseForm,
   csrfProtection,
-  handleMultipleDocCheck,
+  formRadioButtonChecked,
+  handleMultipleDocCheck
 );
 router.post(
   "/page/page-f2f-multiple-doc-check",

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -99,6 +99,7 @@ router.post(
   "/page/pyi-suggest-other-options",
   parseForm,
   csrfProtection,
+  formRadioButtonChecked,
   handleCimitEscapeAction,
 );
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -63,7 +63,8 @@ router.post(
   "/page/page-f2f-multiple-doc-check",
   parseForm,
   csrfProtection,
-  handleMultipleDocCheck,
+  formRadioButtonChecked,
+  handleMultipleDocCheck
 );
 router.post(
   "/page/pyi-cri-escape",

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -82,6 +82,13 @@ router.post(
   handleCriEscapeAction,
 );
 router.post(
+  "/page/pyi-cri-escape-no-f2f",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
+router.post(
   "/page/pyi-suggest-other-options",
   parseForm,
   csrfProtection,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -68,6 +68,13 @@ router.post(
   handleMultipleDocCheck
 );
 router.post(
+  "/page/pyi-escape",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
+router.post(
   "/page/pyi-cri-escape",
   parseForm,
   csrfProtection,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -14,6 +14,7 @@ const {
   handleCimitEscapeAction,
   renderFeatureSetPage,
   validateFeatureSet,
+  formRadioButtonChecked,
   allTemplates,
 } = require("./middleware");
 
@@ -37,6 +38,15 @@ router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
 
 router.get("/page/attempt-recovery", csrfProtection, renderAttemptRecoveryPage);
 router.get("/page/:pageId", csrfProtection, checkLanguage, handleJourneyPage);
+
+router.post(
+  "/page/page-ipv-identity-document-start",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction
+);
+
 router.post(
   "/page/page-multiple-doc-check",
   parseForm,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -78,6 +78,7 @@ router.post(
   "/page/pyi-cri-escape",
   parseForm,
   csrfProtection,
+  formRadioButtonChecked,
   handleCriEscapeAction,
 );
 router.post(

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -102,6 +102,13 @@ router.post(
   formRadioButtonChecked,
   handleCimitEscapeAction,
 );
+router.post(
+  "/page/pyi-suggest-other-options-no-f2f",
+  parseForm,
+  csrfProtection,
+  formRadioButtonChecked,
+  handleJourneyAction,
+);
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
 router.get("/*", updateJourneyState);
 

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -14,6 +14,12 @@ module.exports = {
       return translate(key, options);
     });
 
+    // allow pushing or adding another attribute to an Object
+    nunjucksEnv.addFilter("setAttribute", function (dictionary, key, value) {
+      dictionary[key] = value;
+      return dictionary;
+    });
+
     nunjucksEnv.addFilter("GDSDate", function (formatDate) {
       const dateTransform = new Date(formatDate);
       let dateFormat = "en-GB"; // only using 'en' uses American month-first date formatting

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -493,6 +493,11 @@
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch oes os oes gennych unrhyw un o’r mathau hyn o ID gyda llun",
+          "errorRadioMessage": "Dewiswch oes os oes gennych unrhyw un o’r mathau hyn o ID gyda llun"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -304,6 +304,11 @@
         "formRadioButtons": {
           "tryAgainButtonText": "Ceisiwch brofi eich hunaniaeth gyda One Login eto",
           "continueButtonText": "Parhau i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -433,6 +433,11 @@
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -219,6 +219,11 @@
           "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
           "otherWayButtonText": "Profi eich hunaniaeth mewn ffordd arall",
           "otherWayButtonTextHint": "Ewch i’r gwasanaeth rydych am ei ddefnyddio a chwilio am ffyrdd eraill o brofi eich hunaniaeth."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -146,6 +146,11 @@
           "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
           "continuePostOfficeButtonText": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
           "continuePostOfficeButtonTextHint": "Byddwch yn rhoi manylion o’ch ID llun ar GOV.UK yn gyntaf."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -351,6 +351,11 @@
           "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "separateOptionsInFormText": "neu",
           "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch sut rydych eisiau parhau",
+          "errorRadioMessage": "Dewiswch sut rydych eisiau parhau"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -370,6 +370,11 @@
           "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "separateOptionsInFormText": "neu",
           "otherWayButtonText": "Profi eich hunaniaeth mewn ffordd arall"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch sut rydych eisiau parhau",
+          "errorRadioMessage": "Dewiswch sut rydych eisiau parhau"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -195,6 +195,11 @@
           "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
           "continuePostOfficeButtonText": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
           "continuePostOfficeButtonTextHint": "Byddwch yn rhoi manylion o’ch ID llun ar GOV.UK yn gyntaf."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -121,6 +121,11 @@
         "formRadioButtons": {
           "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
           "restartButtonText": "Ceisio profi eich hunaniaeth gyda GOV.UK One Login eto"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -500,6 +500,11 @@
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Prove my identity with bank or building society details and security questions",
           "otherWayButtonText": "Prove my identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -546,7 +546,7 @@
         }
       }
     },
-    "PyiPostofficeStart": {
+    "pyiPostOffice": {
       "title": "Profwch eich hunaniaeth mewn Swyddfa’r Post - GOV.UK One Login",
       "header": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
       "content": {
@@ -568,6 +568,11 @@
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch oes os oes gennych ID gyda llun y gallwch ei ddefnyddio mewn Swyddfa Bost",
+          "errorRadioMessage": "Dewiswch oes os oes gennych ID gyda llun y gallwch ei ddefnyddio mewn Swyddfa Bost"
         }
       }
     }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -170,6 +170,11 @@
           "continueAppButtonTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio’r ap.",
           "otherWayButtonText": "Profi eich hunaniaeth mewn ffordd arall",
           "otherWayButtonTextHint": "Ewch i’r gwasanaeth rydych am ei ddefnyddio a chwilio am ffyrdd eraill o brofi eich hunaniaeth."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -546,7 +546,7 @@
         }
       }
     },
-    "PyiPostofficeStart": {
+    "pyiPostOffice": {
       "title": "Prove your identity at a Post Office - GOV.UK One Login",
       "header": "Prove your identity at a Post Office",
       "content": {
@@ -568,6 +568,11 @@
         "formRadioButtons": {
           "yes": "Yes",
           "no": "No"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select yes if you have photo ID you can use at a Post Office",
+          "errorRadioMessage": "Select yes if you have photo ID you can use at a Post Office"
         }
       }
     }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -195,6 +195,11 @@
           "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
           "continuePostOfficeButtonText": "Prove your identity at a Post Office",
           "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -170,6 +170,11 @@
           "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
           "otherWayButtonText": "Prove your identity another way",
           "otherWayButtonTextHint": "Go to the service you want to use and look for other ways to prove your identity."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -121,6 +121,11 @@
         "formRadioButtons": {
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
           "restartButtonText": "Try proving your identity with GOV.UK One Login again"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -476,6 +476,11 @@
         "formRadioButtons": {
           "yes": "Yes",
           "no": "No"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -543,6 +543,11 @@
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Prove my identity with bank or building society details and security questions",
           "otherWayButtonText": "Prove my identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -219,6 +219,11 @@
           "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
           "otherWayButtonText": "Prove your identity another way",
           "otherWayButtonTextHint": "Go to the service you want to use and look for other ways to prove your identity."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -370,6 +370,11 @@
           "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
           "separateOptionsInFormText": "or",
           "otherWayButtonText": "Prove your identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select how you want to continue",
+          "errorRadioMessage": "Select how you want to continue"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -304,6 +304,11 @@
         "formRadioButtons": {
           "tryAgainButtonText": "Try proving your identity with GOV.UK One Login again",
           "continueButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -351,6 +351,11 @@
           "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
           "separateOptionsInFormText": "or",
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select how you want to continue",
+          "errorRadioMessage": "Select how you want to continue"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -444,6 +444,11 @@
         "formRadioButtons": {
           "yes": "Yes",
           "no": "No"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select yes if you have any of these types of photo ID",
+          "errorRadioMessage": "Select yes if you have any of these types of photo ID"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -146,6 +146,11 @@
           "continueAppButtonTextHint": "You’ll be shown how to download and use the app.",
           "continuePostOfficeButtonText": "Prove your identity at a Post Office",
           "continuePostOfficeButtonTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         }
       }
     },

--- a/src/views/ipv/page-f2f-multiple-doc-check.njk
+++ b/src/views/ipv/page-f2f-multiple-doc-check.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pageF2FMultipleDockCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageF2FMultipleDockCheck" %}
 

--- a/src/views/ipv/page-f2f-multiple-doc-check.njk
+++ b/src/views/ipv/page-f2f-multiple-doc-check.njk
@@ -2,18 +2,31 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageF2FMultipleDockCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageF2FMultipleDockCheck" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageF2FMultipleDockCheck.header' | translate }}</h1>
-  <p class="govuk-body">{{'pages.pageF2FMultipleDockCheck.content.paragraph1' | translate | safe }}</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.pageF2FMultipleDockCheck.content.bullet1' | translate | safe }}</li>
-    <li>{{'pages.pageF2FMultipleDockCheck.content.bullet2' | translate | safe }}</li>
-  </ul>
-  <p class="govuk-body">{{'pages.pageF2FMultipleDockCheck.content.paragraph2' | translate | safe }}</p>
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#faceToFacetMultipleDocCheckingForm"
+        }
+      ]
+    }) }}
+  {% endif %}
 
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageF2FMultipleDockCheck.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageF2FMultipleDockCheck.content.paragraph1' | translate | safe }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{ 'pages.pageF2FMultipleDockCheck.content.bullet1' | translate | safe }}</li>
+    <li>{{ 'pages.pageF2FMultipleDockCheck.content.bullet2' | translate | safe }}</li>
+  </ul>
+  <p class="govuk-body">{{ 'pages.pageF2FMultipleDockCheck.content.paragraph2' | translate | safe }}</p>
 
   {% if isWelsh %}
     {{ govukInsetText({
@@ -21,34 +34,44 @@
     }) }}
   {% endif %}
 
-  <h2 class="govuk-heading-m">{{'pages.pageF2FMultipleDockCheck.content.subHeading' | translate }}</h2>
+  <form id="faceToFacetMultipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pageF2FMultipleDockCheck.content.subHeading' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next/driving-licence",
+          text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate
+        },
+        {
+          value: "next/passport",
+          text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.continuePassportButtonText' | translate
+        },
+        {
+          divider: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.separateOptionsInFormText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.otherWayButtonText' | translate
+        }
+      ]
+    } %}
 
-  <form id="faceToFacetMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next/driving-licence",
-                text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate
-              },
-              {
-                value: "next/passport",
-                text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.continuePassportButtonText' | translate
-              },
-              {
-                divider: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.separateOptionsInFormText' | translate
-              },
-              {
-                value: "end",
-                text: 'pages.pageF2FMultipleDockCheck.content.formRadioButtons.otherWayButtonText' | translate
-              }
-            ]
-      })
-    }}
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
+      {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 {% endblock %}

--- a/src/views/ipv/page-f2f-multiple-doc-check.njk
+++ b/src/views/ipv/page-f2f-multiple-doc-check.njk
@@ -3,23 +3,15 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageF2FMultipleDockCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageF2FMultipleDockCheck" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#faceToFacetMultipleDocCheckingForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageF2FMultipleDockCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#faceToFacetMultipleDocCheckingForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageF2FMultipleDockCheck.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageF2FMultipleDockCheck.content.paragraph1' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/src/views/ipv/page-ipv-bank-account-start.njk
+++ b/src/views/ipv/page-ipv-bank-account-start.njk
@@ -1,10 +1,24 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvBankAccountStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvBankAccountStart" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pageIpvBankAccountStartForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvBankAccountStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph1' | translate }}</p>
 
@@ -26,23 +40,35 @@
   <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph3' | translate }}</p>
 
   <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading3' | translate }}</h2>
-  <form id="pageIpvBankAccountStartOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+  <form id="pageIpvBankAccountStartForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next",
-                text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.continueBankDetailsButtonText' | translate
-              },
-              {
-                value: "end",
-                text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.otherWayButtonText' | translate
-              }
-            ]
-      })
-    }}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiPostOffice.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.continueBankDetailsButtonText' | translate,
+        },
+        {
+          value: "end",
+          text: 'pages.pageIpvBankAccountStart.content.formRadioButtons.otherWayButtonText' | translate,
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>

--- a/src/views/ipv/page-ipv-bank-account-start.njk
+++ b/src/views/ipv/page-ipv-bank-account-start.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvBankAccountStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvBankAccountStart" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pageIpvBankAccountStartForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageIpvBankAccountStart.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pageIpvBankAccountStartForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvBankAccountStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph1' | translate }}</p>
 

--- a/src/views/ipv/page-ipv-bank-account-start.njk
+++ b/src/views/ipv/page-ipv-bank-account-start.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pageIpvBankAccountStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvBankAccountStart" %}
 

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityDocumentStart" %}
 

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -54,7 +54,7 @@
       <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph6' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ ' pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
       <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph7' | translate }}</p>
     </li>
     <li>

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -2,24 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityDocumentStart" %}
 
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#identityDocumentStartPageOptionsForm" %}
+
 {% block content %}
-
-  {% if errorState %}
-  <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>	    {{ govukErrorSummary({
-      titleText: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#identityDocumentStartPageOptionsForm"
-        }
-      ]
-    }) }}
-  {% endif %}
-
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvIdentityDocumentStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>
 

--- a/src/views/ipv/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page-ipv-identity-document-start.njk
@@ -1,72 +1,100 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvIdentityDocumentStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityDocumentStart" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageIpvIdentityDocumentStart.header' | translate }}</h1>
-  <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>
+
+  {% if errorState %}
+  <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>	    {{ govukErrorSummary({
+      titleText: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#identityDocumentStartPageOptionsForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvIdentityDocumentStart.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph' | translate }}</p>
 
   <ul class="govuk-list" role="list">
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading' | translate }}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">{{'pages.pageIpvIdentityDocumentStart.content.paragraph1' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph1' | translate }}</p>
       <ul class="govuk-list govuk-list--bullet ">
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list1' | translate }}</li>
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list2' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list1' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list2' | translate }}</li>
       </ul>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading2' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph3' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading2' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph3' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading3' | translate }}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">{{'pages.pageIpvIdentityDocumentStart.content.paragraph4' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading3' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph4' | translate }}</p>
       <ul class="govuk-list  govuk-list--bullet">
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list3' | translate }}</li>
-        <li>{{'pages.pageIpvIdentityDocumentStart.content.list4' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list3' | translate }}</li>
+        <li>{{ 'pages.pageIpvIdentityDocumentStart.content.list4' | translate }}</li>
       </ul>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph5' | translate }}</p>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph5' | translate }}</p>
       <picture>
         <source srcset="{{ assetsCdnPath }}/public/images/passport-icon.svg" />
-        <img width="174" height="121" loading="lazy" src="{{ assetsCdnPath }}/public/images/passport-icon-1x.png" srcset="{{ assetsCdnPath }}/public/images/passport-icon-2x.png 2x" alt="{{'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}" />
+        <img width="174" height="121" loading="lazy" src="{{ assetsCdnPath }}/public/images/passport-icon-1x.png" srcset="{{ assetsCdnPath }}/public/images/passport-icon-2x.png 2x" alt="{{ 'pages.pageIpvIdentityDocumentStart.content.imgAltText' | translate }}" />
       </picture>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading4' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph6' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading4' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph6' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph7' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ ' pages.pageIpvIdentityDocumentStart.content.subHeading5' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph7' | translate }}</p>
     </li>
     <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading6' | translate }}</h2>
-      <p class="govuk-body">{{'pages.pageIpvIdentityDocumentStart.content.paragraph8' | translate }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvIdentityDocumentStart.content.subHeading6' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pageIpvIdentityDocumentStart.content.paragraph8' | translate }}</p>
     </li>
   </ul>
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{'pages.pageIpvIdentityDocumentStart.content.subHeading7' | translate }}</h2>
-  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{pageId}}" method="POST">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next",
-                text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate
-              },
-              {
-                value: "end",
-                text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate
-              }
-            ]
-      })
-    }}
+
+  <form id="identityDocumentStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pageIpvIdentityDocumentStart.content.subHeading7' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.yes' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pageIpvIdentityDocumentStart.content.formRadioButtons.no' | translate
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageIpvIdentityDocumentStart.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
+      {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 {% endblock %}

--- a/src/views/ipv/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page-ipv-identity-postoffice-start.njk
@@ -3,23 +3,15 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvIdentityPostofficeStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityPostofficeStart" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#identityPostofficeStartPageOptionsForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#identityPostofficeStartPageOptionsForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pageIpvIdentityPostofficeStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph1' | translate }}</p>

--- a/src/views/ipv/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page-ipv-identity-postoffice-start.njk
@@ -2,10 +2,24 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageIpvIdentityPostofficeStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityPostofficeStart" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#identityPostofficeStartPageOptionsForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pageIpvIdentityPostofficeStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph1' | translate }}</p>
@@ -41,12 +55,18 @@
       <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph6' | translate }}</p>
     </li>
   </ul>
-  <h2 class="govuk-heading-m">{{ 'pages.pageIpvIdentityPostofficeStart.content.subHeading4' | translate }}</h2>
+
   <form id="identityPostofficeStartPageOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
+    {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pageIpvIdentityPostofficeStart.content.subHeading4' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
       items: [
         {
           value: "next",
@@ -57,7 +77,14 @@
           text: 'pages.pageIpvIdentityPostofficeStart.content.formRadioButtons.no' | translate
         }
       ]
-    }) }}
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageIpvIdentityPostofficeStart.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>

--- a/src/views/ipv/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page-ipv-identity-postoffice-start.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pageIpvIdentityPostofficeStart.title' | translate %}
 {% set googleTagManagerPageId = "pageIpvIdentityPostofficeStart" %}
 

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pageMultipleDocCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageMultipleDocCheck" %}
 

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -1,46 +1,70 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageMultipleDocCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageMultipleDocCheck" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{'pages.pageMultipleDocCheck.header' | translate }}</h1>
-  <p class="govuk-body">{{'pages.pageMultipleDocCheck.content.paragraph1' | translate | safe }}</p>
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#multipleDocCheckingForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageMultipleDocCheck.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph1' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.pageMultipleDocCheck.content.bullet1' | translate | safe }}</li>
-    <li>{{'pages.pageMultipleDocCheck.content.bullet2' | translate | safe }}</li>
+    <li>{{ 'pages.pageMultipleDocCheck.content.bullet1' | translate | safe }}</li>
+    <li>{{ 'pages.pageMultipleDocCheck.content.bullet2' | translate | safe }}</li>
   </ul>
-  <p class="govuk-body">{{'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
 
-  <h2 class="govuk-heading-m">{{'pages.pageMultipleDocCheck.content.subHeading' | translate }}</h2>
+  <form id="multipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pageMultipleDocCheck.content.subHeading' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next/driving-licence",
+          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate
+        },
+        {
+          value: "next/passport",
+          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translate
+        },
+        {
+          divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translate
+        }
+      ]
+    } %}
 
-  <form id="passportMultipleDocCheckingForm" action="/ipv/page/{{pageId}}" method="POST">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next/driving-licence",
-                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate
-              },
-              {
-                value: "next/passport",
-                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translate
-              },
-              {
-                divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
-              },
-              {
-                value: "end",
-                text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translate
-              }
-            ]
-      })
-    }}
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageMultipleDocCheck.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
+      {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 {% endblock %}

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pageMultipleDocCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageMultipleDocCheck" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#multipleDocCheckingForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#multipleDocCheckingForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageMultipleDocCheck.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph1' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/src/views/ipv/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/pyi-cri-escape-no-f2f.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiCriEscapeNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscapeNoF2f" %}
 

--- a/src/views/ipv/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/pyi-cri-escape-no-f2f.njk
@@ -1,10 +1,24 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiCriEscapeNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscapeNoF2f" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiCriEscapeNoF2fForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscapeNoF2f.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph1' | translate | safe }}</p>
 
@@ -12,39 +26,50 @@
   <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph2' | translate | safe }}</p>
   <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph3' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.pyiCriEscapeNoF2f.content.bullet1' | translate | safe }}</li>
-    <li>{{'pages.pyiCriEscapeNoF2f.content.bullet2' | translate | safe }}</li>
+    <li>{{ 'pages.pyiCriEscapeNoF2f.content.bullet1' | translate | safe }}</li>
+    <li>{{ 'pages.pyiCriEscapeNoF2f.content.bullet2' | translate | safe }}</li>
   </ul>
-  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscapeNoF2f.content.subHeading2' | translate }}</h2>
 
   <form id="pyiCriEscapeNoF2fForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next",
-                text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonText' | translate,
-                hint: {text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonTextHint' | translate}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiCriEscapeNoF2f.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonText' | translate,
+          hint: {text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.continueAppButtonTextHint' | translate}
 
-              },
-              {
-                value: "end",
-                text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonText' | translate,
-                hint: { text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonTextHint' | translate }
-              }
-            ]
-      })
-    }}
+        },
+        {
+          value: "end",
+          text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonText' | translate,
+          hint: { text: 'pages.pyiCriEscapeNoF2f.content.formRadioButtons.otherWayButtonTextHint' | translate }
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">
-      {{'general.shared.contactLinkText' | translate }}
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
     </a>
   </p>
 

--- a/src/views/ipv/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/pyi-cri-escape-no-f2f.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiCriEscapeNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscapeNoF2f" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiCriEscapeNoF2fForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiCriEscapeNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiCriEscapeNoF2fForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscapeNoF2f.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiCriEscapeNoF2f.content.paragraph1' | translate | safe }}</p>
 

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiCriEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscape" %}
 
-{% block content %}
- {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiCriEscapeForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiCriEscapeForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscape.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph1' | translate | safe }}</p>
 

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -1,10 +1,24 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiCriEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscape" %}
 
 {% block content %}
+ {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiCriEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiCriEscapeForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiCriEscape.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph1' | translate | safe }}</p>
 
@@ -12,40 +26,51 @@
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph2' | translate | safe }}</p>
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph3' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.pyiCriEscape.content.bullet1' | translate | safe }}</li>
-    <li>{{'pages.pyiCriEscape.content.bullet2' | translate | safe }}</li>
+    <li>{{ 'pages.pyiCriEscape.content.bullet1' | translate | safe }}</li>
+    <li>{{ 'pages.pyiCriEscape.content.bullet2' | translate | safe }}</li>
   </ul>
   <p class="govuk-body">{{ 'pages.pyiCriEscape.content.paragraph4' | translate | safe }}</p>
-  <h2 class="govuk-heading-m">{{ 'pages.pyiCriEscape.content.subHeading2' | translate }}</h2>
 
   <form id="pyiCriEscapeForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next/dcmaw",
-                text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonText' | translate,
-                hint: {text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonTextHint' | translate}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiCriEscape.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next/dcmaw",
+          text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonText' | translate,
+          hint: {text: 'pages.pyiCriEscape.content.formRadioButtons.continueAppButtonTextHint' | translate}
 
-              },
-              {
-                value: "next/f2f",
-                text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonText' | translate,
-                hint: { text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
-              }
-            ]
-      })
-    }}
+        },
+        {
+          value: "next/f2f",
+          text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonText' | translate,
+          hint: { text: 'pages.pyiCriEscape.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiCriEscape.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">
-      {{'general.shared.contactLinkText' | translate }}
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
     </a>
   </p>
 {% endblock %}

--- a/src/views/ipv/pyi-cri-escape.njk
+++ b/src/views/ipv/pyi-cri-escape.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiCriEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiCriEscape" %}
 

--- a/src/views/ipv/pyi-escape.njk
+++ b/src/views/ipv/pyi-escape.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiEscape" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiEscape.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiEscapeForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiEscape.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiEscapeForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiEscape.header' | translate }}</h1>
 
   <form id="pyiEscapeForm" action="/ipv/page/{{ pageId }}" method="POST">

--- a/src/views/ipv/pyi-escape.njk
+++ b/src/views/ipv/pyi-escape.njk
@@ -1,39 +1,63 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiEscape" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiEscape.header' | translate }}</h1>
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiEscape.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiEscape.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiEscapeForm"
+        }
+      ]
+    }) }}
+  {% endif %}
 
-  <h2 class="govuk-heading-m">{{ 'pages.pyiEscape.content.subHeading' | translate }}</h2>
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiEscape.header' | translate }}</h1>
 
   <form id="pyiEscapeForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "end",
-                text: 'pages.pyiEscape.content.formRadioButtons.otherWayButtonText' | translate
-              },
-              {
-                value: "next",
-                text: 'pages.pyiEscape.content.formRadioButtons.restartButtonText' | translate
-              }
-            ]
-      })
-    }}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiEscape.content.subHeading' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "end",
+          text: 'pages.pyiEscape.content.formRadioButtons.otherWayButtonText' | translate
+        },
+        {
+          value: "next",
+          text: 'pages.pyiEscape.content.formRadioButtons.restartButtonText' | translate
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiEscape.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">
-      {{'general.shared.contactLinkText' | translate }}
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
     </a>
   </p>
 

--- a/src/views/ipv/pyi-escape.njk
+++ b/src/views/ipv/pyi-escape.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiEscape.title' | translate %}
 {% set googleTagManagerPageId = "pyiEscape" %}
 

--- a/src/views/ipv/pyi-f2f-technical.njk
+++ b/src/views/ipv/pyi-f2f-technical.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiF2fTechnical.title' | translate %}
 {% set googleTagManagerPageId = "pyiF2fTechnical" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiF2fTechnicalForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiF2fTechnicalForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiF2fTechnical.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiF2fTechnical.content.paragraph1' | translate | safe }}</p>
 

--- a/src/views/ipv/pyi-f2f-technical.njk
+++ b/src/views/ipv/pyi-f2f-technical.njk
@@ -1,20 +1,38 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiF2fTechnical.title' | translate %}
 {% set googleTagManagerPageId = "pyiF2fTechnical" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiF2fTechnical.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiF2fTechnicalForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiF2fTechnical.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiF2fTechnical.content.paragraph1' | translate | safe }}</p>
 
-  <h2 class="govuk-heading-m">{{ 'pages.pyiF2fTechnical.content.subHeading' | translate }}</h2>
-
   <form id="pyiF2fTechnicalForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
+    {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiF2fTechnical.content.subHeading' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
       items: [
         {
           value: "next",
@@ -25,11 +43,22 @@
           text: 'pages.pyiF2fTechnical.content.formRadioButtons.continueButtonText' | translate
         }
       ]
-    }) }}
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiF2fTechnical.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
+    </a>
+  </p>
 {% endblock %}

--- a/src/views/ipv/pyi-f2f-technical.njk
+++ b/src/views/ipv/pyi-f2f-technical.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiF2fTechnical.title' | translate %}
 {% set googleTagManagerPageId = "pyiF2fTechnical" %}
 

--- a/src/views/ipv/pyi-post-office.njk
+++ b/src/views/ipv/pyi-post-office.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.pyiPostOffice.title' | translate %}
 {% set googleTagManagerPageId = "pyiPostOffice" %}

--- a/src/views/ipv/pyi-post-office.njk
+++ b/src/views/ipv/pyi-post-office.njk
@@ -1,55 +1,82 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% set pageTitleName = 'pages.PyiPostofficeStart.title' | translate %}
-{% set googleTagManagerPageId = "PyiPostofficeStart" %}
+{% set pageTitleName = 'pages.pyiPostOffice.title' | translate %}
+{% set googleTagManagerPageId = "pyiPostOffice" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiPostOfficeForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
-      xmlns="http://www.w3.org/1999/html">{{ 'pages.PyiPostofficeStart.header' | translate }}</h1>
-  <p class="govuk-body">{{ 'pages.PyiPostofficeStart.content.paragraph1' | translate }}</p>
-  <p class="govuk-body">{{ 'pages.PyiPostofficeStart.content.paragraph2' | translate }}</p>
+      xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiPostOffice.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiPostOffice.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiPostOffice.content.paragraph2' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>{{ 'pages.PyiPostofficeStart.content.list1' | translate }}</li>
-    <li>{{ 'pages.PyiPostofficeStart.content.list2' | translate }}</li>
+    <li>{{ 'pages.pyiPostOffice.content.list1' | translate }}</li>
+    <li>{{ 'pages.pyiPostOffice.content.list2' | translate }}</li>
   </ul>
-  <p class="govuk-body">{{ 'pages.PyiPostofficeStart.content.paragraph3' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiPostOffice.content.paragraph3' | translate }}</p>
 
   <ul class="govuk-list" role="list">
     <li>
-      <h2 class="govuk-heading-m">{{ 'pages.PyiPostofficeStart.content.subHeading' | translate }}</h2>
-      <p class="govuk-body">{{ 'pages.PyiPostofficeStart.content.paragraph4' | translate }}</p>
+      <h2 class="govuk-heading-m">{{ 'pages.pyiPostOffice.content.subHeading' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.pyiPostOffice.content.paragraph4' | translate }}</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.PyiPostofficeStart.content.list3' | translate }}</li>
-        <li>{{ 'pages.PyiPostofficeStart.content.list4' | translate }}</li>
-        <li>{{ 'pages.PyiPostofficeStart.content.list5' | translate }}</li>
-        <li>{{ 'pages.PyiPostofficeStart.content.list6' | translate }}</li>
-        <li>{{ 'pages.PyiPostofficeStart.content.list7' | translate }}</li>
-        <li>{{ 'pages.PyiPostofficeStart.content.list8' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list3' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list4' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list5' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list6' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list7' | translate }}</li>
+        <li>{{ 'pages.pyiPostOffice.content.list8' | translate }}</li>
       </ul>
     </li>
   </ul>
   {{ govukInsetText({
-    text: 'pages.PyiPostofficeStart.content.insetText' | translate
+    text: 'pages.pyiPostOffice.content.insetText' | translate
   }) }}
-  <h2 class="govuk-heading-m">{{ 'pages.PyiPostofficeStart.content.subHeading2' | translate }}</h2>
-  <form id="pyi-post-office" action="/ipv/page/{{ pageId }}" method="POST">
+
+  <form id="pyiPostOfficeForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
+    {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiPostOffice.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
       items: [
         {
           value: "next",
-          text: 'pages.PyiPostofficeStart.content.formRadioButtons.yes' | translate
+          text: 'pages.pages.pyiPostOffice.content.formRadioButtons.yes' | translate,
         },
         {
           value: "end",
-          text: 'pages.PyiPostofficeStart.content.formRadioButtons.no' | translate
+          text: 'pages.pyiPostOffice.content.formRadioButtons.no' | translate,
         }
       ]
-    }) }}
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiPostOffice.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>

--- a/src/views/ipv/pyi-post-office.njk
+++ b/src/views/ipv/pyi-post-office.njk
@@ -2,24 +2,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.pyiPostOffice.title' | translate %}
 {% set googleTagManagerPageId = "pyiPostOffice" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiPostOfficeForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiPostOffice.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiPostOfficeForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiPostOffice.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiPostOffice.content.paragraph1' | translate }}</p>

--- a/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
+++ b/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptionsNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptionsNoF2f" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiSuggestOtherOptionsNoF2fForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiSuggestOtherOptionsNoF2fForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiSuggestOtherOptionsNoF2f.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.paragraph1' | translate }}</p>
 

--- a/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
+++ b/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
@@ -1,10 +1,24 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptionsNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptionsNoF2f" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiSuggestOtherOptionsNoF2fForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiSuggestOtherOptionsNoF2f.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.paragraph1' | translate }}</p>
 
@@ -12,53 +26,50 @@
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.paragraph2' | translate }}</p>
   <p class="govuk-body govuk-!-margin-bottom-1">{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.paragraph3' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-5">
-    <li>{{'pages.pyiSuggestOtherOptionsNoF2f.content.bullet1' | translate }}</li>
-    <li>{{'pages.pyiSuggestOtherOptionsNoF2f.content.bullet2' | translate }}</li>
+    <li>{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.bullet1' | translate }}</li>
+    <li>{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.bullet2' | translate }}</li>
   </ul>
-  <h2 class="govuk-heading-m">{{ 'pages.pyiSuggestOtherOptionsNoF2f.content.subHeading2' | translate }}</h2>
 
   <form id="pyiSuggestOtherOptionsNoF2fForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiSuggestOtherOptionsNoF2fFormSubmit()">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next",
-                text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.continueAppButtonText' | translate,
-                hint: {text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.continueAppButtonTextHint' | translate}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiSuggestOtherOptionsNoF2f.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.continueAppButtonText' | translate,
+          hint: {text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.continueAppButtonTextHint' | translate}
 
-              },
-              {
-                value: "end",
-                text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.otherWayButtonText' | translate,
-                hint: { text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.otherWayButtonTextHint' | translate }
-              }
-            ]
-      })
-    }}
+        },
+        {
+          value: "end",
+          text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.otherWayButtonText' | translate,
+          hint: { text: 'pages.pyiSuggestOtherOptionsNoF2f.content.formRadioButtons.otherWayButtonTextHint' | translate }
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiSuggestOtherOptionsNoF2f.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">
-      {{'general.shared.contactLinkText' | translate }}
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
     </a>
   </p>
-
-  <script nonce="{{ cspNonce }}">
-      let disableSubmit = false;
-
-      function pyiSuggestOtherOptionsNoF2fFormSubmit() {
-          if (!disableSubmit) {
-              disableSubmit = true;
-              document.getElementById('submitButton').disabled = true;
-              return true
-          }
-          return false;
-      }
-
-  </script>
 {% endblock %}

--- a/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
+++ b/src/views/ipv/pyi-suggest-other-options-no-f2f.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptionsNoF2f.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptionsNoF2f" %}
 

--- a/src/views/ipv/pyi-suggest-other-options.njk
+++ b/src/views/ipv/pyi-suggest-other-options.njk
@@ -2,23 +2,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptions.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptions" %}
 
-{% block content %}
-  {% if errorState %}
-    {{ govukErrorSummary({
-      titleText: 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryTitleText' | translate,
-      errorList: [
-        {
-          text: 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryDescriptionText' | translate,
-          href: "#pyiSuggestOtherOptionsForm"
-        }
-      ]
-    }) }}
-  {% endif %}
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiSuggestOtherOptionsForm" %}
 
+{% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiSuggestOtherOptions.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph1' | translate }}</p>
 

--- a/src/views/ipv/pyi-suggest-other-options.njk
+++ b/src/views/ipv/pyi-suggest-other-options.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptions.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptions" %}
 

--- a/src/views/ipv/pyi-suggest-other-options.njk
+++ b/src/views/ipv/pyi-suggest-other-options.njk
@@ -1,10 +1,24 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorState = pageErrorState %}
 {% set pageTitleName = 'pages.pyiSuggestOtherOptions.title' | translate %}
 {% set googleTagManagerPageId = "pyiSuggestOtherOptions" %}
 
 {% block content %}
+  {% if errorState %}
+    {{ govukErrorSummary({
+      titleText: 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryTitleText' | translate,
+      errorList: [
+        {
+          text: 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorSummaryDescriptionText' | translate,
+          href: "#pyiSuggestOtherOptionsForm"
+        }
+      ]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiSuggestOtherOptions.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph1' | translate }}</p>
 
@@ -12,40 +26,51 @@
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph2' | translate }}</p>
   <p class="govuk-body govuk-!-margin-bottom-1">{{ 'pages.pyiSuggestOtherOptions.content.paragraph3' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-5">
-    <li>{{'pages.pyiSuggestOtherOptions.content.bullet1' | translate }}</li>
-    <li>{{'pages.pyiSuggestOtherOptions.content.bullet2' | translate }}</li>
+    <li>{{ 'pages.pyiSuggestOtherOptions.content.bullet1' | translate }}</li>
+    <li>{{ 'pages.pyiSuggestOtherOptions.content.bullet2' | translate }}</li>
   </ul>
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph4' | translate }}</p>
-  <h2 class="govuk-heading-m">{{ 'pages.pyiSuggestOtherOptions.content.subHeading2' | translate }}</h2>
 
   <form id="pyiSuggestOtherOptionsForm" action="/ipv/page/{{ pageId }}" method="POST" onsubmit="return pyiSuggestOtherOptionsFormSubmit()">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios({
-    idPrefix: "journey",
-    name: "journey",
-    items: [
-              {
-                value: "next/dcmaw",
-                text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continueAppButtonText' | translate,
-                hint: {text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continueAppButtonTextHint' | translate}
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiSuggestOtherOptions.content.subHeading2' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next/dcmaw",
+          text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continueAppButtonText' | translate,
+          hint: {text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continueAppButtonTextHint' | translate}
 
-              },
-              {
-                value: "next/f2f",
-                text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continuePostOfficeButtonText' | translate,
-                hint: { text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
-              }
-            ]
-      })
-    }}
+        },
+        {
+          value: "next/f2f",
+          text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continuePostOfficeButtonText' | translate,
+          hint: { text: 'pages.pyiSuggestOtherOptions.content.formRadioButtons.continuePostOfficeButtonTextHint' | translate }
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiSuggestOtherOptions.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
     <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
       {{ 'general.buttons.next' | translate }}
     </button>
   </form>
 
   <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">
-      {{'general.shared.contactLinkText' | translate }}
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
     </a>
   </p>
 

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -58,6 +58,17 @@
         <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+                   {% if errorState %}
+                        {{ govukErrorSummary({
+                            titleText: errorTitle | default('Error Summary'),
+                            errorList: [
+                                {
+                                    text: errorText | translate,
+                                    href: errorHref | default("#")
+                                }
+                            ]
+                        }) }}
+                    {% endif %}
                     {% block content %}{% endblock %}
                 </div>
             </div>

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block head %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added radio button form validation to all core-front pages which have a radio button forms
 - Added nunjucks filter to push more keys into an object  
 - Added a check function to determine whether journey is undefined and set an errorState
 
Added routes for each individual form POST which has the new form validation check
Used the latest translations provided by content for the error messages

Regarding `page-ipv-bank-account-start.njk form validation` I have added a placeholder message which is from the other error messages, this will need to be updated when we get finalised content

### Why did it change

Users where previously able to submit a form without selecting an option which would default to using the first item in the form. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3429](https://govukverify.atlassian.net/browse/PYIC-3429)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

[PYIC-3429]: https://govukverify.atlassian.net/browse/PYIC-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ