### PR TITLE
PYIC-4125: Keep HTTPS connections alive

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -1,22 +1,9 @@
-const {
-  API_BASE_URL,
-  API_CRI_CALLBACK,
-  EXTERNAL_WEBSITE_HOST,
-} = require("../../lib/config");
-const { generateJsonAxiosConfig } = require("../shared/axiosHelper");
+const { API_CRI_CALLBACK, EXTERNAL_WEBSITE_HOST } = require("../../lib/config");
 const { handleBackendResponse } = require("../ipv/middleware");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
-const http = require("http");
-const https = require("https");
-const axios = require("axios");
-
-const httpAgent = new http.Agent({ keepAlive: true });
-const httpsAgent = new https.Agent({ keepAlive: true });
-const axiosInstance = axios.create({
-  httpAgent,
-  httpsAgent,
-});
+const { CoreBackService } = require("../../services/coreBackService");
+const coreBackService = new CoreBackService();
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -41,10 +28,10 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await axiosInstance.post(
-        `${API_BASE_URL}${API_CRI_CALLBACK}`,
-        { ...body, ...errorDetails },
-        generateJsonAxiosConfig(req),
+      const apiResponse = await coreBackService.postCriCallback(
+        req,
+        body,
+        errorDetails,
       );
       if (apiResponse?.status) {
         res.status(apiResponse.status);
@@ -82,10 +69,10 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await axiosInstance.post(
-        `${API_BASE_URL}${API_CRI_CALLBACK}`,
-        { ...body, ...errorDetails },
-        generateJsonAxiosConfig(req),
+      const apiResponse = await coreBackService.postCriCallback(
+        req,
+        body,
+        errorDetails,
       );
       if (apiResponse?.status) {
         res.status(apiResponse.status);

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -2,7 +2,7 @@ const { API_CRI_CALLBACK, EXTERNAL_WEBSITE_HOST } = require("../../lib/config");
 const { handleBackendResponse } = require("../ipv/middleware");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
-const CoreBackService = require("../../services/coreBackService");
+const coreBackService = require("../../services/coreBackService");
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await CoreBackService.postCriCallback(
+      const apiResponse = await coreBackService.postCriCallback(
         req,
         body,
         errorDetails,
@@ -68,7 +68,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await CoreBackService.postCriCallback(
+      const apiResponse = await coreBackService.postCriCallback(
         req,
         body,
         errorDetails,

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -7,7 +7,16 @@ const { generateJsonAxiosConfig } = require("../shared/axiosHelper");
 const { handleBackendResponse } = require("../ipv/middleware");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
+const http = require("http");
+const https = require("https");
 const axios = require("axios");
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+const axiosInstance = axios.create({
+  httpAgent,
+  httpsAgent,
+});
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -32,7 +41,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await axios.post(
+      const apiResponse = await axiosInstance.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
         generateJsonAxiosConfig(req),
@@ -73,7 +82,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await axios.post(
+      const apiResponse = await axiosInstance.post(
         `${API_BASE_URL}${API_CRI_CALLBACK}`,
         { ...body, ...errorDetails },
         generateJsonAxiosConfig(req),

--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -2,8 +2,7 @@ const { API_CRI_CALLBACK, EXTERNAL_WEBSITE_HOST } = require("../../lib/config");
 const { handleBackendResponse } = require("../ipv/middleware");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
-const { CoreBackService } = require("../../services/coreBackService");
-const coreBackService = new CoreBackService();
+const CoreBackService = require("../../services/coreBackService");
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
@@ -28,7 +27,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await coreBackService.postCriCallback(
+      const apiResponse = await CoreBackService.postCriCallback(
         req,
         body,
         errorDetails,
@@ -69,7 +68,7 @@ module.exports = {
         path: API_CRI_CALLBACK,
       });
 
-      const apiResponse = await coreBackService.postCriCallback(
+      const apiResponse = await CoreBackService.postCriCallback(
         req,
         body,
         errorDetails,

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -8,7 +8,8 @@ describe("credential issuer middleware", () => {
     let res;
     let next;
     let axiosResponse;
-    let axiosStub = {};
+    let axiosInstanceStub = {};
+    let axiosStub = { create: () => axiosInstanceStub };
     let configStub = {};
     let middleware;
     let ipvMiddlewareStub = {};
@@ -55,7 +56,7 @@ describe("credential issuer middleware", () => {
     it("should call axios with correct parameters", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
 
       const expectedBody = {
         authorizationCode: req.query.code,
@@ -66,7 +67,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
@@ -84,7 +85,7 @@ describe("credential issuer middleware", () => {
     it("should add error parameters if they exist", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
 
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
@@ -100,7 +101,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
@@ -118,7 +119,7 @@ describe("credential issuer middleware", () => {
     it("should send code to core backend and return with 200 response", async () => {
       axiosResponse.status = 200;
       axiosResponse.data = { journey: "journey/next" };
-      axiosStub.post = sinon.fake.returns(axiosResponse);
+      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -129,7 +130,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.data = {
         journey: "journey/next",
       };
-      axiosStub.post = sinon.fake.returns(axiosResponse);
+      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -142,7 +143,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.status = 404;
       const axiosError = new Error("api error");
       axiosError.response = axiosResponse;
-      axiosStub.post = sinon.fake.throws(axiosError);
+      axiosInstanceStub.post = sinon.fake.throws(axiosError);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -150,7 +151,7 @@ describe("credential issuer middleware", () => {
     });
 
     it("should call cri callback when ipvSessionId is missing", async () => {
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
       req.session.ipvSessionId = null;
 
       await middleware.sendParamsToAPI(req, res, next);
@@ -162,7 +163,7 @@ describe("credential issuer middleware", () => {
         state: req.query.state,
       };
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
@@ -183,7 +184,8 @@ describe("credential issuer middleware", () => {
     let res;
     let next;
     let axiosResponse;
-    let axiosStub = {};
+    let axiosInstanceStub = {};
+    let axiosStub = { create: () => axiosInstanceStub };
     let configStub = {};
     let middleware;
     let ipvMiddlewareStub = {};
@@ -228,7 +230,7 @@ describe("credential issuer middleware", () => {
     it("should call axios with correct parameters", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
 
       const expectedBody = {
         authorizationCode: req.query.code,
@@ -239,7 +241,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
@@ -257,7 +259,7 @@ describe("credential issuer middleware", () => {
     it("should add error parameters if they exist", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
 
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
@@ -273,7 +275,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({
@@ -291,7 +293,7 @@ describe("credential issuer middleware", () => {
     it("should send code to core backend and return with 200 response", async () => {
       axiosResponse.status = 200;
       axiosResponse.data = { journey: "journey/next" };
-      axiosStub.post = sinon.fake.returns(axiosResponse);
+      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -302,7 +304,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.data = {
         journey: "journey/next",
       };
-      axiosStub.post = sinon.fake.returns(axiosResponse);
+      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -315,7 +317,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.status = 404;
       const axiosError = new Error("api error");
       axiosError.response = axiosResponse;
-      axiosStub.post = sinon.fake.throws(axiosError);
+      axiosInstanceStub.post = sinon.fake.throws(axiosError);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -323,7 +325,7 @@ describe("credential issuer middleware", () => {
     });
 
     it("should call cri callback when ipvSessionId is missing", async () => {
-      axiosStub.post = sinon.fake();
+      axiosInstanceStub.post = sinon.fake();
       req.session.ipvSessionId = null;
 
       const expectedBody = {
@@ -335,7 +337,7 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosStub.post).to.have.been.calledWith(
+      expect(axiosInstanceStub.post).to.have.been.calledWith(
         "https://example.net/path/cri/callback",
         expectedBody,
         sinon.match({

--- a/src/app/credential-issuer/middleware.test.js
+++ b/src/app/credential-issuer/middleware.test.js
@@ -8,8 +8,7 @@ describe("credential issuer middleware", () => {
     let res;
     let next;
     let axiosResponse;
-    let axiosInstanceStub = {};
-    let axiosStub = { create: () => axiosInstanceStub };
+    let CoreBackServiceStub = {};
     let configStub = {};
     let middleware;
     let ipvMiddlewareStub = {};
@@ -23,7 +22,7 @@ describe("credential issuer middleware", () => {
       ipvMiddlewareStub.handleBackendResponse = sinon.fake();
 
       middleware = proxyquire("./middleware", {
-        axios: axiosStub,
+        "../../services/coreBackService": CoreBackServiceStub,
         "../../lib/config": configStub,
         "../ipv/middleware": ipvMiddlewareStub,
       });
@@ -56,7 +55,7 @@ describe("credential issuer middleware", () => {
     it("should call axios with correct parameters", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
 
       const expectedBody = {
         authorizationCode: req.query.code,
@@ -67,25 +66,17 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "ipv-session-id": "abadcafe",
-            "Content-Type": "application/json",
-            "x-request-id": "1",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        {},
       );
     });
 
     it("should add error parameters if they exist", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
 
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
@@ -95,31 +86,25 @@ describe("credential issuer middleware", () => {
         credentialIssuerId: req.query.id,
         redirectUri: `http://example.com/credential-issuer/callback?id=${req.query.id}`,
         state: req.query.state,
+      };
+      const expectedErrorDetails = {
         error: req.query.error,
         errorDescription: req.query.error_description,
       };
 
       await middleware.sendParamsToAPI(req, res, next);
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "x-request-id": "1",
-            "ipv-session-id": "abadcafe",
-            "Content-Type": "application/json",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        expectedErrorDetails,
       );
     });
 
     it("should send code to core backend and return with 200 response", async () => {
       axiosResponse.status = 200;
       axiosResponse.data = { journey: "journey/next" };
-      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
+      CoreBackServiceStub.postCriCallback = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -130,7 +115,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.data = {
         journey: "journey/next",
       };
-      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
+      CoreBackServiceStub.postCriCallback = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -143,7 +128,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.status = 404;
       const axiosError = new Error("api error");
       axiosError.response = axiosResponse;
-      axiosInstanceStub.post = sinon.fake.throws(axiosError);
+      CoreBackServiceStub.postCriCallback = sinon.fake.throws(axiosError);
 
       await middleware.sendParamsToAPI(req, res, next);
 
@@ -151,7 +136,7 @@ describe("credential issuer middleware", () => {
     });
 
     it("should call cri callback when ipvSessionId is missing", async () => {
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
       req.session.ipvSessionId = null;
 
       await middleware.sendParamsToAPI(req, res, next);
@@ -163,18 +148,10 @@ describe("credential issuer middleware", () => {
         state: req.query.state,
       };
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "ipv-session-id": null,
-            "Content-Type": "application/json",
-            "x-request-id": "1",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        {},
       );
     });
   });
@@ -184,8 +161,7 @@ describe("credential issuer middleware", () => {
     let res;
     let next;
     let axiosResponse;
-    let axiosInstanceStub = {};
-    let axiosStub = { create: () => axiosInstanceStub };
+    let CoreBackServiceStub = {};
     let configStub = {};
     let middleware;
     let ipvMiddlewareStub = {};
@@ -199,7 +175,7 @@ describe("credential issuer middleware", () => {
       ipvMiddlewareStub.handleBackendResponse = sinon.fake();
 
       middleware = proxyquire("./middleware", {
-        axios: axiosStub,
+        "../../services/coreBackService": CoreBackServiceStub,
         "../../lib/config": configStub,
         "../ipv/middleware": ipvMiddlewareStub,
       });
@@ -230,7 +206,7 @@ describe("credential issuer middleware", () => {
     it("should call axios with correct parameters", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
 
       const expectedBody = {
         authorizationCode: req.query.code,
@@ -241,25 +217,17 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "ipv-session-id": "abadcafe",
-            "Content-Type": "application/json",
-            "x-request-id": "1",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        {},
       );
     });
 
     it("should add error parameters if they exist", async () => {
       req.session.ipvSessionId = "abadcafe";
       req.session.ipAddress = "ip-address";
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
 
       req.query.error = "access_denied";
       req.query.error_description = "Access was denied!";
@@ -269,31 +237,25 @@ describe("credential issuer middleware", () => {
         credentialIssuerId: req.params.criId,
         redirectUri: `http://example.com/credential-issuer/callback/${req.params.criId}`,
         state: req.query.state,
+      };
+      const expectedErrorDetails = {
         error: req.query.error,
         errorDescription: req.query.error_description,
       };
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "x-request-id": "1",
-            "ipv-session-id": "abadcafe",
-            "Content-Type": "application/json",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        expectedErrorDetails,
       );
     });
 
     it("should send code to core backend and return with 200 response", async () => {
       axiosResponse.status = 200;
       axiosResponse.data = { journey: "journey/next" };
-      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
+      CoreBackServiceStub.postCriCallback = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -304,7 +266,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.data = {
         journey: "journey/next",
       };
-      axiosInstanceStub.post = sinon.fake.returns(axiosResponse);
+      CoreBackServiceStub.postCriCallback = sinon.fake.returns(axiosResponse);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -317,7 +279,7 @@ describe("credential issuer middleware", () => {
       axiosResponse.status = 404;
       const axiosError = new Error("api error");
       axiosError.response = axiosResponse;
-      axiosInstanceStub.post = sinon.fake.throws(axiosError);
+      CoreBackServiceStub.postCriCallback = sinon.fake.throws(axiosError);
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
@@ -325,7 +287,7 @@ describe("credential issuer middleware", () => {
     });
 
     it("should call cri callback when ipvSessionId is missing", async () => {
-      axiosInstanceStub.post = sinon.fake();
+      CoreBackServiceStub.postCriCallback = sinon.fake();
       req.session.ipvSessionId = null;
 
       const expectedBody = {
@@ -337,18 +299,10 @@ describe("credential issuer middleware", () => {
 
       await middleware.sendParamsToAPIV2(req, res, next);
 
-      expect(axiosInstanceStub.post).to.have.been.calledWith(
-        "https://example.net/path/cri/callback",
+      expect(CoreBackServiceStub.postCriCallback).to.have.been.calledWith(
+        req,
         expectedBody,
-        sinon.match({
-          headers: {
-            "x-request-id": "1",
-            "ipv-session-id": null,
-            "Content-Type": "application/json",
-            "ip-address": "ip-address",
-            "feature-set": "feature-set",
-          },
-        }),
+        {},
       );
     });
   });

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -32,11 +32,20 @@ const {
   generateUserDetails,
 } = require("../shared/reuseHelper");
 const { HTTP_STATUS_CODES } = require("../../app.constants");
-const axios = require("axios");
 const { getIpAddress } = require("../shared/ipAddressHelper");
 const fs = require("fs");
 const path = require("path");
 const { saveSessionAndRedirect } = require("../shared/redirectHelper");
+const http = require("http");
+const https = require("https");
+const axios = require("axios");
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+const axiosInstance = axios.create({
+  httpAgent,
+  httpsAgent,
+});
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -49,7 +58,7 @@ async function journeyApi(action, req) {
     path: action,
   });
 
-  return axios.post(
+  return axiosInstance.post(
     `${API_BASE_URL}/${action}`,
     {},
     req.session?.clientOauthSessionId
@@ -306,7 +315,7 @@ module.exports = {
           return res.render(`ipv/${sanitize(pageId)}.njk`, renderOptions);
         }
         case "page-ipv-reuse": {
-          const userDetailsResponse = await axios.get(
+          const userDetailsResponse = await axiosInstance.get(
             `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
             generateAxiosConfig(req),
           );

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -27,8 +27,7 @@ const { getIpAddress } = require("../shared/ipAddressHelper");
 const fs = require("fs");
 const path = require("path");
 const { saveSessionAndRedirect } = require("../shared/redirectHelper");
-const { CoreBackService } = require("../../services/coreBackService");
-const coreBackService = new CoreBackService();
+const CoreBackService = require("../../services/coreBackService");
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -41,7 +40,7 @@ async function journeyApi(action, req) {
     path: action,
   });
 
-  return coreBackService.postAction(req, action);
+  return CoreBackService.postAction(req, action);
 }
 
 async function handleJourneyResponse(req, res, action) {
@@ -293,7 +292,7 @@ module.exports = {
         }
         case "page-ipv-reuse": {
           const userDetailsResponse =
-            await coreBackService.getProvenIdentityUserDetails(req);
+            await CoreBackService.getProvenIdentityUserDetails(req);
           const userDetails = generateUserDetails(
             userDetailsResponse,
             req.i18n,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -27,7 +27,7 @@ const { getIpAddress } = require("../shared/ipAddressHelper");
 const fs = require("fs");
 const path = require("path");
 const { saveSessionAndRedirect } = require("../shared/redirectHelper");
-const CoreBackService = require("../../services/coreBackService");
+const coreBackService = require("../../services/coreBackService");
 
 async function journeyApi(action, req) {
   if (action.startsWith("/")) {
@@ -40,7 +40,7 @@ async function journeyApi(action, req) {
     path: action,
   });
 
-  return CoreBackService.postAction(req, action);
+  return coreBackService.postAction(req, action);
 }
 
 async function handleJourneyResponse(req, res, action) {
@@ -292,7 +292,7 @@ module.exports = {
         }
         case "page-ipv-reuse": {
           const userDetailsResponse =
-            await CoreBackService.getProvenIdentityUserDetails(req);
+            await coreBackService.getProvenIdentityUserDetails(req);
           const userDetails = generateUserDetails(
             userDetailsResponse,
             req.i18n,

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,8 +1,9 @@
-const { API_BASE_URL, API_SESSION_INITIALISE } = require("../../lib/config");
+const { API_SESSION_INITIALISE } = require("../../lib/config");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
-const axios = require("axios");
 const { getIpAddress } = require("../shared/ipAddressHelper");
+const { CoreBackService } = require("../../services/coreBackService");
+const coreBackService = new CoreBackService();
 
 module.exports = {
   setIpAddress: (req, res, next) => {
@@ -33,15 +34,9 @@ module.exports = {
         path: API_SESSION_INITIALISE,
       });
 
-      const response = await axios.post(
-        `${API_BASE_URL}${API_SESSION_INITIALISE}`,
+      const response = await coreBackService.postSessionInitialise(
+        req,
         authParams,
-        {
-          headers: {
-            "ip-address": req.session.ipAddress,
-            "feature-set": req.session.featureSet,
-          },
-        },
       );
 
       req.session.ipvSessionId = response?.data?.ipvSessionId;

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -2,8 +2,7 @@ const { API_SESSION_INITIALISE } = require("../../lib/config");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const { getIpAddress } = require("../shared/ipAddressHelper");
-const { CoreBackService } = require("../../services/coreBackService");
-const coreBackService = new CoreBackService();
+const CoreBackService = require("../../services/coreBackService");
 
 module.exports = {
   setIpAddress: (req, res, next) => {
@@ -34,7 +33,7 @@ module.exports = {
         path: API_SESSION_INITIALISE,
       });
 
-      const response = await coreBackService.postSessionInitialise(
+      const response = await CoreBackService.postSessionInitialise(
         req,
         authParams,
       );

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -2,7 +2,7 @@ const { API_SESSION_INITIALISE } = require("../../lib/config");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const { getIpAddress } = require("../shared/ipAddressHelper");
-const CoreBackService = require("../../services/coreBackService");
+const coreBackService = require("../../services/coreBackService");
 
 module.exports = {
   setIpAddress: (req, res, next) => {
@@ -33,7 +33,7 @@ module.exports = {
         path: API_SESSION_INITIALISE,
       });
 
-      const response = await CoreBackService.postSessionInitialise(
+      const response = await coreBackService.postSessionInitialise(
         req,
         authParams,
       );

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -2,13 +2,13 @@ const proxyquire = require("proxyquire");
 const { expect } = require("chai");
 const sinon = require("sinon");
 
-let axiosStub = {};
+let CoreBackServiceStub = {};
 
 const configStub = {
   API_BASE_URL: "https://example.org/subpath",
 };
 const middleware = proxyquire("./middleware", {
-  axios: axiosStub,
+  "../../services/coreBackService": CoreBackServiceStub,
   "../../lib/config": configStub,
 });
 
@@ -64,7 +64,8 @@ describe("oauth middleware", () => {
       });
 
       it("should set ipvSessionId in session", async function () {
-        axiosStub.post = sinon.fake.returns(axiosResponse);
+        CoreBackServiceStub.postSessionInitialise =
+          sinon.fake.returns(axiosResponse);
         await middleware.setIpvSessionId(req, res, next);
         expect(req.session.ipvSessionId).to.eq(axiosResponse.data.ipvSessionId);
       });
@@ -81,7 +82,8 @@ describe("oauth middleware", () => {
       });
 
       it("should set ipvSessionId as null in session", async function () {
-        axiosStub.post = sinon.fake.returns(axiosResponse);
+        CoreBackServiceStub.postSessionInitialise =
+          sinon.fake.returns(axiosResponse);
         await middleware.setIpvSessionId(req, res, next);
         expect(req.session.ipvSessionId).to.eq(null);
       });
@@ -98,7 +100,8 @@ describe("oauth middleware", () => {
       });
 
       it("should throw error", async function () {
-        axiosStub.post = sinon.fake.throws(axiosResponse);
+        CoreBackServiceStub.postSessionInitialise =
+          sinon.fake.throws(axiosResponse);
         await middleware.setIpvSessionId(req, res, next);
 
         expect(next).to.have.been.calledWith(
@@ -115,7 +118,8 @@ describe("oauth middleware", () => {
       });
 
       it("should throw error", async function () {
-        axiosStub.post = sinon.fake.throws(axiosResponse);
+        CoreBackServiceStub.postSessionInitialise =
+          sinon.fake.throws(axiosResponse);
         await middleware.setIpvSessionId(req, res, next);
         expect(next).to.have.been.calledWith(
           sinon.match

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -1,0 +1,93 @@
+const {
+  API_BASE_URL,
+  API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
+  API_CRI_CALLBACK,
+  API_SESSION_INITIALISE,
+} = require("../lib/config");
+const https = require("https");
+const axios = require("axios");
+
+class CoreBackService {
+  constructor() {
+    this.axiosInstance = axios.create({
+      httpsAgent: new https.Agent({ keepAlive: true }),
+    });
+  }
+
+  postAction(req, action) {
+    return this.axiosInstance.post(
+      `${API_BASE_URL}/${action}`,
+      {},
+      req.session?.clientOauthSessionId
+        ? this.generateAxiosConfigWithClientSessionId(req)
+        : this.generateAxiosConfig(req),
+    );
+  }
+
+  postSessionInitialise(req, authParams) {
+    return this.axiosInstance.post(
+      `${API_BASE_URL}${API_SESSION_INITIALISE}`,
+      authParams,
+      {
+        headers: {
+          "ip-address": req.session.ipAddress,
+          "feature-set": req.session.featureSet,
+        },
+      },
+    );
+  }
+
+  postCriCallback(req, body, errorDetails) {
+    return this.axiosInstance.post(
+      `${API_BASE_URL}${API_CRI_CALLBACK}`,
+      { ...body, ...errorDetails },
+      this.generateJsonAxiosConfig(req),
+    );
+  }
+
+  getProvenIdentityUserDetails(req) {
+    return this.axiosInstance.get(
+      `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
+      this.generateAxiosConfig(req),
+    );
+  }
+
+  generateAxiosConfig(req) {
+    return {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "ipv-session-id": req.session?.ipvSessionId,
+        "x-request-id": req.id,
+        "ip-address": req.session.ipAddress,
+        "feature-set": req.session.featureSet,
+      },
+    };
+  }
+  generateAxiosConfigWithClientSessionId(req) {
+    return {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "ipv-session-id": req.session?.ipvSessionId,
+        "client-session-id": req?.session?.clientOauthSessionId,
+        "x-request-id": req.id,
+        "ip-address": req.session.ipAddress,
+        "feature-set": req.session.featureSet,
+      },
+    };
+  }
+  generateJsonAxiosConfig(req) {
+    return {
+      headers: {
+        "Content-Type": "application/json",
+        "ipv-session-id": req.session?.ipvSessionId,
+        "x-request-id": req.id,
+        "ip-address": req.session.ipAddress,
+        "feature-set": req.session.featureSet,
+      },
+    };
+  }
+}
+
+module.exports = {
+  CoreBackService,
+};

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -7,87 +7,83 @@ const {
 const https = require("https");
 const axios = require("axios");
 
-class CoreBackService {
-  constructor() {
-    this.axiosInstance = axios.create({
-      httpsAgent: new https.Agent({ keepAlive: true }),
-    });
-  }
+const axiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  httpsAgent: new https.Agent({ keepAlive: true }),
+});
 
-  postAction(req, action) {
-    return this.axiosInstance.post(
-      `${API_BASE_URL}/${action}`,
-      {},
-      req.session?.clientOauthSessionId
-        ? this.generateAxiosConfigWithClientSessionId(req)
-        : this.generateAxiosConfig(req),
-    );
-  }
+function postAction(req, action) {
+  return axiosInstance.post(
+    `/${action}`,
+    {},
+    req.session?.clientOauthSessionId
+      ? generateAxiosConfigWithClientSessionId(req)
+      : generateAxiosConfig(req),
+  );
+}
 
-  postSessionInitialise(req, authParams) {
-    return this.axiosInstance.post(
-      `${API_BASE_URL}${API_SESSION_INITIALISE}`,
-      authParams,
-      {
-        headers: {
-          "ip-address": req.session.ipAddress,
-          "feature-set": req.session.featureSet,
-        },
-      },
-    );
-  }
+function postSessionInitialise(req, authParams) {
+  return axiosInstance.post(API_SESSION_INITIALISE, authParams, {
+    headers: {
+      "ip-address": req.session.ipAddress,
+      "feature-set": req.session.featureSet,
+    },
+  });
+}
 
-  postCriCallback(req, body, errorDetails) {
-    return this.axiosInstance.post(
-      `${API_BASE_URL}${API_CRI_CALLBACK}`,
-      { ...body, ...errorDetails },
-      this.generateJsonAxiosConfig(req),
-    );
-  }
+function postCriCallback(req, body, errorDetails) {
+  return axiosInstance.post(
+    API_CRI_CALLBACK,
+    { ...body, ...errorDetails },
+    generateJsonAxiosConfig(req),
+  );
+}
 
-  getProvenIdentityUserDetails(req) {
-    return this.axiosInstance.get(
-      `${API_BASE_URL}${API_BUILD_PROVEN_USER_IDENTITY_DETAILS}`,
-      this.generateAxiosConfig(req),
-    );
-  }
+function getProvenIdentityUserDetails(req) {
+  return axiosInstance.get(
+    API_BUILD_PROVEN_USER_IDENTITY_DETAILS,
+    generateAxiosConfig(req),
+  );
+}
 
-  generateAxiosConfig(req) {
-    return {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-    };
-  }
-  generateAxiosConfigWithClientSessionId(req) {
-    return {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "client-session-id": req?.session?.clientOauthSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-    };
-  }
-  generateJsonAxiosConfig(req) {
-    return {
-      headers: {
-        "Content-Type": "application/json",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-    };
-  }
+function generateAxiosConfig(req) {
+  return {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "ipv-session-id": req.session?.ipvSessionId,
+      "x-request-id": req.id,
+      "ip-address": req.session.ipAddress,
+      "feature-set": req.session.featureSet,
+    },
+  };
+}
+function generateAxiosConfigWithClientSessionId(req) {
+  return {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "ipv-session-id": req.session?.ipvSessionId,
+      "client-session-id": req?.session?.clientOauthSessionId,
+      "x-request-id": req.id,
+      "ip-address": req.session.ipAddress,
+      "feature-set": req.session.featureSet,
+    },
+  };
+}
+function generateJsonAxiosConfig(req) {
+  return {
+    headers: {
+      "Content-Type": "application/json",
+      "ipv-session-id": req.session?.ipvSessionId,
+      "x-request-id": req.id,
+      "ip-address": req.session.ipAddress,
+      "feature-set": req.session.featureSet,
+    },
+  };
 }
 
 module.exports = {
-  CoreBackService,
+  postAction,
+  postSessionInitialise,
+  postCriCallback,
+  getProvenIdentityUserDetails,
 };

--- a/src/services/coreBackService.test.js
+++ b/src/services/coreBackService.test.js
@@ -1,0 +1,124 @@
+const sinon = require("sinon");
+const { expect } = require("chai");
+const proxyquire = require("proxyquire");
+
+const configStub = {
+  API_CRI_CALLBACK: "/cri/callback",
+  API_BASE_URL: "https://example.net",
+  API_BUILD_PROVEN_USER_IDENTITY_DETAILS: "/proven-identity",
+  API_SESSION_INITIALISE: "/session-initialise",
+};
+
+describe("CoreBackService", () => {
+  let axiosInstanceStub = {};
+  let axiosStub = { create: () => axiosInstanceStub };
+  let CoreBackService;
+
+  const req = {
+    session: {
+      clientOauthSessionId: "test_client_session_id",
+      ipvSessionId: "test_ipv_session_id",
+      ipAddress: "127.0.0.1",
+      featureSet: "test_feature_set",
+    },
+    id: "test_request_id",
+  };
+
+  beforeEach(() => {
+    axiosInstanceStub.post = sinon.fake();
+    axiosInstanceStub.get = sinon.fake();
+
+    CoreBackService = proxyquire("./coreBackService", {
+      axios: axiosStub,
+      "../lib/config": configStub,
+    });
+  });
+
+  it("should postAction with correct parameters and headers", async () => {
+    // Arrange
+    const action = "test_action";
+
+    // Act
+    await CoreBackService.postAction(req, action);
+
+    // Assert
+    expect(axiosInstanceStub.post).to.have.been.calledWith(
+      "/test_action",
+      {},
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "ipv-session-id": "test_ipv_session_id",
+          "client-session-id": "test_client_session_id",
+          "x-request-id": "test_request_id",
+          "ip-address": "127.0.0.1",
+          "feature-set": "test_feature_set",
+        },
+      },
+    );
+  });
+
+  it("should postSessionInitialise with correct parameters and headers", async () => {
+    // Arrange
+    const authParams = { someAuthParam: "someValue" };
+
+    // Act
+    await CoreBackService.postSessionInitialise(req, authParams);
+
+    // Assert
+    expect(axiosInstanceStub.post).to.have.been.calledWith(
+      "/session-initialise",
+      { someAuthParam: "someValue" },
+      {
+        headers: {
+          "ip-address": "127.0.0.1",
+          "feature-set": "test_feature_set",
+        },
+      },
+    );
+  });
+
+  it("should postCriCallback with correct parameters and headers", async () => {
+    // Arrange
+    const body = { test_param: "someValue" };
+    const errorDetails = { error_param: "anotherValue" };
+
+    // Act
+    await CoreBackService.postCriCallback(req, body, errorDetails);
+
+    // Assert
+    expect(axiosInstanceStub.post).to.have.been.calledWith(
+      "/cri/callback",
+      { test_param: "someValue", error_param: "anotherValue" },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "ipv-session-id": "test_ipv_session_id",
+          "x-request-id": "test_request_id",
+          "ip-address": "127.0.0.1",
+          "feature-set": "test_feature_set",
+        },
+      },
+    );
+  });
+
+  it("should getProvenIdentityUserDetails to retrieve user identity details", async () => {
+    // Arrange
+    const body = { test_param: "someValue" };
+    const errorDetails = { error_param: "anotherValue" };
+
+    // Act
+    await CoreBackService.getProvenIdentityUserDetails(req, body, errorDetails);
+
+    // Assert
+    expect(axiosInstanceStub.get).to.have.been.calledWith("/proven-identity", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "ipv-session-id": "test_ipv_session_id",
+        "x-request-id": "test_request_id",
+        "ip-address": "127.0.0.1",
+        "feature-set": "test_feature_set",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

- Use HTTP keep alive connections

### Why did it change

- I/O performance optimisation

### Issue tracking

- [PYIC-4125](https://govukverify.atlassian.net/browse/PYIC-4125)


[PYIC-4125]: https://govukverify.atlassian.net/browse/PYIC-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ