### PR TITLE
PYIC-4084: Create new F2F escape flow pages

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -264,6 +264,7 @@ module.exports = {
         case "pyi-new-details":
         case "pyi-confirm-delete-details":
         case "pyi-details-deleted":
+        case "pyi-f2f-delete-details":
         case "page-ipv-identity-document-start":
         case "page-ipv-identity-postoffice-start":
         case "page-ipv-bank-account-start":

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -428,6 +428,7 @@
         "list2": "dweud wrthym ble rydych chi wedi byw am y 3 mis diwetha",
         "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "paragraph4": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
+        "submitButtonTextF2f": "Continue to prove your identity",
         "submitButtonText": "Parhau i brofi eich hunaniaeth eto"
       }
     },
@@ -435,14 +436,12 @@
       "title": "Prove your identity another way",
       "header": "Prove your identity another way",
       "content": {
-        "paragraph1": "You've been sent a confirmation email.",
-        "paragraph2": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity.",
-        "paragraph3": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "paragraph1": "If you no longer want to prove your identity at a Post Office, you can delete your details and try to prove your identity another way.",
+        "paragraph2": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
-        "paragraph4": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
+        "paragraph3": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
         "submitButtonText": "Continue to delete your details",
-        "paragraph5LinkText": "I want to prove my identity at a Post Office",
-        "paragraph5LinkHref": "..."
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/next\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
       }
     },
     "pageMultipleDocCheck": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -425,6 +425,20 @@
         "submitButtonText": "Parhau i brofi eich hunaniaeth eto"
       }
     },
+    "pyiF2fDeleteDetails": {
+      "title": "Prove your identity another way",
+      "header": "Prove your identity another way",
+      "content": {
+        "paragraph1": "You've been sent a confirmation email.",
+        "paragraph2": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity.",
+        "paragraph3": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
+        "paragraph4": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
+        "submitButtonText": "Continue to delete your details",
+        "paragraph5LinkText": "I want to prove my identity at a Post Office",
+        "paragraph5LinkHref": "..."
+      }
+    },
     "pageMultipleDocCheck": {
       "title": "Parhau profi eich hunaniaeth ar-lein",
       "header": "Parhau profi eich hunaniaeth ar-lein",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -398,12 +398,15 @@
     },
     "pyiConfirmDeleteDetails": {
       "title": "Ydych chi'n siwr eich bod am ddileu eich manylion a phrofi eich hunaniaeth eto?",
+      "titleF2f": "Are you sure you want to delete your details and prove your identity another way?",
       "header": "Ydych chi'n siwr eich bod am ddileu eich manylion a phrofi eich hunaniaeth eto?",
+      "headerF2f": "Are you sure you want to delete your details and prove your identity another way?",
       "content": {
         "paragraph1": "Ni fydd dileu eich GOV.UK One Login yn effeithio ar unrhyw gyfrifon eraill y llywodraeth sydd gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
         "formRadioButtons": {
           "yes": "Ydw, dileu fy manylion",
-          "no": "Na, canslo a mynd yn ôl at fy manylion cyfredol "
+          "no": "Na, canslo a mynd yn ôl at fy manylion cyfredol",
+          "noF2f": "No, I want to prove my identity at a Post Office"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
@@ -417,10 +420,13 @@
       "header": "Rydych chi wedi dileu'r manylion yn eich GOV.UK One Login",
       "content": {
         "paragraph1": "Rydych wedi derbyn e-bost cadarnhau.",
+        "paragraph2F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
         "paragraph2": "Nawr gallwch brofi eich hunaniaeth eto gan ddefnyddio'ch manylion newydd.",
+        "paragraph3F2f": "You can now try to prove your identity another way.",
         "paragraph3": "Byddwch angen:",
         "list1": "ID gyda llun gyda'r enw rydych chi ei eisiau GOV.UK One Login ei ddefnyddio ",
         "list2": "dweud wrthym ble rydych chi wedi byw am y 3 mis diwetha",
+        "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "paragraph4": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
         "submitButtonText": "Parhau i brofi eich hunaniaeth eto"
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -403,7 +403,8 @@
         "paragraph1": "Deleting the details saved in your GOV.UK One Login will not affect any other government account you may have such as Government Gateway or Universal Credit.",
         "formRadioButtons": {
           "yes": "Yes, delete my details",
-          "no": "No, cancel and go back to my current details"
+          "no": "No, cancel and go back to my current details",
+          "nof2f": "No, I want to prove my identity at a Post Office"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -428,6 +428,7 @@
         "list2": "to tell us where you've lived for the last 3 months",
         "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "paragraph4": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
+        "submitButtonTextF2f": "Continue to prove your identity",
         "submitButtonText": "Continue to prove your identity again"
       }
     },
@@ -435,14 +436,12 @@
       "title": "Prove your identity another way",
       "header": "Prove your identity another way",
       "content": {
-        "paragraph1": "You've been sent a confirmation email.",
-        "paragraph2": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity.",
-        "paragraph3": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "paragraph1": "If you no longer want to prove your identity at a Post Office, you can delete your details and try to prove your identity another way.",
+        "paragraph2": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
-        "paragraph4": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
+        "paragraph3": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
         "submitButtonText": "Continue to delete your details",
-        "paragraph5LinkText": "I want to prove my identity at a Post Office",
-        "paragraph5LinkHref": "..."
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/next\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
       }
     },
     "pageMultipleDocCheck": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -425,6 +425,20 @@
         "submitButtonText": "Continue to prove your identity again"
       }
     },
+    "pyiF2fDeleteDetails": {
+      "title": "Prove your identity another way",
+      "header": "Prove your identity another way",
+      "content": {
+        "paragraph1": "You've been sent a confirmation email.",
+        "paragraph2": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity.",
+        "paragraph3": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
+        "paragraph4": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
+        "submitButtonText": "Continue to delete your details",
+        "paragraph5LinkText": "I want to prove my identity at a Post Office",
+        "paragraph5LinkHref": "..."
+      }
+    },
     "pageMultipleDocCheck": {
       "title": "Continue proving your identity online",
       "header": "Continue proving your identity online",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -398,13 +398,15 @@
     },
     "pyiConfirmDeleteDetails": {
       "title": "Are you sure you want to delete your details and prove your identity again?",
+      "titleF2f": "Are you sure you want to delete your details and prove your identity another way?",
       "header": "Are you sure you want to delete your details and prove your identity again?",
+      "headerF2f": "Are you sure you want to delete your details and prove your identity another way?",
       "content": {
         "paragraph1": "Deleting the details saved in your GOV.UK One Login will not affect any other government account you may have such as Government Gateway or Universal Credit.",
         "formRadioButtons": {
           "yes": "Yes, delete my details",
           "no": "No, cancel and go back to my current details",
-          "nof2f": "No, I want to prove my identity at a Post Office"
+          "noF2f": "No, I want to prove my identity at a Post Office"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
@@ -418,10 +420,13 @@
       "header": "You have deleted the details in your GOV.UK One Login",
       "content": {
         "paragraph1": "You've been sent a confirmation email.",
+        "paragraph2F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
         "paragraph2": "You can now prove your identity again using your new details.",
+        "paragraph3F2f": "You can now try to prove your identity another way.",
         "paragraph3": "You'll need:",
         "list1": "photo ID with the name you want GOV.UK One Login to use",
         "list2": "to tell us where you've lived for the last 3 months",
+        "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
         "paragraph4": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
         "submitButtonText": "Continue to prove your identity again"
       }

--- a/src/views/ipv/pyi-confirm-delete-details.njk
+++ b/src/views/ipv/pyi-confirm-delete-details.njk
@@ -1,6 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleName = 'pages.pyiConfirmDeleteDetails.title' | translate %}
+{% set pageTitleName = 'pages.pyiConfirmDeleteDetails.title' | translateWithContext(context) %}
 {% set googleTagManagerPageId = "pyiConfirmDeleteDetails" %}
 
 {% set errorState = pageErrorState %}
@@ -10,8 +10,8 @@
 
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
-      xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiConfirmDeleteDetails.header' | translate }}</h1>
-  {% if context != "f2f" %}
+      xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiConfirmDeleteDetails.header' | translateWithContext(context) }}</h1>
+  {% if context !== "f2f" %}
     <p class="govuk-body">{{ 'pages.pyiConfirmDeleteDetails.content.paragraph1' | translate }}</p>
   {% endif %}
 

--- a/src/views/ipv/pyi-confirm-delete-details.njk
+++ b/src/views/ipv/pyi-confirm-delete-details.njk
@@ -11,12 +11,13 @@
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiConfirmDeleteDetails.header' | translate }}</h1>
+  {% if context != "f2f" %}
+    <p class="govuk-body">{{ 'pages.pyiConfirmDeleteDetails.content.paragraph1' | translate }}</p>
+  {% endif %}
 
-  <p class="govuk-body">{{ 'pages.pyiConfirmDeleteDetails.content.paragraph1' | translate }}</p>
-    
-  <form id="pyiConfirmDeleteDetailsActionForm" action="/ipv/page/{{pageId}}" method="POST">
-    <input type="hidden" name="_csrf" value="{{csrfToken}}">
-      {% set radiosConfig = {  
+  <form id="pyiConfirmDeleteDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      {% set radiosConfig = {
         idPrefix: "journey",
         name: "journey",
         items: [
@@ -26,10 +27,10 @@
                 },
                 {
                   value: "end",
-                  text: 'pages.pyiConfirmDeleteDetails.content.formRadioButtons.no' | translate
+                  text: 'pages.pyiConfirmDeleteDetails.content.formRadioButtons.no' | translateWithContext(context)
                 }
               ]
-      } 
+      }
     %}
 
     {% if errorState %}

--- a/src/views/ipv/pyi-details-deleted.njk
+++ b/src/views/ipv/pyi-details-deleted.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set pageTitleName = 'pages.pyiDetailsDeleted.title' | translate %}
-{% set customButtonLabel = 'pages.pyiDetailsDeleted.content.submitButtonText' | translate %}
+{% set customButtonLabel = 'pages.pyiDetailsDeleted.content.submitButtonText' | translateWithContext(context) %}
 {% set googleTagManagerPageId = "pyiDetailsDeleted" %}
 
 {% block content %}
@@ -20,7 +20,7 @@
     </ul>
   {% endif %}
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translateWithContext(context) | safe }}</p>
 
 {% include "shared/journey-next-form.njk" %}
 {% endblock %}

--- a/src/views/ipv/pyi-details-deleted.njk
+++ b/src/views/ipv/pyi-details-deleted.njk
@@ -9,16 +9,18 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiDetailsDeleted.header' | translate }}</h1>
 
-   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
-   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph2' | translate }}</p>
-   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph2' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) }}</p>
+  
+  {% if context !== "f2f" %}
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{ 'pages.pyiDetailsDeleted.content.list1' | translate }}</li>
+      <li>{{ 'pages.pyiDetailsDeleted.content.list2' | translate }}</li>
+    </ul>
+  {% endif %}
 
-   <ul class="govuk-list govuk-list--bullet">
-    <li>{{ 'pages.pyiDetailsDeleted.content.list1' | translate }}</li>
-    <li>{{ 'pages.pyiDetailsDeleted.content.list2' | translate }}</li>
-  </ul>
-
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translate | safe}}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translate | safe }}</p>
 
 {% include "shared/journey-next-form.njk" %}
 {% endblock %}

--- a/src/views/ipv/pyi-f2f-delete-details.njk
+++ b/src/views/ipv/pyi-f2f-delete-details.njk
@@ -19,7 +19,8 @@
   }) }}
 
   <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph4' | translate }}</p>
+  
+  {% include "shared/journey-next-form.njk" %}
 
   <p class="govuk-body"> <a href="{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkText' | translate }}</a></p>
-{% include "shared/journey-next-form.njk" %}
 {% endblock %}

--- a/src/views/ipv/pyi-f2f-delete-details.njk
+++ b/src/views/ipv/pyi-f2f-delete-details.njk
@@ -11,16 +11,15 @@
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiF2fDeleteDetails.header' | translate }}</h1>
 
   <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph1' | translate }}</p>
-  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph2' | translate }}</p>
-  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph3' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph2' | translate | safe }}</p>
 
   {{ govukInsetText({
     text: 'pages.pyiF2fDeleteDetails.content.insetText' | translate
   }) }}
 
-  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph4' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph3' | translate }}</p>
   
   {% include "shared/journey-next-form.njk" %}
 
-  <p class="govuk-body"> <a href="{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkText' | translate }}</a></p>
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph4LinkText' | translate | safe }}</p>
 {% endblock %}

--- a/src/views/ipv/pyi-f2f-delete-details.njk
+++ b/src/views/ipv/pyi-f2f-delete-details.njk
@@ -1,0 +1,25 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.pyiF2fDeleteDetails.title' | translate %}
+{% set customButtonLabel = 'pages.pyiF2fDeleteDetails.content.submitButtonText' | translate %}
+{% set googleTagManagerPageId = "pyiF2fDeleteDetails" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
+      xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiF2fDeleteDetails.header' | translate }}</h1>
+
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph3' | translate | safe }}</p>
+
+  {{ govukInsetText({
+    text: 'pages.pyiF2fDeleteDetails.content.insetText' | translate
+  }) }}
+
+  <p class="govuk-body">{{ 'pages.pyiF2fDeleteDetails.content.paragraph4' | translate }}</p>
+
+  <p class="govuk-body"> <a href="{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ 'pages.pyiF2fDeleteDetails.content.paragraph5LinkText' | translate }}</a></p>
+{% include "shared/journey-next-form.njk" %}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Created a new page pyi-f2f-delete-details.njk as content largely differs from existing pages
<img width="500" alt="pyi-f2f-delete-details" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/a60d17a0-d40e-4b36-ba03-66c43547bba4">

Added dynamic content to pyi-confirm-delete-details.njk
BEFORE:
<img width="500" alt=" pyi-confirm-delete-details" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/276a9b22-e217-4a17-9632-10c56b62ee17">
AFTER with `context: "f2f"`:
<img width="500" alt="pyi-confirm-delete-details (f2f)" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/c746fec5-4ec7-404d-b605-7a57b60b416d">

Added dynamic content to pyi-details-deleted.njk
BEFORE:
<img width="500" alt="pyi-details-deleted" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/bb0663e2-c3f3-4656-a1ed-18982b3c1ccb">
AFTER with `context: "f2f"`:
<img width="500" alt="pyi-details-deleted(f2f)" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/89581fe8-2bdc-411b-80a7-70a10ccabb83">


### Why did it change

New/separate content is required for the F2F escape flow 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4084](https://govukverify.atlassian.net/browse/PYIC-4084)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

[PYIC-4084]: https://govukverify.atlassian.net/browse/PYIC-4084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ