### PR TITLE
BAU: Fixed user details not showing when RFC pages error

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -432,7 +432,7 @@ module.exports = {
   formRadioButtonChecked: async (req, res, next) => {
     try {
       const { context } = req?.session || "";
-      const pageId = req.params.currentPage;
+      const pageId = req.session.currentPage;
 
       const renderOptions = {
         pageId,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -311,14 +311,10 @@ module.exports = {
         const userDetailsResponse =
           await coreBackService.getProvenIdentityUserDetails(req);
 
-        const userDetails = generateUserDetails(
-          userDetailsResponse,
-          req.i18n,
-        );
+        const userDetails = generateUserDetails(userDetailsResponse, req.i18n);
 
-        renderOptions.userDetails = userDetails
-        req.session.userDetails = userDetails
-
+        renderOptions.userDetails = userDetails;
+        req.session.userDetails = userDetails;
       } else if (pageId === "pyi-triage-desktop-download-app") {
         // PYIC-4816: Use the actual device type selected on a previous page.
         const qrCodeUrl = appDownloadHelper.getAppStoreRedirectUrl(
@@ -437,7 +433,7 @@ module.exports = {
           csrfToken: req.csrfToken(),
           pageErrorState: true,
           context,
-          userDetails: req.session.userDetails
+          userDetails: req.session.userDetails,
         });
       } else {
         next();

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -432,7 +432,7 @@ module.exports = {
   formRadioButtonChecked: async (req, res, next) => {
     try {
       const { context } = req?.session || "";
-      const pageId = req.session.currentPage;
+      const { pageId } = req.session;
 
       const renderOptions = {
         pageId,

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -338,10 +338,7 @@ module.exports = {
         }
       }
 
-      const sanitzedPageId = sanitize(pageId);
-
-      req.session.currentPage = sanitzedPageId;
-      return res.render(`ipv/page/${sanitzedPageId}.njk`, renderOptions);
+      return res.render(`ipv/page/${sanitize(pageId)}.njk`, renderOptions);
     } catch (error) {
       transformError(error, `error handling journey page: ${req.params}`);
       next(error);

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -442,7 +442,7 @@ module.exports = {
 
       if (req.method === "POST" && req.body.journey === undefined) {
         res.render(
-          `ipv/page/${sanitize(req.session.currentPage)}.njk`,
+          `ipv/page/${sanitize(pageId)}.njk`,
           renderOptions,
         );
       } else {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -310,10 +310,15 @@ module.exports = {
       if (pageRequiresUserDetails(pageId)) {
         const userDetailsResponse =
           await coreBackService.getProvenIdentityUserDetails(req);
-        renderOptions.userDetails = generateUserDetails(
+
+        const userDetails = generateUserDetails(
           userDetailsResponse,
           req.i18n,
         );
+
+        renderOptions.userDetails = userDetails
+        req.session.userDetails = userDetails
+
       } else if (pageId === "pyi-triage-desktop-download-app") {
         // PYIC-4816: Use the actual device type selected on a previous page.
         const qrCodeUrl = appDownloadHelper.getAppStoreRedirectUrl(
@@ -432,6 +437,7 @@ module.exports = {
           csrfToken: req.csrfToken(),
           pageErrorState: true,
           context,
+          userDetails: req.session.userDetails
         });
       } else {
         next();

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -441,10 +441,7 @@ module.exports = {
       }
 
       if (req.method === "POST" && req.body.journey === undefined) {
-        res.render(
-          `ipv/page/${sanitize(pageId)}.njk`,
-          renderOptions,
-        );
+        res.render(`ipv/page/${sanitize(pageId)}.njk`, renderOptions);
       } else {
         next();
       }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -926,6 +926,18 @@ describe("journey middleware", () => {
       expect(next).to.have.been.calledOnce;
     });
 
+    it("should fetch user details if required", async function () {
+      CoreBackServiceStub.getProvenIdentityUserDetails = sinon.stub();
+
+      req.params.currentPage = "page-ipv-reuse";
+      await middleware.formRadioButtonChecked(req, res, next);
+
+      expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.have.been
+        .called;
+      expect(res.render).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+
     it("should call next in case of a successful execution", async function () {
       req.body.journey = "journey/dcmaw";
 

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -929,7 +929,7 @@ describe("journey middleware", () => {
     it("should fetch user details if required", async function () {
       CoreBackServiceStub.getProvenIdentityUserDetails = sinon.stub();
 
-      req.params.currentPage = "page-ipv-reuse";
+      req.session.currentPage = "page-ipv-reuse";
       await middleware.formRadioButtonChecked(req, res, next);
 
       expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.have.been


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed user details not showing when RFC pages error

### Why did it change

We didn't store a fetched user details anywhere when displaying the detail confirmation pages as part of the Repeat Fraud Check flow. 

Fixed by storing user details on the request session, so that we can populate the frontend with those details when the page reloads due to a user not selecting a radio option.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5256](https://govukverify.atlassian.net/browse/PYIC-5256)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-5256]: https://govukverify.atlassian.net/browse/PYIC-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ