### PR TITLE
BAU: Restrict dev core-front to VPN

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -913,6 +913,29 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
+      Policy: !If
+        - IsDevelopment
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal: "*"
+              Action: "execute-api:Invoke"
+              Resource: "execute-api:/*/*/*"
+            - Effect: "Deny"
+              Principal: "*"
+              Action: "execute-api:/*/*/*"
+              Resource: "execute-api:/*/*/*"
+              Condition:
+                NotIpAddress:
+                  "aws:SourceIp":
+                    - "217.196.229.77"
+                    - "217.196.229.79"
+                    - "217.196.229.80"
+                    - "217.196.229.81"
+                    - "51.149.8.0/25"
+                    - "51.149.8.128/29"
+        - AWS::NoValue
+
 
   RestApiGwDeployment:
     DependsOn: RestApiGatewayMethod


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Restrict dev core-front to VPN

### Why did it change

This adds a resource policy to the core-front rest api gateway that restricts access to requests coming from the GDS IP addresses. That is, the VPN and the office WiFi. This is due to seeing a fair amount of spurios traffic in my dev env (see below for examples).

The first implementation included getting dev-deploy to insert your current IP address into the allow list, for when you want to access your dev env when not on the VPN. This turned out to be hard however as we currently restricts running dev-deploy to being on the VPN in the first place, so can't capture a users non-VPN public IP.

This change will mean that you will need to be on the VPN (or in the office) to access your dev-deploy frontend.

If we want to do this, there is a question of if we would want to do this to other envs?

Examples of requests seen while writing this commit message:
* `/index.php?s=captcha`
* `/index.php?a=fetch&content=%3C?php+file_put_contents(%222eZHM559mInzU6F2gRqqVv9zf6T.php%22,%22%3C?php+echo+phpinfo();%22);`
* `/index.php?ids%5B0,updatexml(0,concat(0xa,user()),0)%5D=1`
* `/WUYZH5.jsp`
* `/seeyon/wpsAssistServlet?fileId=2&flag=save&realFileType=../../../../ApacheJetspeed/webapps/ROOT/WUYZH5.jsp`
* `/actuator/env`
