### PR TITLE
PYIC-4811: Add smartphone triage page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -314,6 +314,44 @@
         }
       }
     },
+    "pyiTriageSelectSmartphone": {
+      "title": "Prove your identity with the GOV.UK One Login app and an iPhone or Android phone",
+      "header": "Prove your identity with the GOV.UK One Login app and an iPhone or Android phone",
+      "content": {
+        "paragraphIntro1": "The GOV.UK One Login app works by matching your face to your photo ID. You'll be shown how to download and use the app.",
+        "paragraphIntro2": "You can prove your identity this way if you have an iPhone or Android phone with a working camera.",
+        "iphone": {
+          "subHeading": "iPhone",
+          "paragraph": "You can use an iPhone if it:",
+          "condition1": "is an iPhone 7 or newer - or an iPhone 6s or newer if your photo ID is a driving licence",
+          "condition2": "is running iOS13 or higher",
+          "infoLabel": "How do I know which iPhone I have?",
+          "infoHtml": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur non quam eget viverra. Duis enim velit, dignissim a feugiat id, ultricies a tortor."
+        },
+        "android": {
+          "subHeading": "Android phone (for example, Samsung or Google Pixel)",
+          "paragraph": "You can use an Android phone if it:",
+          "condition1": "is running Android version 10 or higher",
+          "condition2": "has Near Field Communication (NFC) - your phone has NFC if you can use it to make contactless payments",
+          "infoLabel": "How do I know which Android I have?",
+          "infoHtml": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur non quam eget viverra. Duis enim velit, dignissim a feugiat id, ultricies a tortor."
+        },
+        "subHeadingSelectSmartphone": "Do you have one of these smartphones?",
+        "formRadioButtons": {
+          "iphoneButtonText": "Yes, I have an iPhone",
+          "androidButtonText": "Yes, I have an Android phone",
+          "neitherButtonText": "No"
+        },
+        "subHeadingAppendix": "If you're not sure you'll be able to prove your identity with the app",
+        "paragraphAppendix1": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
+        "paragraphAppendix2": "You can also prove your identity in person at a Post Office."
+      },
+      "formErrorMessage": {
+        "errorSummaryTitleText": "There is a problem",
+        "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
+        "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+      }
+    },
     "pyiContinueWithPassport": {
       "title": "Parhau profi eich hunaniaeth ar-lein",
       "header": "Parhau profi eich hunaniaeth ar-lein",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -346,6 +346,44 @@
         "paragraph2": "Continue to the service you were trying to use and look for other ways to prove your identity."
       }
     },
+    "pyiTriageSelectSmartphone": {
+      "title": "Prove your identity with the GOV.UK One Login app and an iPhone or Android phone",
+      "header": "Prove your identity with the GOV.UK One Login app and an iPhone or Android phone",
+      "content": {
+        "paragraphIntro1": "The GOV.UK One Login app works by matching your face to your photo ID. You'll be shown how to download and use the app.",
+        "paragraphIntro2": "You can prove your identity this way if you have an iPhone or Android phone with a working camera.",
+        "iphone": {
+          "subHeading": "iPhone",
+          "paragraph": "You can use an iPhone if it:",
+          "condition1": "is an iPhone 7 or newer - or an iPhone 6s or newer if your photo ID is a driving licence",
+          "condition2": "is running iOS13 or higher",
+          "infoLabel": "How do I know which iPhone I have?",
+          "infoHtml": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur non quam eget viverra. Duis enim velit, dignissim a feugiat id, ultricies a tortor."
+        },
+        "android": {
+          "subHeading": "Android phone (for example, Samsung or Google Pixel)",
+          "paragraph": "You can use an Android phone if it:",
+          "condition1": "is running Android version 10 or higher",
+          "condition2": "has Near Field Communication (NFC) - your phone has NFC if you can use it to make contactless payments",
+          "infoLabel": "How do I know which Android I have?",
+          "infoHtml": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur non quam eget viverra. Duis enim velit, dignissim a feugiat id, ultricies a tortor."
+        },
+        "subHeadingSelectSmartphone": "Do you have one of these smartphones?",
+        "formRadioButtons": {
+          "iphoneButtonText": "Yes, I have an iPhone",
+          "androidButtonText": "Yes, I have an Android phone",
+          "neitherButtonText": "No"
+        },
+        "subHeadingAppendix": "If you're not sure you'll be able to prove your identity with the app",
+        "paragraphAppendix1": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
+        "paragraphAppendix2": "You can also prove your identity in person at a Post Office."
+      },
+      "formErrorMessage": {
+        "errorSummaryTitleText": "There is a problem",
+        "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
+        "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+      }
+    },
     "pyiTimeoutRecoverable": {
       "title": "You have been signed out of your GOV.UK One Login",
       "header": "You have been signed out of your GOV.UK One Login",

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -79,7 +79,8 @@
 
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({
-      "text": button_text|default('general.buttons.next' | translate, true)
+      id: submitButton,
+      text: 'general.buttons.next' | translate
     }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -80,6 +80,7 @@
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({
       id: submitButton,
+      classes: "govuk-!-margin-top-7",
       text: 'general.buttons.next' | translate
     }) }}
   </form>

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -76,8 +76,8 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      "text": button_text|default('general.shared.govUKHomepageButtonText' | translate, true)
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -1,0 +1,83 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% set pageTitleKey = 'pages.pyiTriageSelectSmartphone.title' %}
+
+{% set googleTagManagerPageId = "pyiTriageSelectSmartphone" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiTriageSelectSmartphone.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiTriageSelectSmartphone.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiTriageSelectSmartphoneOptionsForm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiTriageSelectSmartphone.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphIntro1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphIntro2' | translate }}</p>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.subHeading' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.paragraph' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet ">
+    <li>{{ 'pages.pyiTriageSelectSmartphone.content.iphone.condition1' | translate }}</li>
+    <li>{{ 'pages.pyiTriageSelectSmartphone.content.iphone.condition2' | translate }}</li>
+  </ul>
+  {{ govukDetails({
+      summaryText: 'pages.pyiTriageSelectSmartphone.content.iphone.infoLabel' | translate,
+      text: 'pages.pyiTriageSelectSmartphone.content.iphone.infoHtml' | translate( { url: contactUsUrl } ) | safe
+  }) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.android.subHeading' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pyiTriageSelectSmartphone.content.android.paragraph' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet ">
+    <li>{{ 'pages.pyiTriageSelectSmartphone.content.android.condition1' | translate }}</li>
+    <li>{{ 'pages.pyiTriageSelectSmartphone.content.android.condition2' | translate }}</li>
+  </ul>
+  {{ govukDetails({
+    summaryText: 'pages.pyiTriageSelectSmartphone.content.android.infoLabel' | translate,
+    text: 'pages.pyiTriageSelectSmartphone.content.android.infoHtml' | translate( { url: contactUsUrl } ) | safe
+  }) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.subHeadingAppendix' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix2' | translate }}</p>
+
+  <form id="pyiTriageSelectSmartphoneOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiTriageSelectSmartphone.content.subHeadingSelectSmartphone' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "iphone",
+          text: 'pages.pyiTriageSelectSmartphone.content.formRadioButtons.iphoneButtonText' | translate
+        },
+        {
+          value: "android",
+          text: 'pages.pyiTriageSelectSmartphone.content.formRadioButtons.androidButtonText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.pyiTriageSelectSmartphone.content.formRadioButtons.neitherButtonText' | translate
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiTriageSelectSmartphone.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+{% endblock %}

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -77,7 +77,7 @@
 
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({
-      "text": button_text|default('general.shared.govUKHomepageButtonText' | translate, true)
+      "text": button_text|default('general.buttons.next' | translate, true)
     }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -80,7 +80,6 @@
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({
       id: submitButton,
-      classes: "govuk-!-margin-top-7",
       text: 'general.buttons.next' | translate
     }) }}
   </form>

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -17,8 +17,8 @@
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphIntro1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphIntro2' | translate }}</p>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.subHeading' | translate }}</h2>
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.paragraph' | translate }}</p>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.iphone.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet ">
     <li>{{ 'pages.pyiTriageSelectSmartphone.content.iphone.condition1' | translate }}</li>
     <li>{{ 'pages.pyiTriageSelectSmartphone.content.iphone.condition2' | translate }}</li>
@@ -28,8 +28,8 @@
       text: 'pages.pyiTriageSelectSmartphone.content.iphone.infoHtml' | translate( { url: contactUsUrl } ) | safe
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.android.subHeading' | translate }}</h2>
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pyiTriageSelectSmartphone.content.android.paragraph' | translate }}</p>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageSelectSmartphone.content.android.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.android.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet ">
     <li>{{ 'pages.pyiTriageSelectSmartphone.content.android.condition1' | translate }}</li>
     <li>{{ 'pages.pyiTriageSelectSmartphone.content.android.condition2' | translate }}</li>
@@ -39,7 +39,7 @@
     text: 'pages.pyiTriageSelectSmartphone.content.android.infoHtml' | translate( { url: contactUsUrl } ) | safe
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pyiTriageSelectSmartphone.content.subHeadingAppendix' | translate }}</h2>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageSelectSmartphone.content.subHeadingAppendix' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix2' | translate }}</p>
 

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -43,6 +43,8 @@
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pyiTriageSelectSmartphone.content.paragraphAppendix2' | translate }}</p>
 
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
   <form id="pyiTriageSelectSmartphoneOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% set radiosConfig = {
@@ -74,8 +76,6 @@
       {% set errorMessageObject = { 'text': 'pages.pyiTriageSelectSmartphone.content.formErrorMessage.errorRadioMessage' | translate } %}
       {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
     {% endif %}
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({

--- a/src/views/ipv/page/pyi-triage-select-smartphone.njk
+++ b/src/views/ipv/page/pyi-triage-select-smartphone.njk
@@ -75,6 +75,8 @@
       {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
     {% endif %}
 
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
     {{ govukRadios(radiosConfig) }}
     {{ govukButton({
       "text": button_text|default('general.buttons.next' | translate, true)


### PR DESCRIPTION
## Proposed changes

### What changed

- Add smartphone triage page

### Why did it change

- Migrating pages from mobile

### Issue tracking

- [PYIC-4811](https://govukverify.atlassian.net/browse/PYIC-4811)

<img width="588" alt="Screenshot 2024-03-20 at 10 17 30" src="https://github.com/govuk-one-login/ipv-core-front/assets/144116535/96b6ba03-7541-4b53-881e-61c311682ecd">


[PYIC-4811]: https://govukverify.atlassian.net/browse/PYIC-4811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ