### PR TITLE
PYIC-5818: added update name page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -961,6 +961,43 @@
           "errorRadioMessage": "Select what you would like to do"
         }
       }
+    },
+    "pageUpdateName": {
+      "title": "Update your name using the GOV.UK ID Check app",
+      "header": "Update your name using the GOV.UK ID Check app",
+      "content": {
+        "paragraph1": "To update your details, you need to prove your identity again with your new details.",
+        "paragraph2": "You'll need:",
+        "list1": "photo ID with the name you want GOV.UK One Login to use",
+        "list2": "to tell us where you've lived for the last 3 months",
+        "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
+        "warningText": "You may not be able to use your GOV.UK One Login if we cannot confirm your identity using your new details.",
+        "warningTextFallback": "Warning",
+        "subHeading1": "If there is a mistake in your name",
+        "paragraph4": "If there is a mistake in your name, do not try to prove your identity again unless the GOV.UK One Login support team has told you to.",
+        "paragraph5": "For example, if your name is missing letters or a hyphen, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> instead.",
+        "subHeading2": "If you need to use the service now",
+        "paragraph6": "Your proof of identity is still valid even if your details are out of date.",
+        "paragraph7": "You can use your saved details to access the service you need to use.",
+        "subHeading3": "What would you like to do?",
+        "formRadioButtons": {
+          "updateDetailsButtonText": "Update your details using the GOV.UK ID Check app",
+          "updateDetailsButtonTextHint": "We'll guide you through this",
+          "continueServiceButtonText": "Continue to the service you were trying to use",
+          "continueServiceButtonTextHint": "You can update your details later",
+          "goBackButtonText": "Go back and check your details again",
+          "separateOptionsInFormText": "or"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select how you want to continue",
+          "errorRadioMessage": "Select how you want to continue"
+        },
+        "cannotUseInformation": {
+          "summary": "I cannot use the GOV.UK ID Check app",
+          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Contact the GOV.UK One Login team if you cannot use the app.</p>We'll need to delete your details so you can prove your identity again with your new details.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a></p>"
+        }
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -961,6 +961,43 @@
           "errorRadioMessage": "Select what you would like to do"
         }
       }
+    },
+    "pageUpdateName": {
+      "title": "Update your name using the GOV.UK ID Check app",
+      "header": "Update your name using the GOV.UK ID Check app",
+      "content": {
+        "paragraph1": "To update your details, you need to prove your identity again with your new details.",
+        "paragraph2": "You'll need:",
+        "list1": "photo ID with the name you want GOV.UK One Login to use",
+        "list2": "to tell us where you've lived for the last 3 months",
+        "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
+        "warningText": "You may not be able to use your GOV.UK One Login if we cannot confirm your identity using your new details.",
+        "warningTextFallback": "Warning",
+        "subHeading1": "If there is a mistake in your name",
+        "paragraph4": "If there is a mistake in your name, do not try to prove your identity again unless the GOV.UK One Login support team has told you to.",
+        "paragraph5": "For example, if your name is missing letters or a hyphen, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> instead.",
+        "subHeading2": "If you need to use the service now",
+        "paragraph6": "Your proof of identity is still valid even if your details are out of date.",
+        "paragraph7": "You can use your saved details to access the service you need to use.",
+        "subHeading3": "What would you like to do?",
+        "formRadioButtons": {
+          "updateDetailsButtonText": "Update your details using the GOV.UK ID Check app",
+          "updateDetailsButtonTextHint": "We'll guide you through this",
+          "continueServiceButtonText": "Continue to the service you were trying to use",
+          "continueServiceButtonTextHint": "You can update your details later",
+          "goBackButtonText": "Go back and check your details again",
+          "separateOptionsInFormText": "or"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select how you want to continue",
+          "errorRadioMessage": "Select how you want to continue"
+        },
+        "cannotUseInformation": {
+          "summary": "I cannot use the GOV.UK ID Check app",
+          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Contact the GOV.UK One Login team if you cannot use the app.</p>We'll need to delete your details so you can prove your identity again with your new details.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a></p>"
+        }
+      }
     }
   }
 }

--- a/src/views/ipv/page/page-update-name.njk
+++ b/src/views/ipv/page/page-update-name.njk
@@ -1,0 +1,95 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% set pageTitleKey = 'pages.pageUpdateName.title' %}
+{% set googleTagManagerPageId = "pageUpdateName" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.pageUpdateName.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.pageUpdateName.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#pageUpdateNameOptionsForm" %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageUpdateName.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.pageUpdateName.content.paragraph1' | translate }}</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph2' | translate }}</p>
+
+  <ul class="govuk-list" role="list">
+    <li>
+      <ul class="govuk-list govuk-list--bullet ">
+        <li>{{ 'pages.pageUpdateName.content.list1' | translate }}</li>
+        <li>{{ 'pages.pageUpdateName.content.list2' | translate }}</li>
+      </ul>
+    </li>
+  </ul>
+
+  <p class="govuk-body">{{ 'pages.pyiNewDetails.content.paragraph3' | translate | safe}}</p>
+
+  {{ govukWarningText({
+    text: 'pages.pageUpdateName.content.warningText' | translate,
+    iconFallbackText: 'pages.pageUpdateName.content.warningTextFallback' | translate
+  }) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.subHeading1' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph4' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pageUpdateName.content.paragraph5' | translate( { url: contactUsUrl } ) | safe}}</p>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph6' | translate }}</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph7' | translate }}</p>
+
+  <form class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="pageUpdateNameOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.pageUpdateName.content.subHeading3' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "update-name",
+          text: 'pages.pageUpdateName.content.formRadioButtons.updateDetailsButtonText' | translate,
+          hint: {text: 'pages.pageUpdateName.content.formRadioButtons.updateDetailsButtonTextHint' | translate}
+
+        },
+        {
+          value: "end",
+          text: 'pages.pageUpdateName.content.formRadioButtons.continueServiceButtonText' | translate,
+          hint: { text: 'pages.pageUpdateName.content.formRadioButtons.continueServiceButtonTextHint' | translate }
+        },
+        {
+          divider: 'pages.pageUpdateName.content.formRadioButtons.separateOptionsInFormText' | translate
+        },
+        {
+          value: "page-ipv-reuse",
+          text: 'pages.pageUpdateName.content.formRadioButtons.goBackButtonText' | translate
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.pageUpdateName.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+
+    {{ govukDetails({
+      summaryText: 'pages.pageUpdateName.content.cannotUseInformation.summary' | translate,
+      text: 'pages.pageUpdateName.content.cannotUseInformation.text' | translate( { url: contactUsUrl } ) | safe
+    }) }}
+
+
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
## Proposed changes

Adds a new page to explain process of updating a user's name

<img width="551" alt="Screenshot 2024-04-16 at 14 00 34" src="https://github.com/govuk-one-login/ipv-core-front/assets/7995998/30d032bb-7eac-41cf-ab99-8cf173dfb917">



### What changed

A new page added explaining the requirements/options for a user name. chan

### Why did it change

As part of the Continuity of Identity work, users must be able to update their name online

### Issue tracking

- [PYIC-5818](https://govukverify.atlassian.net/browse/PYIC-5818)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-5818]: https://govukverify.atlassian.net/browse/PYIC-5818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ