### PR TITLE
PYIC-4125 Increase health-check timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -386,8 +386,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
-      HealthCheckTimeoutSeconds: 2
-      HealthCheckIntervalSeconds: 5
+      HealthCheckTimeoutSeconds: 5
+      HealthCheckIntervalSeconds: 10
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: 200
@@ -439,7 +439,7 @@ Resources:
         - !Ref AWS::AccountId
         - desiredTaskCount
       EnableECSManagedTags: false
-      HealthCheckGracePeriodSeconds: 30
+      HealthCheckGracePeriodSeconds: 45
       LaunchType: FARGATE
       LoadBalancers:
         - ContainerName: app


### PR DESCRIPTION
In the high-volume reuse load-test, tasks are being killed due to health-check timeouts when under load. This means the service is stuck in a task recycle loop without being able to scale up sufficiently to handle the volume.