### PR TITLE
PYIC-4086: add temp button to allow test for f2f delete details feature

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -160,6 +160,7 @@ module.exports = {
     try {
       const allowedActions = [
         "/journey/next",
+        "/journey/end",
         "/journey/error",
         "/journey/fail",
         "/journey/attempt-recovery",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -441,7 +441,7 @@
         "insetText": "Ar ôl i chi ddileu eich manylion, ni fydd llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
         "paragraph3": "Byddwn yn dileu'ch manylion yn awtomatig os na fyddwch yn mynd i Swyddfa'r Post o fewn 10 diwrnod o gael eich e-bost cadarnhau.",
         "submitButtonText": "Parhau i ddileu eich manylion",
-        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/next\" rel=\"noopener noreferrer\">Rwyf am brofi fy hunaniaeth mewn Swyddfa'r Post</a>"
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/end\" rel=\"noopener noreferrer\">Rwyf am brofi fy hunaniaeth mewn Swyddfa'r Post</a>"
       }
     },
     "pageMultipleDocCheck": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -441,7 +441,7 @@
         "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
         "paragraph3": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
         "submitButtonText": "Continue to delete your details",
-        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/next\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/end\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
       }
     },
     "pageMultipleDocCheck": {

--- a/src/views/ipv/page-ipv-pending.njk
+++ b/src/views/ipv/page-ipv-pending.njk
@@ -20,4 +20,7 @@
   </ul>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% if context == "f2f-delete-details" %}
+    {% include 'shared/journey-next-form.njk' %}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Allow f2f delete jounery when featureflag `deleteDetailsEnabled` is enabled.

### What changed

- Added Temp button that we can use to test f2f delete details journey.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- New feature development.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4086](https://govukverify.atlassian.net/browse/PYIC-4086)

[PYIC-4086]: https://govukverify.atlassian.net/browse/PYIC-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ