### PR TITLE
Update codeowners for new gh org

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @alphagov/digital-identity-ipv
-
+* @govuk-one-login/core-team


### PR DESCRIPTION
Should set the IPV Core team as default reviews