### PR TITLE
PYIC-3932: Added user initiated VC reset content to reuse-identity page

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -157,7 +157,6 @@ module.exports = {
     });
   },
   updateJourneyState: async (req, res, next) => {
-    console.log("Updating journey state")
     try {
       const allowedActions = [
         "/journey/next",

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -157,11 +157,13 @@ module.exports = {
     });
   },
   updateJourneyState: async (req, res, next) => {
+    console.log("Updating journey state")
     try {
       const allowedActions = [
         "/journey/next",
         "/journey/error",
         "/journey/fail",
+        "/journey/reset-identity",
         "/journey/attempt-recovery",
         "/journey/cri/build-oauth-request/ukPassport",
         "/journey/cri/build-oauth-request/stubUkPassport",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -488,12 +488,7 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "Os yw'ch manylion ddim yn gyfredol",
-          "updateDetailsParagraph1": "Mae eich prawf hunaniaeth yn dal i fod yn ddilys hyd yn oed os yw'ch manylion ddim yn gyfredol.",
-          "updateDetailsParagraph2": "Nid oes angen i chi ddiweddaru'ch manylion i barhau â'r gwasanaeth rydych angen ei ddefnyddio. Pan fyddwch yn parhau, bydd GOV.UK One Login yn rhannu eich manylion cyfredol gyda'r gwasanaeth.",
-          "updateDetailsParagraph3": "Os ydych am ddiweddaru eich manylion cyn iddynt gael eu rhannu gyda'r gwasanaeth, bydd angen i chi:",
-          "updateDetailsListItem1": "dileu eich manylion",
-          "updateDetailsListItem2": "profi eich hunaniaeth eto",
-          "updateDetailsParagraph4": "Profi eich hunaniaeth eto gyda manylion newydd"
+          "updateDetailsHtml": "<p>Mae eich prawf hunaniaeth yn dal i fod yn ddilys hyd yn oed os yw'ch manylion ddim yn gyfredol.</p><p>Nid oes angen i chi ddiweddaru'ch manylion i barhau â'r gwasanaeth rydych angen ei ddefnyddio. Pan fyddwch yn parhau, bydd GOV.UK One Login yn rhannu eich manylion cyfredol gyda'r gwasanaeth.</p><p>Os ydych am ddiweddaru eich manylion cyn iddynt gael eu rhannu gyda'r gwasanaeth, bydd angen i chi:</p><ul><li>dileu eich manylion</li><li>profi eich hunaniaeth eto</li></ul><a class=\"govuk-link\" href=\"/ipv/journey/reset-identity\" rel=\"noopener noreferrer\">Profi eich hunaniaeth eto gyda manylion newydd</a>"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -487,8 +487,13 @@
           "previousAddress": "Cyfeiriad blaenorol"
         },
         "updateUserDetailsInformation": {
-          "updateDetailsLabel": "Sut i ddiweddaru eich manylion",
-          "updateDetailsHtml": "Cysylltwch â thîm cymorth <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">GOV.UK One Login (agor mewn tab newydd)</a>."
+          "updateDetailsLabel": "Os yw'ch manylion ddim yn gyfredol",
+          "updateDetailsParagraph1": "Mae eich prawf hunaniaeth yn dal i fod yn ddilys hyd yn oed os yw'ch manylion ddim yn gyfredol.",
+          "updateDetailsParagraph2": "Nid oes angen i chi ddiweddaru'ch manylion i barhau â'r gwasanaeth rydych angen ei ddefnyddio. Pan fyddwch yn parhau, bydd GOV.UK One Login yn rhannu eich manylion cyfredol gyda'r gwasanaeth.",
+          "updateDetailsParagraph3": "Os ydych am ddiweddaru eich manylion cyn iddynt gael eu rhannu gyda'r gwasanaeth, bydd angen i chi:",
+          "updateDetailsListItem1": "dileu eich manylion",
+          "updateDetailsListItem2": "profi eich hunaniaeth eto",
+          "updateDetailsParagraph4": "Profi eich hunaniaeth eto gyda manylion newydd"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -487,8 +487,14 @@
           "previousAddress": "Previous address"
         },
         "updateUserDetailsInformation": {
-          "updateDetailsLabel": "How to update your details",
-          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> to update your details."
+          "updateDetailsLabel": "If your details are out of date",
+          "updateDetailsHtml": "<p>Your proof of identity is still valid even if your details are out of date.</p><p>You do not need to update your details to continue to the service you need to use. When you continue, GOV.UK One Login will share your current details with the service.</p><p>If you want to update your details before they are shared with the service, you'll need to:</p><div><ul><li>delete your details</li><li>prove your identity again</li></ul></div><p>Prove your identity again with new details.</p>",
+          "updateDetailsParagraph1": "",
+          "updateDetailsParagraph2": "",
+          "updateDetailsParagraph3": "",
+          "updateDetailsListItem1": "delete your details",
+          "updateDetailsListItem2": "prove your identity again",
+          "updateDetailsParagraph4": ""
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -488,13 +488,7 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "If your details are out of date",
-          "updateDetailsHtml": "<p>Your proof of identity is still valid even if your details are out of date.</p><p>You do not need to update your details to continue to the service you need to use. When you continue, GOV.UK One Login will share your current details with the service.</p><p>If you want to update your details before they are shared with the service, you'll need to:</p><div><ul><li>delete your details</li><li>prove your identity again</li></ul></div><p>Prove your identity again with new details.</p>",
-          "updateDetailsParagraph1": "",
-          "updateDetailsParagraph2": "",
-          "updateDetailsParagraph3": "",
-          "updateDetailsListItem1": "delete your details",
-          "updateDetailsListItem2": "prove your identity again",
-          "updateDetailsParagraph4": ""
+          "updateDetailsHtml": "<p>Your proof of identity is still valid even if your details are out of date.</p><p>You do not need to update your details to continue to the service you need to use. When you continue, GOV.UK One Login will share your current details with the service.</p><p>If you want to update your details before they are shared with the service, you'll need to:</p><ul><li>delete your details</li><li>prove your identity again</li></ul><a class=\"govuk-link\" href=\"/ipv/journey/reset-identity\" rel=\"noopener noreferrer\">Prove your identity again with new details</a>."
         }
       }
     },

--- a/src/views/ipv/page-ipv-reuse.njk
+++ b/src/views/ipv/page-ipv-reuse.njk
@@ -55,7 +55,7 @@
 
     {{ govukDetails({
         summaryText: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translate,
-        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translate( { pageId: pageId } ) | safe
+        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translate | safe
     }) }}
 
     {% include 'shared/journey-next-form.njk' %}

--- a/src/views/ipv/page-ipv-reuse.njk
+++ b/src/views/ipv/page-ipv-reuse.njk
@@ -55,7 +55,7 @@
 
     {{ govukDetails({
         summaryText: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translate,
-        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translate( { url: contactUsUrl } ) | safe
+        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translate( { pageId: pageId } ) | safe
     }) }}
 
     {% include 'shared/journey-next-form.njk' %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

============== DO NOT MERGE UNTIL READY TO GO LIVE ================

## Proposed changes

### What changed

Added user initiated VC reset content to reuse-identity page

### Why did it change

To enable the user initiated VC reset journey when we want to go live with this feature.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3932](https://govukverify.atlassian.net/browse/PYIC-3932)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-3932]: https://govukverify.atlassian.net/browse/PYIC-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ