### PR TITLE
PYIC-5629: Made ipv-page-reuse dynamic for continuity of identity

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -255,12 +255,11 @@ module.exports = {
   // https://govukverify.atlassian.net/browse/PYIC-4859.
   updateJourneyState: async (req, res, next) => {
     try {
-      const allowedActions = ["/journey/end"];
+      const currentPageId = req.params.pageId;
+      const { action } = req.params;
 
-      const action = allowedActions.find((x) => x === req.url);
-
-      if (action) {
-        await handleJourneyResponse(req, res, action, "pyi-f2f-delete-details");
+      if (action && isValidPage(currentPageId)) {
+        await handleJourneyResponse(req, res, action, currentPageId);
       } else {
         res.status(HTTP_STATUS_CODES.NOT_FOUND);
         return res.render("errors/page-not-found.njk");

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -16,7 +16,6 @@ const {
   formRadioButtonChecked,
   handleUpdateNameDobAction,
   handleAppStoreRedirect,
-  handlePageBackButton,
 } = require("./middleware");
 
 // Remove this as part of PYIC-4278
@@ -95,6 +94,6 @@ router.post(
   formRadioButtonChecked,
   handleJourneyAction,
 );
-router.get("/page/:pageId/back", handlePageBackButton);
-router.get("/*", updateJourneyState);
+
+router.get("/journey/:pageId/:action", updateJourneyState);
 module.exports = router;

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -691,7 +691,7 @@
         "insetText": "Ar ôl i chi ddileu eich manylion, ni fydd llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
         "paragraph3": "Byddwn yn dileu'ch manylion yn awtomatig os na fyddwch yn mynd i Swyddfa'r Post o fewn 10 diwrnod o gael eich e-bost cadarnhau.",
         "submitButtonText": "Parhau i ddileu eich manylion",
-        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/end\" rel=\"noopener noreferrer\">Rwyf am brofi fy hunaniaeth mewn Swyddfa'r Post</a>"
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/pyi-f2f-delete-details/end\" rel=\"noopener noreferrer\">Rwyf am brofi fy hunaniaeth mewn Swyddfa'r Post</a>"
       }
     },
     "pageMultipleDocCheck": {
@@ -734,7 +734,9 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "Sut i ddiweddaru eich manylion",
-          "updateDetailsHtml": "Cysylltwch â thîm cymorth <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">GOV.UK One Login (agor mewn tab newydd)</a>."
+          "updateDetailsLabelCoi": "TEMP My details are wrong",
+          "updateDetailsHtml": "Cysylltwch â thîm cymorth <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">GOV.UK One Login (agor mewn tab newydd)</a>.",
+          "updateDetailsHtmlCoi": "TEMP <h3 class=\"govuk-heading-s\">If your details have changed</h3> <p class=\"govuk-body\">Your proof of identity is still valid even if your details have changed.</p><p class=\"govuk-body\"> You do not need to update your details to continue to the service you need to use.</p><p class=\"govuk-body\"> If you continue, GOV.UK One Login will share your saved details with the service.</p><p class=\"govuk-body\"> If you need to, you can <a class=\"govuk-link\" href=\"/ipv/journey/page-ipv-reuse/update-details\" rel=\"noopener noreferrer\">update your details</a>.</p> <h3 class=\"govuk-heading-s\"> If there is a mistake in your name</h3> <p class=\"govuk-body\">Contact the GOV.UK One Login team if there is a mistake in your name. For example if your name is missing letters or a hyphen.</p><p class=\"govuk-body\"> Do not try to update your details or prove your identity again unless the GOV.UK One Login support team has told you to.</p> <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a>"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -691,7 +691,7 @@
         "insetText": "After you’ve deleted your details, your Post Office customer letter will no longer be valid and you should not try to use it to prove your identity.",
         "paragraph3": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
         "submitButtonText": "Continue to delete your details",
-        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/end\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
+        "paragraph4LinkText": "<a class=\"govuk-link\" href=\"/ipv/journey/pyi-f2f-delete-details/end\" rel=\"noopener noreferrer\">I want to prove my identity at a Post Office</a>"
       }
     },
     "pageMultipleDocCheck": {
@@ -734,7 +734,9 @@
         },
         "updateUserDetailsInformation": {
           "updateDetailsLabel": "How to update your details",
-          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> to update your details."
+          "updateDetailsLabelCoi": "My details are wrong",
+          "updateDetailsHtml": "You can <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> to update your details.",
+          "updateDetailsHtmlCoi": "<h3 class=\"govuk-heading-s\">If your details have changed</h3> <p class=\"govuk-body\">Your proof of identity is still valid even if your details have changed.</p><p class=\"govuk-body\"> You do not need to update your details to continue to the service you need to use.</p><p class=\"govuk-body\"> If you continue, GOV.UK One Login will share your saved details with the service.</p><p class=\"govuk-body\"> If you need to, you can <a class=\"govuk-link\" href=\"/ipv/journey/page-ipv-reuse/update-details\" rel=\"noopener noreferrer\">update your details</a>.</p> <h3 class=\"govuk-heading-s\"> If there is a mistake in your name</h3> <p class=\"govuk-body\">Contact the GOV.UK One Login team if there is a mistake in your name. For example if your name is missing letters or a hyphen.</p><p class=\"govuk-body\"> Do not try to update your details or prove your identity again unless the GOV.UK One Login support team has told you to.</p> <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a>."
         }
       }
     },

--- a/src/views/ipv/page/confirm-address.njk
+++ b/src/views/ipv/page/confirm-address.njk
@@ -11,7 +11,7 @@
 {% set errorText = 'pages.confirmAddress.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
 {% set errorHref = "#confirmAddressActionForm" %}
 {% set showBack = true %}
-{% set hrefBack = "/ipv/page/confirm-address/back" %}
+{% set hrefBack = "/ipv/journey/confirm-address/back" %}
 
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"

--- a/src/views/ipv/page/page-ipv-reuse.njk
+++ b/src/views/ipv/page/page-ipv-reuse.njk
@@ -54,8 +54,8 @@
     }) }}
 
     {{ govukDetails({
-        summaryText: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translate,
-        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translate( { url: contactUsUrl } ) | safe
+        summaryText: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translateWithContext(context),
+        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translateWithContext(context, { url: contactUsUrl } ) | safe
     }) }}
 
     {% include 'shared/journey-next-form.njk' %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Made ipv-page-reuse dynamic for continuity of identity

### Why did it change

With the COI feature flag enabled, users will see updated content allowing them to start the continuity of identity journey and update their details

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5629](https://govukverify.atlassian.net/browse/PYIC-5629)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<img width="430" alt="Screenshot 2024-04-12 at 12 27 52" src="https://github.com/govuk-one-login/ipv-core-front/assets/143799384/f30aebb8-71a4-4291-a744-a5c411b1f722">
<img width="429" alt="Screenshot 2024-04-12 at 12 27 59" src="https://github.com/govuk-one-login/ipv-core-front/assets/143799384/fb2eb31d-9276-48d5-b871-d436354f4b05">


[PYIC-5629]: https://govukverify.atlassian.net/browse/PYIC-5629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ