### PR TITLE
BAU: Fixed typo in reprove identity start page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -408,7 +408,7 @@
       "title": "You need to prove your identity",
       "header": "You need to prove your identity",
       "content": {
-        "paragraph1": "We will need to check who you are before you can continue with this service.",
+        "paragraph1": "We need to check who you are before you can continue to use the service.",
         "paragraph2": "You need to do this even if you have proved your identity with GOV.UK One Login before."
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed typo in reprove identity start page

### Why did it change

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5718](https://govukverify.atlassian.net/browse/PYIC-5718)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-5718]: https://govukverify.atlassian.net/browse/PYIC-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ