### PR TITLE
BAU: Fixed page title translation not found

### DIFF
--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -34,6 +34,19 @@ module.exports = {
       },
     );
 
+    nunjucksEnv.addFilter(
+      "translateWithContextOrFallback",
+      function (key, context, options) {
+        const translate = i18next.getFixedT(this.ctx.i18n.language);
+
+        const pascalContext = kebabCaseToPascalCase(context);
+
+        const fullKey = key + pascalContext;
+
+        return translate([fullKey, key], options);
+      },
+    );
+
     // allow pushing or adding another attribute to an Object
     nunjucksEnv.addFilter("setAttribute", function (dictionary, key, value) {
       dictionary[key] = value;

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -31,7 +31,7 @@
       {{ 'general.govuk.errorTitlePrefix' | translate }}
       – GOV.UK
     {%- endif %}
-    {%- if pageTitleKey %}{{ pageTitleKey | translateWithContext(context) }} – GOV.UK{% endif %}
+    {%- if pageTitleKey %}{{ pageTitleKey | translateWithContextOrFallback(context) }} – GOV.UK{% endif %}
 {%- endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed page title translation not found

### Why did it change

We had to change the way we generate the page title to allow for us to always be sending the English page name to GA4, regardless of the page title language the user is seeing.

We have to allow the page title to be changeable by adding context (for certain dynamic pages), but this means that every dynamic page would try to fetch the title using the context-key, even if it hadn't been set in the translation file.

The fix here is to add a new filter, allowing us to translate the title with a fallback, where if the context key doesn't exist, it just searches for the title without the context field.

There's an argument that we could be doing this everywhere, but runs the risk of the dynamic pages failing silently, and displaying the wrong context to users. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed
