### PR TITLE
SPT-700: Add SPoT signing key bucket to `template.taml`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,28 +134,28 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 187
+        "line_number": 192
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 829
+        "line_number": 881
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 830
+        "line_number": 882
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 835
+        "line_number": 887
       }
     ],
     "src/app/ipv/middleware.test.js": [
@@ -168,5 +168,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-21T15:49:40Z"
+  "generated_at": "2024-04-04T13:01:50Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -86,6 +86,7 @@ Mappings:
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      spotAccountArn: arn:aws:iam::738810260032:root
     "175872367215": # core-dev02
       lb400ErrorLimit: 10
       lb500ErrorLimit: 2
@@ -105,6 +106,7 @@ Mappings:
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      spotAccountArn: arn:aws:iam::738810260032:root
     "457601271792": # Build
       lb400ErrorLimit: 10
       lb500ErrorLimit: 2
@@ -128,6 +130,7 @@ Mappings:
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      spotAccountArn: arn:aws:iam::429671060046:root
     "335257547869": # Staging
       lb400ErrorLimit: 10
       lb500ErrorLimit: 2
@@ -147,6 +150,7 @@ Mappings:
       contactUrl: "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      spotAccountArn: arn:aws:iam::444977453444:root
     "991138514218": # Integration
       lb400ErrorLimit: 10
       lb500ErrorLimit: 2
@@ -166,6 +170,7 @@ Mappings:
       contactUrl: "https://home.integration.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      spotAccountArn: arn:aws:iam::298945768017:root
     "075701497069": # Production
       lb400ErrorLimit: 20
       lb500ErrorLimit: 2
@@ -185,6 +190,7 @@ Mappings:
       contactUrl: "https://home.account.gov.uk/contact-gov-uk-one-login"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+      spotAccountArn: arn:aws:iam::101836073728:root
   SecurityGroups:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
@@ -346,6 +352,52 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+
+  SpotKeysS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub published-did-documents-${Environment}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: !GetAtt S3KmsKey.Arn
+              SSEAlgorithm: "aws:kms"
+      VersioningConfiguration:
+        Status: "Enabled"
+      LoggingConfiguration:
+        DestinationBucketName: !Ref AccessLogsBucket
+        LogFilePrefix: spot-signing-keys
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+
+  SpotKeysBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref SpotKeysS3Bucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowAccountAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "s3:*"
+            Resource: !Sub "arn:aws:s3:::${SpotKeysS3Bucket}/*"
+          - Sid: AllowSpotAccountAccess
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - spotAccountArn
+            Action:
+              - "s3:PutObject"
+              - "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${SpotKeysS3Bucket}/*"
 
   CoreFrontAccessLogsBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -1203,22 +1255,33 @@ Resources:
             Action:
               - kms:*
             Resource: "*"
+
+  S3KmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
           - Effect: Allow
             Principal:
-              Service: "dynamodb.amazonaws.com"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
             Action:
-              - "kms:Encrypt*"
+              - "kms:*"
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - spotAccountArn
+            Action:
+              - "kms:GenerateDataKey"
               - "kms:Decrypt*"
-              - "kms:ReEncrypt*"
-              - "kms:GenerateDataKey*"
-              - "kms:Describe*"
             Resource: "*"
             Condition:
               StringEquals:
-                "kms:CallerAccount": !Sub "${AWS::AccountId}"
-                "kms:ViaService":
-                  - "dynamodb.amazonaws.com"
-                  - "ecs-tasks.amazonaws.com"
+                kms:ViaService: "s3.amazonaws.com"
 
   FrontLoadBalancer5xxErrors:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add an S3 bucket (`SpotKeysS3Bucket`) to cloudformation template.
- Define access permissions on `SpotKeysS3Bucket` for ipv-core, and spot accounts.
- Add a KMS key (`S3KmsKey`) to encrypt contents of `SpotKeysS3Bucket`.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We will be using IPV Core to host our signing keys, we should create the document in a bucket in their account in order to avoid any issues that may occur from cross-account permissions being removed.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [SPT-700](https://govukverify.atlassian.net/browse/SPT-700)


[SPT-700]: https://govukverify.atlassian.net/browse/SPT-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ