### PR TITLE
PYIC-4821: Revert Apple app store links to UK app store

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -665,7 +665,7 @@ Resources:
             - Name: APP_STORE_URL_ANDROID
               Value: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
             - Name: APP_STORE_URL_APPLE
-              Value: "https://apps.apple.com/us/app/ipv-alpha/id16290505666"
+              Value: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
             - Name: SESSION_TABLE_NAME
               Value: !Sub
                 - "core-front-sessions-${Environment}"

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -18,7 +18,7 @@ module.exports = {
     "https://play.google.com/store/apps/details?id=uk.gov.documentchecking",
   APP_STORE_URL_APPLE:
     process.env.APP_STORE_URL_APPLE ||
-    "https://apps.apple.com/us/app/ipv-alpha/id16290505666",
+    "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566",
   ENABLE_PREVIEW: process.env.ENABLE_PREVIEW === "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 3000,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Put the default app store link back to the UK app store

### Why did it change

Changing to the US app store did not fix the link

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4821](https://govukverify.atlassian.net/browse/PYIC-4821)


[PYIC-4821]: https://govukverify.atlassian.net/browse/PYIC-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ