### PR TITLE
PYIC-5435 - Return a 404 response for invalid ipv/ pages

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -262,6 +262,7 @@ module.exports = {
 
       // handles page id validation first
       if (!isValidPage(pageId)) {
+        res.status(HTTP_STATUS_CODES.NOT_FOUND);
         return res.render("errors/page-not-found.njk");
       }
 

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -260,6 +260,11 @@ module.exports = {
         return res.redirect("/ipv/all-templates");
       }
 
+      // handles page id validation first
+      if (!isValidPage(pageId)) {
+        return res.render("errors/page-not-found.njk");
+      }
+
       if (req.session?.ipvSessionId === null) {
         logError(
           req,
@@ -293,10 +298,6 @@ module.exports = {
           res,
           `/ipv/page/pyi-attempt-recovery`,
         );
-      }
-
-      if (!isValidPage(pageId)) {
-        return res.render("ipv/page/pyi-technical.njk");
       }
 
       const renderOptions = {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -172,7 +172,7 @@ describe("journey middleware", () => {
       expect(req.session.currentPageStatusCode).to.equal(undefined);
     });
 
-    it("should render technical error page when given invalid pageId", async () => {
+    it("should render page not found error page when given invalid pageId", async () => {
       req = {
         id: "1",
         params: { pageId: "../ipv/page/page-this-is-invalid" },
@@ -181,7 +181,7 @@ describe("journey middleware", () => {
       };
 
       await middleware.handleJourneyPage(req, res);
-      expect(res.render).to.have.been.calledWith("ipv/page/pyi-technical.njk");
+      expect(res.render).to.have.been.calledWith("errors/page-not-found.njk");
     });
 
     it("should render unrecoverable timeout error page when given unrecoverable timeout pageId", async () => {
@@ -201,7 +201,7 @@ describe("journey middleware", () => {
     it("should render attempt recovery error page when current page is not equal to pageId", async () => {
       req = {
         id: "1",
-        params: { pageId: "invalid-page-id" },
+        params: { pageId: "page-ipv-reuse" },
         session: {
           currentPage: "../ipv/page/page-multiple-doc-check",
           save: sinon.fake.yields(null),
@@ -223,7 +223,7 @@ describe("journey middleware", () => {
     it("should render pyi-technical page with 'unrecoverable' context if ipvSessionId is missing", async () => {
       req = {
         id: "1",
-        params: { pageId: "../ipv/page/page-multiple-doc-check" },
+        params: { pageId: "page-multiple-doc-check" },
         session: { currentPage: "page-ipv-success", ipvSessionId: null },
         log: { info: sinon.fake(), error: sinon.fake() },
       };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC-5435](https://govukverify.atlassian.net/browse/PYIC-5435) - Return a 404 response for invalid ipv/ pages

- Moves validation for pageId to render 404 instead
- Fixes tests to match
- Fixes related test to use relatable and possible pageId

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We currently attempt recovery if a user attempts to visit a page that does not exist under the `/ipv/page` path. Which is different from how invalid pages are handled outside `/ipv/page/~` path. It would be nice if this returned a 404 if the page is invalid.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5435](https://govukverify.atlassian.net/browse/PYIC-5435)



[PYIC-5435]: https://govukverify.atlassian.net/browse/PYIC-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-5435]: https://govukverify.atlassian.net/browse/PYIC-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ