### PR TITLE
PYIC-5483: Handle error on unknown backend response

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -134,7 +134,15 @@ async function handleBackendResponse(req, res, backendResponse) {
     );
   }
 
-  throw new Error(`Unknown backend response received ${backendResponse}`);
+  const err = new Error(`Unknown backend response received ${backendResponse}`);
+  err.status = HTTP_STATUS_CODES.UNAUTHORIZED;
+  logError(req, err);
+
+  req.session.currentPage = "pyi-technical";
+  res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
+  return res.render("ipv/page/pyi-technical.njk", {
+    context: "unrecoverable",
+  });
 }
 
 function tryValidateCriResponse(criResponse) {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -136,8 +136,8 @@ async function handleBackendResponse(req, res, backendResponse) {
 
   const message = {
     description: "Unexpected backend response",
-    data: backendResponse
-  }
+    data: backendResponse,
+  };
   req.log.error({ message, level: "ERROR" });
   throw new Error(message.description);
 }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -133,6 +133,8 @@ async function handleBackendResponse(req, res, backendResponse) {
       `/ipv/page/${req.session.currentPage}`,
     );
   }
+
+  throw new Error(`Unknown backend response received ${backendResponse}`);
 }
 
 function tryValidateCriResponse(criResponse) {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -134,15 +134,12 @@ async function handleBackendResponse(req, res, backendResponse) {
     );
   }
 
-  const err = new Error(`Unknown backend response received ${backendResponse}`);
-  err.status = HTTP_STATUS_CODES.UNAUTHORIZED;
-  logError(req, err);
-
-  req.session.currentPage = "pyi-technical";
-  res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
-  return res.render("ipv/page/pyi-technical.njk", {
-    context: "unrecoverable",
-  });
+  const message = {
+    description: "Unexpected backend response",
+    data: backendResponse
+  }
+  req.log.error({ message, level: "ERROR" });
+  throw new Error(message.description);
 }
 
 function tryValidateCriResponse(criResponse) {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1043,7 +1043,7 @@ describe("journey middleware", () => {
       eventResponses = [
         {
           data: {
-            test: "unknown-response"
+            test: "unknown-response",
           },
         },
       ];
@@ -1070,5 +1070,5 @@ describe("journey middleware", () => {
       await middleware.handleJourneyResponse(req, res, "/journey/next");
       expect(res.render).to.have.been.calledWith("ipv/page/pyi-technical.njk");
     });
-  })
+  });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1067,9 +1067,10 @@ describe("journey middleware", () => {
       sinon.restore();
     });
 
-    it("should render unrecoverable error page", async function () {
-      await middleware.handleJourneyResponse(req, res, "/journey/next");
-      expect(res.render).to.have.been.calledWith("ipv/page/pyi-technical.njk");
+    it("should throw an error when receiving an unexpected backend response", async function () {
+      expect(
+        middleware.handleJourneyResponse(req, res, "/journey/next"),
+      ).to.be.rejectedWith("Unexpected backend response");
     });
   });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1037,4 +1037,38 @@ describe("journey middleware", () => {
       expect(next).to.be.calledWith(sinon.match.instanceOf(Error));
     });
   });
+
+  context("handle unknown backend response", () => {
+    beforeEach(() => {
+      eventResponses = [
+        {
+          data: {
+            test: "unknown-response"
+          },
+        },
+      ];
+      req = {
+        id: "1",
+        url: "/journey/next",
+        session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+
+      const callBack = sinon.stub();
+      CoreBackServiceStub.postAction = callBack;
+
+      eventResponses.forEach((er, index) => {
+        callBack.onCall(index).returns(eventResponses[index]);
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should render unrecoverable error page", async function () {
+      await middleware.handleJourneyResponse(req, res, "/journey/next");
+      expect(res.render).to.have.been.calledWith("ipv/page/pyi-technical.njk");
+    });
+  })
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1039,6 +1039,7 @@ describe("journey middleware", () => {
   });
 
   context("handle unknown backend response", () => {
+    let eventResponses = [];
     beforeEach(() => {
       eventResponses = [
         {


### PR DESCRIPTION
## Proposed changes

### What changed

- Adds error handling in `handleBackendResponse` for unknown responses

### Why did it change

- Prevents timeouts / doing nothing when receiving unrecognised responses

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5483](https://govukverify.atlassian.net/browse/PYIC-5483)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-5483]: https://govukverify.atlassian.net/browse/PYIC-5483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ