### PR TITLE
IPS-618 update workflow actions

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: npm build assets, zip and sign
-        uses: alphagov/di-github-actions/upload-assets@main
+        uses: govuk-one-login/github-actions/govuk/upload-assets@main
         with:
           zip-signing-key-arn: ${{ secrets.UPLOAD_ASSETS_ZIP_SIGNING_KEY }}
           stack-name: 'core-front'
@@ -40,7 +40,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Proposed changes

### What changed

Update workflow versions and use one-login upload-assets action

### Why did it change

The workflow was using the obsolete alphagov upload-assets action and had other deprecated action versions

### Issue tracking

- [IPS-618](https://govukverify.atlassian.net/browse/IPS-618)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-618]: https://govukverify.atlassian.net/browse/IPS-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ