### PR TITLE
PYIC-5249: Added new confirm current address screen

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -171,7 +171,11 @@ async function handleEscapeAction(req, res, next, actionType) {
 }
 
 function pageRequiresUserDetails(pageId) {
-  return ["page-ipv-reuse", "pyi-confirm-name-dob"].includes(pageId);
+  return [
+    "page-ipv-reuse",
+    "pyi-confirm-name-dob",
+    "pyi-confirm-address",
+  ].includes(pageId);
 }
 
 function isValidPage(pageId) {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -512,6 +512,24 @@
         }
       }
     },
+    "pyiConfirmAddress": {
+      "title": "TEMP You need to confirm your address",
+      "header": "TEMP You need to confirm your address",
+      "content": {
+        "paragraph1": "TEMP To keep your account secure, you need to confirm the address you gave us when you proved your identity.",
+        "summaryListHeading1": "TEMP Current home address",
+        "radioButtonHeading": "TEMP Is this your current address?",
+        "formRadioButtons": {
+          "yes": "TEMP Yes",
+          "no": "TEMP No - I need to update it"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "TEMP There is a problem",
+          "errorSummaryDescriptionText": "TEMP Select what you would like to do",
+          "errorRadioMessage": "TEMP Select what you would like to do"
+        }
+      }
+    },
     "pyiConfirmNameDob": {
       "title": "TEMP You need to confirm your name and date of birth",
       "header": "TEMP You need to confirm your name and date of birth",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -493,6 +493,24 @@
         }
       }
     },
+    "pyiConfirmAddress": {
+      "title": "You need to confirm your address",
+      "header": "You need to confirm your address",
+      "content": {
+        "paragraph1": "To keep your account secure, you need to confirm the address you gave us when you proved your identity.",
+        "summaryListHeading1": "Current home address",
+        "radioButtonHeading": "Is this your current address?",
+        "formRadioButtons": {
+          "yes": "Yes",
+          "no": "No - I need to update it"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "TEMP There is a problem",
+          "errorSummaryDescriptionText": "TEMP Select what you would like to do",
+          "errorRadioMessage": "TEMP Select what you would like to do"
+        }
+      }
+    },
     "pyiConfirmNameDob": {
       "title": "You need to confirm your name and date of birth",
       "header": "You need to confirm your name and date of birth",

--- a/src/views/ipv/page/pyi-confirm-address.njk
+++ b/src/views/ipv/page/pyi-confirm-address.njk
@@ -5,7 +5,6 @@
 
 {% set pageTitleKey = 'pages.pyiConfirmAddress.title' %}
 {% set googleTagManagerPageId = "pyiConfirmAddress" %}
-{% set isPageDynamic = false %}
 
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.pyiConfirmAddress.content.formErrorMessage.errorSummaryTitleText' | translate %}

--- a/src/views/ipv/page/pyi-confirm-address.njk
+++ b/src/views/ipv/page/pyi-confirm-address.njk
@@ -1,0 +1,71 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% set pageTitleKey = 'pages.pyiConfirmAddress.title' %}
+{% set googleTagManagerPageId = "pyiConfirmAddress" %}
+{% set isPageDynamic = false %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiConfirmAddress.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiConfirmNameDob.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiConfirmAddressActionForm" %}
+
+{% block content %}
+    <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
+        xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiConfirmAddress.header' | translate }}</h1>
+
+    <p class="govuk-body">{{'pages.pyiConfirmAddress.content.paragraph1' | translate }}</p>
+
+    {% set rows = [
+        {
+            key: {
+                text: 'pages.pyiConfirmAddress.content.summaryListHeading1' | translate
+            },
+            value: {
+                text: userDetails.addresses[0].addressDetailHtml | safe
+            }
+        }
+    ] %}
+
+    {{ govukSummaryList({
+        rows: rows
+    }) }}
+
+
+    <form id="pyiConfirmAddressActionForm" action="/ipv/page/{{ pageId }}" method="POST">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        {% set radiosConfig = {
+            idPrefix: "journey",
+            name: "journey",
+            fieldset: {
+                legend: {
+                    text: 'pages.pyiConfirmAddress.content.radioButtonHeading' | translate,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: [
+                    {
+                    value: "next",
+                    text: 'pages.pyiConfirmAddress.content.formRadioButtons.yes' | translate
+                    },
+                    {
+                    value: "end",
+                    text: 'pages.pyiConfirmAddress.content.formRadioButtons.no' | translateWithContext(context)
+                    }
+                ]
+        }
+        %}
+
+        {% if errorState %}
+        {% set errorMessageObject = { 'text': 'pages.pyiConfirmAddress.content.formErrorMessage.errorRadioMessage' | translate } %}
+        {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+        {% endif %}
+
+        {{ govukRadios(radiosConfig) }}
+        <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+        {{ 'general.buttons.next' | translate }}
+        </button>
+    </form>
+{% endblock %}

--- a/src/views/ipv/page/pyi-confirm-address.njk
+++ b/src/views/ipv/page/pyi-confirm-address.njk
@@ -51,7 +51,7 @@
                     },
                     {
                     value: "end",
-                    text: 'pages.pyiConfirmAddress.content.formRadioButtons.no' | translateWithContext(context)
+                    text: 'pages.pyiConfirmAddress.content.formRadioButtons.no' | translate
                     }
                 ]
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC-5249](https://govukverify.atlassian.net/browse/PYIC-5249) - "You need to confirm your address" screen

- Adds new confirm current address screen
- Adds temporary contents for screen

<!-- Describe the changes in detail - the "what"-->

### Why did it change

This screen ensures that the address information IPV Core has on file is current and accurate, aligning with the One Login policy and the broader goals of maintaining up-to-date user data for identity proofing. It addresses the operational need to validate user address information as part of the identity fraud scoring process and is critical for supporting future journey adaptations, such as the M1C profile and the identity uplift process, where address data might not have been previously collected.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5249](https://govukverify.atlassian.net/browse/PYIC-5249)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

![Screenshot 2024-03-16 at 15 13 37](https://github.com/govuk-one-login/ipv-core-front/assets/11758541/40b23ecd-cc43-4a0b-94f5-564082efcb14)



[PYIC-5249]: https://govukverify.atlassian.net/browse/PYIC-5249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-5249]: https://govukverify.atlassian.net/browse/PYIC-5249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ