### PR TITLE
PYIC-3974: remove inset text from multiple-doc-check page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -417,7 +417,6 @@
         "bullet1": "gennych drwydded yrru y DU (llawn neu dros dro) neu basbort y DU",
         "bullet2": "rydych yn gallu ateb rhai cwestiynau diogelwch",
         "paragraph2": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
-        "insetText": "Nid yw’r opsiwn hwn ar gael yn Gymraeg eto. Dewiswch un o’r opsiynau ar-lein os ydych am barhau yn Gymraeg.",
         "subHeading": "Sut ydych chi am barhau?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Rhowch fanylion eich trwydded yrru cerdyn-llun y DU ac atebwch y cwestiynau diogelwch ar-lein",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -417,7 +417,6 @@
         "bullet1": "have a UK driving licence (full or provisional) or a UK passport",
         "bullet2": "can answer some security questions",
         "paragraph2": "We use security questions to stop anyone who might have your details from pretending to be you.",
-        "insetText": "This option is not available in Welsh yet. Choose one of the online options if you want to continue in Welsh.",
         "subHeading": "How do you want to continue?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",

--- a/src/views/ipv/page-multiple-doc-check.njk
+++ b/src/views/ipv/page-multiple-doc-check.njk
@@ -1,7 +1,6 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.pageMultipleDocCheck.title' | translate %}
 {% set googleTagManagerPageId = "pageMultipleDocCheck" %}
 
@@ -18,14 +17,6 @@
     <li>{{ 'pages.pageMultipleDocCheck.content.bullet2' | translate | safe }}</li>
   </ul>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
-
-  {% if context == "f2f" %}
-    {% if isWelsh %}
-      {{ govukInsetText({
-        text: 'pages.pageMultipleDockCheck.content.insetText' | translate
-      }) }}
-    {% endif %}
-  {% endif %}
 
   <form id="multipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

remove inset text from multiple-doc-check page

### Why did it change

No longer required as there are now Welsh translations across the F2F journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3974](https://govukverify.atlassian.net/browse/PYIC-3974)


[PYIC-3974]: https://govukverify.atlassian.net/browse/PYIC-3974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ