### PR TITLE
PYIC-5029: Add mobile device compatibility triage page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -918,6 +918,36 @@
         "paragraph2": "You will finish proving your identity here. Then you can continue to the government service you want to use.",
         "inset": "<p>Prefer to not use an app? You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"#\">prove your identity another way</a>.</p><p>For additional help, <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{contactUsUrl}}\">contact the GOV.UK One Login support team</a>.</p>"
       }
+    },
+    "pyiTriageMobileConfirm": {
+      "title": "Prove your identity with the GOV.UK One Login app",
+      "header": "Prove your identity with the GOV.UK One Login app",
+      "content": {
+        "paragraph1": "The GOV.UK One Login app works by matching your face to your photo ID.",
+        "paragraph2": "You can prove your identity this way if you have an iPhone or Android phone.",
+        "subHeading": "iPhone",
+        "paragraph3": "You can use an iPhone if it:",
+        "bullet1": "an iPhone 7 or newer - or an iPhone 6s or newer if your photo ID is a driving licence",
+        "bullet2": "has a working camera",
+        "subHeading2": "Android phone (for example, Samsung or Google Pixel)",
+        "paragraph4": "You can use an Android phone if it:",
+        "bullet3": "has a working camera",
+        "bullet4": "has Near Field Communication (NFC) - your phone has NFC if you can use it to make contacless payments",
+        "subHeading3": "If you’re not sure you’ll be able to prove your identity with the app",
+        "paragraph5": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
+        "paragraph6": "You can also prove your identity in person at a Post Office.",
+        "subHeading4": "What would you like to do?",
+        "formRadioButtons": {
+          "proveWithAppButtonText": "Prove your identity with the GOV.UK One Login app",
+          "proveWithAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "otherWayButtonText": "Prove your identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
+        }
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -918,6 +918,36 @@
         "paragraph2": "You will finish proving your identity here. Then you can continue to the government service you want to use.",
         "inset": "<p>Prefer to not use an app? You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"#\">prove your identity another way</a>.</p><p>For additional help, <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{contactUsUrl}}\">contact the GOV.UK One Login support team</a>.</p>"
       }
+    },
+    "pyiTriageMobileConfirm": {
+      "title": "Prove your identity with the GOV.UK One Login app",
+      "header": "Prove your identity with the GOV.UK One Login app",
+      "content": {
+        "paragraph1": "The GOV.UK One Login app works by matching your face to your photo ID.",
+        "paragraph2": "You can prove your identity this way if you have an iPhone or Android phone.",
+        "subHeading": "iPhone",
+        "paragraph3": "You can use an iPhone if it:",
+        "bullet1": "an iPhone 7 or newer - or an iPhone 6s or newer if your photo ID is a driving licence",
+        "bullet2": "has a working camera",
+        "subHeading2": "Android phone (for example, Samsung or Google Pixel)",
+        "paragraph4": "You can use an Android phone if it:",
+        "bullet3": "has a working camera",
+        "bullet4": "has Near Field Communication (NFC) - your phone has NFC if you can use it to make contacless payments",
+        "subHeading3": "If you’re not sure you’ll be able to prove your identity with the app",
+        "paragraph5": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
+        "paragraph6": "You can also prove your identity in person at a Post Office.",
+        "subHeading4": "What would you like to do?",
+        "formRadioButtons": {
+          "proveWithAppButtonText": "Prove your identity with the GOV.UK One Login app",
+          "proveWithAppButtonTextHint": "You’ll be shown how to download and use the app.",
+          "otherWayButtonText": "Prove your identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
+        }
+      }
     }
   }
 }

--- a/src/views/ipv/page/pyi-triage-mobile-confirm.njk
+++ b/src/views/ipv/page/pyi-triage-mobile-confirm.njk
@@ -1,0 +1,66 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleKey = 'pages.pyiTriageMobileConfirm.title' %}
+{% set googleTagManagerPageId = "pyiTriageMobileConfirm" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pyiTriageMobileConfirm.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pyiTriageMobileConfirm.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pyiTriageMobileConfirm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiTriageMobileConfirm.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph2' | translate }}</p>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageMobileConfirm.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph3' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{ 'pages.pyiTriageMobileConfirm.content.bullet1' | translate }}</li>
+    <li>{{ 'pages.pyiTriageMobileConfirm.content.bullet2' | translate }}</li>
+  </ul>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageMobileConfirm.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph4' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>{{ 'pages.pyiTriageMobileConfirm.content.bullet3' | translate }}</li>
+    <li>{{ 'pages.pyiTriageMobileConfirm.content.bullet4' | translate }}</li>
+  </ul>
+  <h2 class="govuk-heading-m">{{ 'pages.pyiTriageMobileConfirm.content.subHeading3' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph5' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiTriageMobileConfirm.content.paragraph6' | translate }}</p>
+
+  <form id="pyiTriageMobileConfirmForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pyiTriageMobileConfirm.content.subHeading4' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.pyiTriageMobileConfirm.content.formRadioButtons.proveWithAppButtonText' | translate,
+          hint: {text: 'pages.pyiTriageMobileConfirm.content.formRadioButtons.proveWithAppButtonTextHint' | translate}
+        },
+        {
+          value: "end",
+          text: 'pages.pyiTriageMobileConfirm.content.formRadioButtons.otherWayButtonText' | translate        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pyiTriageMobileConfirm.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
+  </form>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added mobile device compatibility triage page

<img width="750" alt="Screenshot 2024-04-04 at 10 16 16" src="https://github.com/govuk-one-login/ipv-core-front/assets/24409958/10db7653-60f9-4d2d-984e-2a2c96c6a88a">


*No welsh translations yet
*Error content TBD

### Why did it change

This page will be used to determine whether the user is on a compatible smartphone to be able to continue the MAM journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5029](https://govukverify.atlassian.net/browse/PYIC-5029)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5029]: https://govukverify.atlassian.net/browse/PYIC-5029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ