### PR TITLE
PYIC-4821: Update testing iphone store link to match production DCMAW…

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -18,7 +18,7 @@ module.exports = {
     "https://play.google.com/store/apps/details?id=uk.gov.documentchecking",
   APP_STORE_URL_APPLE:
     process.env.APP_STORE_URL_APPLE ||
-    "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566",
+    "https://apps.apple.com/us/app/ipv-alpha/id16290505666",
   ENABLE_PREVIEW: process.env.ENABLE_PREVIEW === "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,


### PR DESCRIPTION
… link

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Default app store link was changed to match DCMAW production link: https://github.com/govuk-one-login/mobile-id-check-frontend/blob/f62bceea97dd6ecbd089a1084afa5b029ff1dac9/deploy/template.yaml#L206

### Why did it change

To see if this link opens the app when it's already installed rather than just going to the app store page. Unfortunately we need to test this on `build` rather than locally.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4821](https://govukverify.atlassian.net/browse/PYIC-4821)


[PYIC-4821]: https://govukverify.atlassian.net/browse/PYIC-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ