### PR TITLE
PYIC-5462: Made pyi-no-match dynamic to support 6MFC

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -105,11 +105,13 @@
     },
     "pyiNoMatch": {
       "title": "Mae’n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth",
+      "titleSixMonthFraudCheck": "TEMP Sorry, we cannot confirm your identity",
       "header": "Mae’n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth",
+      "headerSixMonthFraudCheck": "TEMP Sorry, we could not confirm your details",
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
-        "paragraph1BankAccount": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda’ch banc neu gymdeithas adeiladu",
         "paragraph1Nino": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda CThEF.",
+        "paragraph1BankAccount": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda’ch banc neu gymdeithas adeiladu",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
         "subHeading": "Beth allwch chi ei wneud",
         "paragraph3": "Parhewch i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o brofi eich hunaniaeth."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -104,12 +104,14 @@
       }
     },
     "pyiNoMatch": {
-      "title": "Sorry, we cannot confirm your identity",
+      "title": "Sorry, we could not confirm your details",
+      "titleSixMonthFraudCheck": "Sorry, we cannot confirm your identity",
       "header": "Sorry, we cannot confirm your identity",
+      "headerSixMonthFraudCheck": "Sorry, we could not confirm your details",
       "content": {
         "paragraph1": "We could not find a match when we checked your details with another organisation.",
-        "paragraph1BankAccount": "We could not find a match when we checked your details with your bank or building society.",
         "paragraph1Nino": "We could not find a match for your National Insurance number when we checked your details with HMRC.",
+        "paragraph1BankAccount": "We could not find a match when we checked your details with your bank or building society.",
         "paragraph2": "To keep your information safe, we cannot tell you which of your details we were unable to match.",
         "subHeading": "What you can do",
         "paragraph3": "Continue to the service you were trying to use to find out if there are other ways to prove your identity"

--- a/src/views/ipv/page/pyi-no-match.njk
+++ b/src/views/ipv/page/pyi-no-match.njk
@@ -5,8 +5,8 @@
 {% set isPageDynamic = true %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiNoMatch.header' | translate }}</h1>
-  <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph1' | translateWithContext(context) }}</p>
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiNoMatch.header' | translateWithContextOrFallback(context) }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph1' | translateWithContextOrFallback(context) }}</p>
   {% if context !== "nino" %}
     <p class="govuk-body">{{ 'pages.pyiNoMatch.content.paragraph2' | translate }}</p>
   {% endif %}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Made pyi-no-match dynamic to support 6MFC

### Why did it change

So we can change the content displayed to users who unsuccessfully complete the 6 month fraud check flow.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5462](https://govukverify.atlassian.net/browse/PYIC-5462)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

[PYIC-5462]: https://govukverify.atlassian.net/browse/PYIC-5462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



![Screenshot 2024-03-19 at 09 48 37](https://github.com/govuk-one-login/ipv-core-front/assets/143799384/d53d1bd4-de81-436e-8e8d-40b33de320e7)