### PR TITLE
PYIC-5636

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -11,6 +11,7 @@
       "backLink": "Yn ôl",
       "errorSummaryTitle": "Mae problem",
       "error": "Gwall",
+      "errorTitlePrefix": "Gwall: ",
       "warning": "Rhybudd",
       "signOut": "Allgofnodi",
       "phaseBanner": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -11,6 +11,7 @@
       "backLink": "Back",
       "errorSummaryTitle": "There’s a problem",
       "error": "Error",
+      "errorTitlePrefix": "Error: ",
       "warning": "Warning",
       "signOut": "Sign out",
       "phaseBanner": {

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -28,10 +28,9 @@
 {% endblock %}
 
 {% block pageTitle-%}
-    {%- if error or errors %}
-      {{ 'general.govuk.errorTitlePrefix' | translate }}
-      – GOV.UK
-    {%- endif %}
+    {%- if pageErrorState %}
+        {{ 'general.govuk.errorTitlePrefix' | translate }}
+    {% endif %}
     {%- if pageTitleKey %}{{ pageTitleKey | translateWithContextOrFallback(context) }} – GOV.UK{% endif %}
 {%- endblock %}
 
@@ -58,7 +57,7 @@
             activeLanguage: htmlLang,
             class: "",
             languages: [
-            { 
+            {
               code: 'en',
               text: 'English',
               visuallyHidden: 'Change to English'
@@ -152,7 +151,7 @@
       });
     </script>
     {{ ga4OnPageLoad({
-        cspNonce: cspNonce, 
-        isPageDynamic: isPageDynamic, 
+        cspNonce: cspNonce,
+        isPageDynamic: isPageDynamic,
         englishPageTitle: pageTitleKey | translateToEnglish }) }}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
 - Adds an error prefix to the html title if there is an error in a page
<img width="1243" alt="Screenshot 2024-04-15 at 14 32 16" src="https://github.com/govuk-one-login/ipv-core-front/assets/7995998/96b69dfd-6119-4e9f-89af-7c61453457ba">


### What changed
- adds a `govuk.errorTitlePrefix` value to the to translation files
- use `pageErrorState` instead of `error/errors` to determine if an error has occurred

### Why did it change
For accessibilty issues, if an error occurs we should prefix the page title with 'Error: '
- `govuk.errorTitlePrefix` was being referenced but is not defined
-  `error/errors` we being referenced but were not defined - use `pageErrorState` instead



### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-5636

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

