### PR TITLE
PYIC-5747 - Adds Support For Routing `/ipv/<invalid>` Pages to 404 Screen 

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -246,7 +246,6 @@ module.exports = {
       } else {
         res.status(HTTP_STATUS_CODES.NOT_FOUND);
         return res.render("errors/page-not-found.njk");
-        // next(new Error(`Action ${req.url} not valid`));
       }
     } catch (error) {
       next(error);

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -244,7 +244,9 @@ module.exports = {
       if (action) {
         await handleJourneyResponse(req, res, action);
       } else {
-        next(new Error(`Action ${req.url} not valid`));
+        res.status(HTTP_STATUS_CODES.NOT_FOUND);
+        return res.render("errors/page-not-found.njk");
+        // next(new Error(`Action ${req.url} not valid`));
       }
     } catch (error) {
       next(error);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Small PR to fix how `ipv/<invalid>` pages are handled.

This is related to ticket [PYIC-5435](https://govukverify.atlassian.net/browse/PYIC-5435)

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We want to route users to the 404 page when a user in session attempts to visit an invalid page

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5747](https://govukverify.atlassian.net/browse/PYIC-5747)



[PYIC-5435]: https://govukverify.atlassian.net/browse/PYIC-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-5747]: https://govukverify.atlassian.net/browse/PYIC-5747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ