### PR TITLE
IPS-618 lock upload-assets to sha

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: npm build assets, zip and sign
-        uses: govuk-one-login/github-actions/govuk/upload-assets@main
+        uses: govuk-one-login/github-actions/govuk/upload-assets@f31d8d78a76b89c62c80e2587c687af9fee4e478
         with:
           zip-signing-key-arn: ${{ secrets.UPLOAD_ASSETS_ZIP_SIGNING_KEY }}
           stack-name: 'core-front'


### PR DESCRIPTION
## Proposed changes

### What changed
Lock upload-assets action to sha before changes

### Why did it change

The upload assets action has been broken, locking to sha before changes

### Issue tracking

- [IPS-618](https://govukverify.atlassian.net/browse/IPS-618)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-618]: https://govukverify.atlassian.net/browse/IPS-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ