### PR TITLE
PYIC-5640: Remove some Welsh only text

### DIFF
--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -24,19 +24,10 @@ const { allTemplatesMoved } = require("../development/middleware");
 const csrfProtection = csrf({});
 const parseForm = bodyParser.urlencoded({ extended: false });
 
-function checkLanguage(req, res, next) {
-  const lang = req.cookies.lng;
-
-  // Set the flag "isWelsh" to true if the language is Welsh, otherwise set to false
-  res.locals.isWelsh = lang === "cy";
-
-  next();
-}
-
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
 
 router.get("/page/attempt-recovery", csrfProtection, renderAttemptRecoveryPage);
-router.get("/page/:pageId", csrfProtection, checkLanguage, handleJourneyPage);
+router.get("/page/:pageId", csrfProtection, handleJourneyPage);
 // Remove this as part of PYIC-4278
 router.get("/all-templates", allTemplatesMoved);
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -759,7 +759,6 @@
       "content": {
         "paragraph1": "Yn seiliedig ar yr hyn a ddywedoch wrthym, ni allwch brofi eich hunaniaeth ar-lein.",
         "paragraph2": "Os oes gennych unrhyw un o’r mathau canlynol o ID gyda llun, gallwch brofi eich hunaniaeth mewn Swyddfa’r Post yn lle hynny.",
-        "insetText": "Nid yw’r opsiwn hwn ar gael yn Gymraeg eto",
         "subHeading": "Trwydded yrru cerdyn gyda llun yr Undeb Ewropeaidd (UE)",
         "paragraph3": "Gallwch ddefnyddio trwydded yrru’r UE os:",
         "list1": "mae’n gerdyn plastig gyda llun, nid trwydded bapur neu lawysgrifen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -803,7 +803,6 @@
       "content": {
         "paragraph1": "Based on what you told us, you cannot prove your identity online.",
         "paragraph2": "If you have any of the following types of photo ID, you can prove your identity at a Post Office instead.",
-        "insetText": "This option is not available in Welsh yet",
         "subHeading": "European Union (EU) photocard driving licence",
         "paragraph3": "You can use an EU driving licence if:",
         "list1": "it is a plastic photocard, not a paper or handwritten licence",

--- a/src/views/ipv/page/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page/page-ipv-identity-postoffice-start.njk
@@ -16,12 +16,6 @@
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph2' | translate }}</p>
 
-  {% if isWelsh %}
-      {{ govukInsetText({
-        text: 'pages.pageIpvIdentityPostofficeStart.content.insetText' | translate
-      }) }}
-  {% endif %}
-
   <ul class="govuk-list" role="list">
     <li>
       <h2 class="govuk-heading-m">{{ 'pages.pageIpvIdentityPostofficeStart.content.subHeading' | translate }}</h2>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed some Welsh only text from the F2F journey

### Why did it change

It wasn't needed any more

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5640](https://govukverify.atlassian.net/browse/PYIC-5640)

![image](https://github.com/govuk-one-login/ipv-core-front/assets/142887905/580378ce-5ee6-42a6-9caf-cfb3b43a1a72)


[PYIC-5640]: https://govukverify.atlassian.net/browse/PYIC-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ