### PR TITLE
PYIC-5403: Use application/json for core-back APIs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": "src/app/ipv/middleware.test.js",
         "hashed_secret": "ec420572bb867a4f38076e71a4ac3b712326e496",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 240
       }
     ]
   },

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -44,13 +44,17 @@ async function journeyApi(action, req) {
     action = action.substr(1);
   }
 
+  if (action.startsWith("journey/")) {
+    action = action.substr(8);
+  }
+
   logCoreBackCall(req, {
     logCommunicationType: LOG_COMMUNICATION_TYPE_REQUEST,
     type: LOG_TYPE_JOURNEY,
     path: action,
   });
 
-  return coreBackService.postAction(req, action);
+  return coreBackService.postJourneyEvent(req, action);
 }
 
 async function fetchUserDetails(req) {
@@ -195,11 +199,11 @@ async function handleEscapeAction(req, res, next, actionType) {
     checkForSessionId(req, res);
 
     if (req.body?.journey === "next/f2f") {
-      await handleJourneyResponse(req, res, "journey/f2f");
+      await handleJourneyResponse(req, res, "f2f");
     } else if (req.body?.journey === "next/dcmaw") {
-      await handleJourneyResponse(req, res, "journey/dcmaw");
+      await handleJourneyResponse(req, res, "dcmaw");
     } else {
-      await handleJourneyResponse(req, res, "journey/end");
+      await handleJourneyResponse(req, res, "end");
     }
   } catch (error) {
     transformError(error, `error invoking ${actionType}`);
@@ -359,22 +363,18 @@ module.exports = {
       checkForIpvAndOauthSessionId(req, res);
 
       if (req.body?.journey === "end") {
-        await handleJourneyResponse(req, res, "journey/end");
+        await handleJourneyResponse(req, res, "end");
       } else if (req.body?.journey === "addressCurrent") {
-        await handleJourneyResponse(req, res, "journey/address-current");
+        await handleJourneyResponse(req, res, "address-current");
       } else if (req.body?.journey === "attempt-recovery") {
-        await handleJourneyResponse(req, res, "journey/attempt-recovery");
+        await handleJourneyResponse(req, res, "attempt-recovery");
       } else if (req.body?.journey === "build-client-oauth-response") {
         req.session.ipAddress = req?.session?.ipAddress
           ? req.session.ipAddress
           : getIpAddress(req);
-        await handleJourneyResponse(
-          req,
-          res,
-          "journey/build-client-oauth-response",
-        );
+        await handleJourneyResponse(req, res, "build-client-oauth-response");
       } else {
-        await handleJourneyResponse(req, res, "journey/next");
+        await handleJourneyResponse(req, res, "next");
       }
     } catch (error) {
       transformError(error, "error invoking handleJourneyAction");
@@ -386,11 +386,11 @@ module.exports = {
       checkForSessionId(req, res);
 
       if (req.body?.journey === "next/passport") {
-        await handleJourneyResponse(req, res, "journey/ukPassport");
+        await handleJourneyResponse(req, res, "ukPassport");
       } else if (req.body?.journey === "next/driving-licence") {
-        await handleJourneyResponse(req, res, "journey/drivingLicence");
+        await handleJourneyResponse(req, res, "drivingLicence");
       } else {
-        await handleJourneyResponse(req, res, "journey/end");
+        await handleJourneyResponse(req, res, "end");
       }
     } catch (error) {
       transformError(error, "error invoking handleMultipleDocCheck");
@@ -402,11 +402,11 @@ module.exports = {
       checkForSessionId(req, res);
 
       if (req.body?.journey === "next") {
-        await handleJourneyResponse(req, res, "journey/next");
+        await handleJourneyResponse(req, res, "next");
       } else if (req.body?.journey === "next/bank-account") {
-        await handleJourneyResponse(req, res, "journey/bankAccount");
+        await handleJourneyResponse(req, res, "bankAccount");
       } else {
-        await handleJourneyResponse(req, res, "journey/end");
+        await handleJourneyResponse(req, res, "end");
       }
     } catch (error) {
       transformError(error, "error invoking handleEscapeM2b");
@@ -420,7 +420,7 @@ module.exports = {
       if (req.body?.journey === "contact") {
         return await saveSessionAndRedirect(req, res, res.locals.contactUsUrl);
       } else {
-        await handleJourneyResponse(req, res, "journey/end");
+        await handleJourneyResponse(req, res, "end");
       }
     } catch (error) {
       transformError(error, "error invoking handleUpdateNameDobAction");

--- a/src/app/shared/axiosHelper.js
+++ b/src/app/shared/axiosHelper.js
@@ -55,41 +55,4 @@ const axiosErrorHandler = (error) => {
 module.exports = {
   createAxiosInstance,
   axiosErrorHandler,
-  generateAxiosConfig: (req) => {
-    return {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-      logger: req.log,
-    };
-  },
-  generateAxiosConfigWithClientSessionId: (req) => {
-    return {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "client-session-id": req?.session?.clientOauthSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-      logger: req.log,
-    };
-  },
-  generateJsonAxiosConfig: (req) => {
-    return {
-      headers: {
-        "Content-Type": "application/json",
-        "ipv-session-id": req.session?.ipvSessionId,
-        "x-request-id": req.id,
-        "ip-address": req.session.ipAddress,
-        "feature-set": req.session.featureSet,
-      },
-      logger: req.log,
-    };
-  },
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -12,6 +12,7 @@ module.exports = {
   ANDROID_APP_ID: process.env.ANDROID_APP_ID || "uk.gov.documentchecking",
   API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
   API_CRI_CALLBACK: "/cri/callback",
+  API_JOURNEY_EVENT: "/journey",
   API_SESSION_INITIALISE: "/session/initialise",
   API_BUILD_PROVEN_USER_IDENTITY_DETAILS: "/user/proven-identity-details",
   APP_STORE_URL_ANDROID:

--- a/src/services/coreBackService.test.js
+++ b/src/services/coreBackService.test.js
@@ -35,25 +35,25 @@ describe("CoreBackService", () => {
     });
   });
 
-  it("should postAction with correct parameters and headers", async () => {
+  it("should postJourneyEvent with correct parameters and headers", async () => {
     // Arrange
-    const action = "test_action";
+    const event = "test_event";
 
     // Act
-    await CoreBackService.postAction(req, action);
+    await CoreBackService.postJourneyEvent(req, event);
 
     // Assert
     expect(axiosInstanceStub.post).to.have.been.calledWith(
-      "/test_action",
+      "/journey/test_event",
       {},
       {
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          "ipv-session-id": "test_ipv_session_id",
-          "client-session-id": "test_client_session_id",
+          "content-type": "application/json",
           "x-request-id": "test_request_id",
           "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
+          "ipv-session-id": "test_ipv_session_id",
+          "client-session-id": "test_client_session_id",
         },
         logger: undefined,
       },
@@ -73,8 +73,12 @@ describe("CoreBackService", () => {
       { someAuthParam: "someValue" },
       {
         headers: {
+          "content-type": "application/json",
+          "x-request-id": "test_request_id",
           "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
+          "ipv-session-id": "test_ipv_session_id",
+          "client-session-id": "test_client_session_id",
         },
         logger: undefined,
       },
@@ -95,11 +99,12 @@ describe("CoreBackService", () => {
       { test_param: "someValue", error_param: "anotherValue" },
       {
         headers: {
-          "Content-Type": "application/json",
-          "ipv-session-id": "test_ipv_session_id",
+          "content-type": "application/json",
           "x-request-id": "test_request_id",
           "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
+          "ipv-session-id": "test_ipv_session_id",
+          "client-session-id": "test_client_session_id",
         },
         logger: undefined,
       },
@@ -117,11 +122,12 @@ describe("CoreBackService", () => {
     // Assert
     expect(axiosInstanceStub.get).to.have.been.calledWith("/proven-identity", {
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "ipv-session-id": "test_ipv_session_id",
+        "content-type": "application/json",
         "x-request-id": "test_request_id",
         "ip-address": "127.0.0.1",
         "feature-set": "test_feature_set",
+        "ipv-session-id": "test_ipv_session_id",
+        "client-session-id": "test_client_session_id",
       },
       logger: undefined,
     });


### PR DESCRIPTION
## Proposed changes

### What changed

- Commonised all core-back API calls to use `application/json`
- Changed 'action' API into 'journey event'

### Why did it change

There were a mixture of JSON and x-www-formurlencoded endpoints. Mostly they don't send a request body anyway, so the content-type didn't matter.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5403](https://govukverify.atlassian.net/browse/PYIC-5403)

### Other considerations

This must not go live until https://github.com/govuk-one-login/ipv-core-back/pull/1804 is merged

[PYIC-5403]: https://govukverify.atlassian.net/browse/PYIC-5403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ