### PR TITLE
BAU: Fix unnecessary context being logged 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -133,7 +133,6 @@ app.use((req, res, next) => {
     requestId: req.id,
     ipvSessionId: req.session?.ipvSessionId,
     sessionId: req.session?.id,
-    context: req.session?.context || "",
   });
   next();
 });
@@ -158,7 +157,6 @@ router.use((req, res, next) => {
     requestId: req.id,
     ipvSessionId: req.session?.ipvSessionId,
     sessionId: req.session?.id,
-    context: req.session?.context || "",
   });
   next();
 });

--- a/src/app/shared/loggerHelper.js
+++ b/src/app/shared/loggerHelper.js
@@ -25,16 +25,18 @@ module.exports = {
   },
   logCoreBackCall: (
     req,
-    { logCommunicationType, type, path, info, context = "" },
+    { logCommunicationType, type, path, info, context },
   ) => {
     const message = {
       logCommunicationType,
       path,
       info,
-      context,
     };
     if (type) {
       message.type = type;
+    }
+    if (context !== "") {
+      message.context = context;
     }
     req.log.info({ message, level: "INFO", requestId: req.id });
   },

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,5 +1,7 @@
 const pino = require("pino");
 const { randomUUID } = require("node:crypto");
+const pinoHttp = require("pino-http");
+
 const logger = pino({
   name: "di-ipv-core-front",
   level: process.env.LOGS_LEVEL || "debug",
@@ -25,10 +27,9 @@ const logger = pino({
   },
 });
 
-const loggerMiddleware = require("pino-http")({
+const loggerMiddleware = pinoHttp({
   // Reuse an existing logger instance
   logger,
-
   // Define a custom request id function, this will be assigned to req.id
   genReqId: function (req, res) {
     if (req.id) return req.id;
@@ -38,7 +39,6 @@ const loggerMiddleware = require("pino-http")({
     res.header("x-request-id", id);
     return id;
   },
-
   // Set to `false` to prevent standard serializers from being wrapped.
   wrapSerializers: false,
   autoLogging: {
@@ -49,12 +49,22 @@ const loggerMiddleware = require("pino-http")({
     return "REQUEST RECEIVED: " + req.method;
   },
   customReceivedObject: function (req, res, val) {
-    return {
-      ...val,
+    const commonParams = {
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
       sessionId: req.session?.id,
-      context: req.session?.context || "",
+    };
+
+    if (req.method === "GET") {
+      return {
+        ...val,
+        ...commonParams,
+        context: req.session?.context,
+      };
+    }
+    return {
+      ...val,
+      ...commonParams,
     };
   },
   customErrorMessage: function (req, res) {
@@ -67,7 +77,7 @@ const loggerMiddleware = require("pino-http")({
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
       sessionId: req.session?.id,
-      context: req.session?.context || "",
+      context: req.session?.context,
     };
   },
   customSuccessMessage: function (req, res) {
@@ -77,12 +87,27 @@ const loggerMiddleware = require("pino-http")({
     return `REQUEST COMPLETED WITH STATUS CODE OF: ${res.statusCode}`;
   },
   customSuccessObject: function (req, res, val) {
-    return {
-      ...val,
+    const commonParams = {
       requestId: req.id,
       ipvSessionId: req.session?.ipvSessionId,
       sessionId: req.session?.id,
-      context: req.session?.context || "",
+    };
+    if (req.method === "GET") {
+      const successObject = {
+        ...val,
+        ...commonParams,
+      };
+
+      if (res.statusCode !== 302) {
+        successObject.context = req.session?.context;
+      }
+
+      return successObject;
+    }
+
+    return {
+      ...val,
+      ...commonParams,
     };
   },
   customAttributeKeys: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`context` should only be logged in the original request to load the page which requires it

BEFORE:
<img width="400" alt="Screenshot 2024-01-31 at 12 23 07" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/de319d23-1983-4729-9b09-d7c352bc81f0">


AFTER:
<img width="400" alt="Screenshot 2024-01-31 at 12 16 43" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/c6a3d0f8-d066-41ad-af4d-83a339ff7983">


### Why did it change

Context is showing in logs as empty string which can cause confusion and is not necessary
It is also being logged in other requests such as redirects 
