### PR TITLE
PYIC-3966: Reinstate cut down version of updateJourneyState

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -174,6 +174,26 @@ module.exports = {
       csrfToken: req.csrfToken(),
     });
   },
+  // This method is currently only used by a link on the pyi-f2f-delete-details page.
+  // It shouldn't be used for anything else, see
+  // https://govukverify.atlassian.net/browse/PYIC-4859.
+  updateJourneyState: async (req, res, next) => {
+    try {
+      const allowedActions = [
+        "/journey/end",
+      ];
+
+      const action = allowedActions.find((x) => x === req.url);
+
+      if (action) {
+        await handleJourneyResponse(req, res, action);
+      } else {
+        next(new Error(`Action ${req.url} not valid`));
+      }
+    } catch (error) {
+      next(error);
+    }
+  },
   handleJourneyPage: async (req, res, next) => {
     try {
       const { pageId } = req.params;

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -179,9 +179,7 @@ module.exports = {
   // https://govukverify.atlassian.net/browse/PYIC-4859.
   updateJourneyState: async (req, res, next) => {
     try {
-      const allowedActions = [
-        "/journey/end",
-      ];
+      const allowedActions = ["/journey/end"];
 
       const action = allowedActions.find((x) => x === req.url);
 

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 const {
   renderAttemptRecoveryPage,
+  updateJourneyState,
   handleJourneyPage,
   handleJourneyAction,
   handleMultipleDocCheck,
@@ -130,5 +131,5 @@ router.post(
   handleJourneyAction,
 );
 router.post("/page/:pageId", parseForm, csrfProtection, handleJourneyAction);
-
+router.get("/*", updateJourneyState);
 module.exports = router;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Put back a minimal version of updateJourneyState

### Why did it change

It is used in one place in core-front

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3966](https://govukverify.atlassian.net/browse/PYIC-3966)


[PYIC-3966]: https://govukverify.atlassian.net/browse/PYIC-3966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ