### PR TITLE
PYIC-4046: bug probably caused by the change to how we redirect on error

### DIFF
--- a/src/handlers/journey-event-error-handler.js
+++ b/src/handlers/journey-event-error-handler.js
@@ -29,6 +29,7 @@ module.exports = {
         : res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
 
       return res.render(`ipv/${pageId}.njk`, {
+        pageId: pageId,
         csrfToken: req.csrfToken(),
       });
     }


### PR DESCRIPTION
Add missing pageId being passed into the template

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This is caused by a change to the way we display error screens: instead of redirecting to a dedicated error page, we render the error screen directly from the callback URL (in order to get the right status code).

In the shared journey form, it attempts to post to `/ipv/page/{pageId}`, but there is no page id for the callback URL, and therefore it posts to `/ipv/page/`, which 404s.

Now passes in pageId into the template

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4036](https://govukverify.atlassian.net/browse/PYIC-4036)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-4036]: https://govukverify.atlassian.net/browse/PYIC-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ