### PR TITLE
IPS-492: Update secure-post-merge.yml workflow

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -49,58 +49,12 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: Create tag
-        id: create-tag
-        run: |
-          IMAGE_TAG="${{ github.sha }}-secure-pipeline-$(date +'%Y-%m-%d-%H%M%S')"
-          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+      - name: Deploy SAM app to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.0
         with:
-          cosign-release: 'v1.9.0'
-
-      - name: Build, tag, sign and push image to Amazon ECR
-        env:
-          CONTAINER_SIGN_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
-        run: |
-          cd ${GITHUB_WORKSPACE} || exit 1
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          cosign sign --key awskms:///${CONTAINER_SIGN_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-
-      - name: SAM Validate
-        working-directory: ./deploy
-        run: sam validate --region ${{ env.AWS_REGION }}
-
-      - name: SAM Package
-        working-directory: ./deploy
-        env:
-          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
-
-      - name: Update SAM template with ECR image
-        working-directory: ./deploy
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
-        run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
-
-      - name: Compress Template
-        working-directory: ./deploy
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload Compressed CloudFormation artifacts to S3
-        working-directory: ./deploy
-        env:
-          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-        run: aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          working-directory: ./deploy
+          template-file: template.yaml
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}


### PR DESCRIPTION
Updated post-merge github workflow to use [GitHub - govuk-one-login/devplatform-upload-action-ecr: Upload action for Fargate containers](https://github.com/govuk-one-login/devplatform-upload-action-ecr) version v1.2.0

## Proposed changes

See above

### What changed

ECR/SAM/Template upload stages steps replaced by including the govuk-one-login/devplatform-upload-action-ecr

### Why did it change

This is required for canary deployments

### Issue tracking
- [IPS-492](https://govukverify.atlassian.net/browse/IPS-492)
- 
## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-492]: https://govukverify.atlassian.net/browse/IPS-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ