### PR TITLE
IPS-478: GHA fixes

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -32,7 +32,7 @@ jobs:
       - name: npm build assets, zip and sign
         uses: govuk-one-login/github-actions/govuk/upload-assets@main
         with:
-          zip-signing-key-arn: ${{ secrets.UPLOAD_ASSETS_ZIP_SIGNING_KEY }}
+          signing-key-arn: ${{ secrets.UPLOAD_ASSETS_ZIP_SIGNING_KEY }}
           stack-name: 'core-front'
           destination-bucket-name: ${{ secrets.UPLOAD_ASSETS_ARTIFACT_SOURCE_BUCKET_NAME }}
 
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: Deploy SAM app to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.1
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
### What changed

1. Renamed zip-signing-key-arn to signing-key-arn
2. Patch upgrade to devplatform upload ecr action

### Why did it change

1. To fix "Unexpected Input" warning - the github action itself was refactored in https://github.com/govuk-one-login/github-actions/pull/16, and the input was renamed
2. To upgrade outdated versions (v1.2.0 vs v1.2.1: [devplatform-upload-action-ecr](https://github.com/govuk-one-login/devplatform-upload-action-ecr))

<img width="1382" alt="Screenshot 2024-02-28 at 10 45 56" src="https://github.com/govuk-one-login/ipv-core-front/assets/153090281/fc506917-76e6-4bd4-ae30-0c2b485c7044">


### Issue tracking

- [IPS-478](https://govukverify.atlassian.net/browse/IPS-478)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-478]: https://govukverify.atlassian.net/browse/IPS-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ