### PR TITLE
PYIC-4821: Fix odd line breaks on numbered headers

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -115,9 +115,17 @@
   text-indent: -16%;
   margin-right: 6px;
 
+  margin-top: 0;
+  vertical-align: middle;
   @include govuk-font($size: false);
 }
 
 .circle + h2 {
   display: inline-block;
+  white-space: normal;
+  vertical-align: middle;
+}
+
+.circle-header-wrapper {
+  white-space: nowrap;
 }

--- a/src/views/ipv/page/pyi-triage-desktop-download-app.njk
+++ b/src/views/ipv/page/pyi-triage-desktop-download-app.njk
@@ -11,7 +11,7 @@
         {{ 'pages.pyiTriageDesktopDownload.header' | translate }}
     </h1>
 
-    <div>
+    <div class="circle-header-wrapper">
         <p class="circle">{{ "pages.pyiTriageDesktopDownload.section1.circle" | translate }}</p>
         <h2 class="govuk-heading-m">
             {{ 'pages.pyiTriageDesktopDownload.section1.heading' | translate }}
@@ -37,7 +37,7 @@
         text: 'pages.pyiTriageDesktopDownload.section1.details2.text' | translate
     }) }}
 
-    <div>
+    <div class="circle-header-wrapper">
         <p class="circle">{{ "pages.pyiTriageDesktopDownload.section2.circle" | translate }}</p>
         <h2 class="govuk-heading-m">
             {{ 'pages.pyiTriageDesktopDownload.section2.heading' | translate }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix early line breaking after the circled number as the page gets narrower

### Why did it change

The old behaviour looked bad on narrow pages

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4821](https://govukverify.atlassian.net/browse/PYIC-4821)

<img width="724" alt="image" src="https://github.com/govuk-one-login/ipv-core-front/assets/142887905/551fc8bb-f05e-47e1-91b6-9f6e0d9b564c">


[PYIC-4821]: https://govukverify.atlassian.net/browse/PYIC-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ