### PR TITLE
PYIC-4151: Bug fix - double-submit prevention now working for all forms

### DIFF
--- a/src/assets/javascript/app/init.js
+++ b/src/assets/javascript/app/init.js
@@ -14,13 +14,12 @@ window.DI = window.DI || {};
 // Globally disable second clicks on the continue button for radio button pages,
 // But allow onSubmit scripts to overwrite this global behaviour
 
-const checkForOnSubmit = document.querySelector("form[onsubmit]");
-const checkForRadio = document.querySelector('input[type="radio"]');
 let disableSubmit = false;
 
-if (checkForOnSubmit === null && checkForRadio !== null) {
-  const manageFormClicks = document.querySelector("form");
-  manageFormClicks.addEventListener("submit", () => {
+const manageFormClicks = document.querySelectorAll("form");
+
+manageFormClicks.forEach((form) => {
+  form.addEventListener("submit", () => {
     if (!disableSubmit) {
       disableSubmit = true;
       document.getElementById("submitButton").disabled = true;
@@ -28,4 +27,4 @@ if (checkForOnSubmit === null && checkForRadio !== null) {
     }
     return false;
   });
-}
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the form check to look for all forms 

### Why did it change

Double-submit prevention is not working, allowing users in some browsers (e.g. Firefox) to submit twice from pages in ipv core.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4151](https://govukverify.atlassian.net/browse/PYIC-4151)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-4151]: https://govukverify.atlassian.net/browse/PYIC-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ