### PR TITLE
IPS-279 Locking down the egress rule, Dynatrace api endpoint enabled

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -261,11 +261,6 @@ Resources:
           IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-        - CidrIp: 0.0.0.0/0
-          Description: Allow outbound HTTPS traffic to Internet - Network Firewall will allow only to CRIs
-          FromPort: 443
-          IpProtocol: tcp
-          ToPort: 443
       SecurityGroupIngress:
         - CidrIp:
             Fn::ImportValue: !Sub ${VpcStackName}-VpcCidr


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
IPS-279 Locking down the egress rule, Dynatrace api endpoint enabled
<!-- Describe the changes in detail - the "what"-->

### Why did it change
IPS-279 Locking down the egress rule, Dynatrace api endpoint enabled
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-279](https://govukverify.atlassian.net/browse/IPS-279)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-279]: https://govukverify.atlassian.net/browse/IPS-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ