### PR TITLE
BAU: slightly lower CPU target

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -535,7 +535,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 50
+        TargetValue: 45
         ScaleInCooldown: 420
         ScaleOutCooldown: 60
 


### PR DESCRIPTION
The last performance test failed to scale out correctly, with CPU hovering between 40-50% but requests timing out consistently.

This change slightly lowers the target to encourage core-front to scale even when under severe load.