### PR TITLE
PYIC-5718: Added new reprove identity start page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -670,6 +670,14 @@
         "submitButtonTextF2f": "Parhau i brofi eich hunaniaeth eto"
       }
     },
+    "reproveIdentityStart": {
+      "title": "Mae angen i chi brofi eich hunaniaeth",
+      "header": "Mae angen i chi brofi eich hunaniaeth",
+      "content": {
+        "paragraph1": "Mae angen i ni wirio pwy ydych chi cyn y gallwch barhau i ddefnyddio'r gwasanaeth.",
+        "paragraph2": "Mae angen i chi wneud hyn hyd yn oed os ydych wedi profi eich hunaniaeth gyda GOV.UK One Logn o'r blaen."
+      }
+    },
     "pyiF2fDeleteDetails": {
       "title": "Profi eich hunaniaeth mewn ffordd arall",
       "header": "Profi eich hunaniaeth mewn ffordd arall",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -403,6 +403,14 @@
         }
       }
     },
+    "reproveIdentityStart": {
+      "title": "You need to prove your identity",
+      "header": "You need to prove your identity",
+      "content": {
+        "paragraph1": "We will need to check who you are before you can continue with this service.",
+        "paragraph2": "You need to do this even if you have proved your identity with GOV.UK One Login before."
+      }
+    },
     "pyiAnotherWay": {
       "title": "Prove your identity another way",
       "header": "Prove your identity another way",

--- a/src/views/ipv/page/pyi-triage-select-device.njk
+++ b/src/views/ipv/page/pyi-triage-select-device.njk
@@ -1,7 +1,7 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleName = 'pages.pyiTriageSelectDevice.title' %}
+{% set pageTitleKey = 'pages.pyiTriageSelectDevice.title' %}
 {% set googleTagManagerPageId = "pyiTriageSelectDevice" %}
 
 {% set errorState = pageErrorState %}

--- a/src/views/ipv/page/reprove-identity-start.njk
+++ b/src/views/ipv/page/reprove-identity-start.njk
@@ -1,0 +1,13 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleKey = 'pages.reproveIdentityStart.title' %}
+{% set googleTagManagerPageId = "reproveIdentityStart" %}
+{% set isPageDynamic = false %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{ 'pages.reproveIdentityStart.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.reproveIdentityStart.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.reproveIdentityStart.content.paragraph2' | translate }}</p>
+
+  {% include 'shared/journey-next-form.njk' %}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added new reprove identity start page

### Why did it change

So we have a new information screen telling a user they must reprove their identity if it has been deleted, instead of simply being redirected to the start new IPV journey page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5718](https://govukverify.atlassian.net/browse/PYIC-5718)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-5718]: https://govukverify.atlassian.net/browse/PYIC-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ