### PR TITLE
PYIC-3799: Update CRI Callback Endpoint

### DIFF
--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -14,7 +14,7 @@ describe("credential issuer middleware", () => {
     let ipvMiddlewareStub = {};
 
     beforeEach(() => {
-      configStub.API_CRI_CALLBACK = "/journey/cri/callback";
+      configStub.API_CRI_CALLBACK = "/cri/callback";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
@@ -67,7 +67,7 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPI(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {
@@ -101,7 +101,7 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPI(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {
@@ -163,7 +163,7 @@ describe("credential issuer middleware", () => {
       };
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {
@@ -189,7 +189,7 @@ describe("credential issuer middleware", () => {
     let ipvMiddlewareStub = {};
 
     beforeEach(() => {
-      configStub.API_CRI_CALLBACK = "/journey/cri/callback";
+      configStub.API_CRI_CALLBACK = "/cri/callback";
       configStub.API_BASE_URL = "https://example.net/path";
       configStub.CREDENTIAL_ISSUER_ID = "testCredentialIssuerId";
       configStub.EXTERNAL_WEBSITE_HOST = "http://example.com";
@@ -240,7 +240,7 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {
@@ -274,7 +274,7 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {
@@ -336,7 +336,7 @@ describe("credential issuer middleware", () => {
       await middleware.sendParamsToAPIV2(req, res, next);
 
       expect(axiosStub.post).to.have.been.calledWith(
-        "https://example.net/path/journey/cri/callback",
+        "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
           headers: {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,7 +14,7 @@ function getServiceDomain() {
 
 module.exports = {
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
-  API_CRI_CALLBACK: "/journey/cri/callback",
+  API_CRI_CALLBACK: "/cri/callback",
   API_SESSION_INITIALISE: "/session/initialise",
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS: "/user/proven-identity-details",
   ENABLE_PREVIEW: process.env.ENABLE_PREVIEW === "development",


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated cri callback endpoint to remove "/journey" prefix

### Why did it change

- To mirror changes in core-back
- "/journey" normally precedes events, which doesn't fit this use case

### Issue tracking

- [PYIC-3799](https://govukverify.atlassian.net/browse/PYIC-3799)


[PYIC-3799]: https://govukverify.atlassian.net/browse/PYIC-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ