### PR TITLE
PYIC-4492: Make page dynamic for the NINO CRI "exit" page and Welsh translations

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -109,6 +109,7 @@
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph1BankAccount": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda’ch banc neu gymdeithas adeiladu",
+        "paragraph1Nino": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda CThEF.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
         "subHeading": "Beth allwch chi ei wneud",
         "paragraph3": "Parhewch i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o brofi eich hunaniaeth."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -109,6 +109,7 @@
       "content": {
         "paragraph1": "We could not find a match when we checked your details with another organisation.",
         "paragraph1BankAccount": "We could not find a match when we checked your details with your bank or building society.",
+        "paragraph1Nino": "We could not find a match for your National Insurance number when we checked your details with HMRC.",
         "paragraph2": "To keep your information safe, we cannot tell you which of your details we were unable to match.",
         "subHeading": "What you can do",
         "paragraph3": "Continue to the service you were trying to use to find out if there are other ways to prove your identity"

--- a/src/views/ipv/pyi-no-match.njk
+++ b/src/views/ipv/pyi-no-match.njk
@@ -6,7 +6,9 @@
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiNoMatch.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph1' | translateWithContext(context) }}</p>
-  <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph2' | translate }}</p>
+  {% if context !== "nino" %}
+    <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph2' | translate }}</p>
+  {% endif %}
   <h2 class="govuk-heading-m">{{ 'pages.pyiNoMatch.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph3' | translate }}</p>
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add dynamic content for the NINO CRI exit page to the pyi-no-match

pyi-no-match : Context = "nino"
<img width="500" alt="Screenshot 2024-02-29 at 11 17 41" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/7a9b81fd-439c-4c2e-8242-6382306061ef">

pyi-no-match : Context = "bankAccount"
<img width="500" alt="Screenshot 2024-02-29 at 11 17 47" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/65a269b1-5687-42f4-851e-caec0ac26a9a">

pyi-no-match : standard
<img width="500" alt="Screenshot 2024-02-29 at 11 17 52" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/469b9114-19e7-4daa-9328-c03e65192491">


### Why did it change

When a user enters the NINO CRI stage of the M2B journey and fails for a 2nd time to enter a verifiable national insurance number, then they are routed to an exit page “Sorry we cannot confirm your identity”.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4492](https://govukverify.atlassian.net/browse/PYIC-4492)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-4492]: https://govukverify.atlassian.net/browse/PYIC-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ