### PR TITLE
PLAT-3445 - amended 400 alarms threshold to 20

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -68,7 +68,7 @@ Conditions:
 Mappings:
   EnvironmentConfiguration:
     "130355686670": # core-dev01
-      lb400ErrorLimit: 10
+      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -85,7 +85,7 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "175872367215": # core-dev02
-      lb400ErrorLimit: 10
+      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -102,7 +102,7 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "457601271792": # Build
-      lb400ErrorLimit: 10
+      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -123,7 +123,7 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "335257547869": # Staging
-      lb400ErrorLimit: 10
+      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -140,7 +140,7 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "991138514218": # Integration
-      lb400ErrorLimit: 10
+      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10


### PR DESCRIPTION
## Proposed changes
### What changed

- Canary 4xx error alarm threshold increased to 20 in non-prod environments

### Why did it change

- Issues with unexpected traffic in lower envs causing deployment rollback

### Issue tracking
[PLAT-3445](https://govukverify.atlassian.net/browse/PLAT-3445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
[DCP-2828](https://govukverify.atlassian.net/browse/DCP-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)


[PLAT-3445]: https://govukverify.atlassian.net/browse/PLAT-3445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCP-2828]: https://govukverify.atlassian.net/browse/DCP-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ