### PR TITLE
PYIC-5343: Override status code if provided

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,9 +164,9 @@
         "filename": "src/app/ipv/middleware.test.js",
         "hashed_secret": "ec420572bb867a4f38076e71a4ac3b712326e496",
         "is_verified": false,
-        "line_number": 196
+        "line_number": 235
       }
     ]
   },
-  "generated_at": "2024-02-29T11:53:07Z"
+  "generated_at": "2024-03-12T16:36:23Z"
 }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -105,6 +105,7 @@ async function handleBackendResponse(req, res, backendResponse) {
 
     req.session.currentPage = backendResponse.page;
     req.session.context = backendResponse?.context;
+    req.session.currentPageStatusCode = backendResponse?.statusCode;
 
     return await saveSessionAndRedirect(
       req,
@@ -274,6 +275,10 @@ module.exports = {
             renderOptions.pageErrorState = req.query.errorState;
           }
 
+          if (req.session.currentPageStatusCode !== undefined) {
+            res.status(req.session.currentPageStatusCode);
+          }
+
           return res.render(`ipv/${sanitize(pageId)}.njk`, renderOptions);
         }
         case "page-ipv-reuse": {
@@ -297,6 +302,8 @@ module.exports = {
     } catch (error) {
       transformError(error, `error handling journey page: ${req.params}`);
       next(error);
+    } finally {
+      delete req.session.currentPageStatusCode;
     }
   },
   handleJourneyAction: async (req, res, next) => {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Override status code if provided

### Why did it change
In the case of an error page, core-back can provide a status code in the body of the response. Core-front should respect that status code.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5343](https://govukverify.atlassian.net/browse/PYIC-5343)


[PYIC-5343]: https://govukverify.atlassian.net/browse/PYIC-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ