### PR TITLE
PYIC-5637: set attributes so that focus is on an error if it occurs

### DIFF
--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -58,7 +58,7 @@
             activeLanguage: htmlLang,
             class: "",
             languages: [
-            { 
+            {
               code: 'en',
               text: 'English',
               visuallyHidden: 'Change to English'
@@ -83,6 +83,7 @@
                    {% if errorState %}
                         {{ govukErrorSummary({
                             titleText: errorTitle | default('Error Summary'),
+                            attributes: { autoFocus: true, tabindex: 0 },
                             errorList: [
                                 {
                                     text: errorText | translate,
@@ -152,7 +153,7 @@
       });
     </script>
     {{ ga4OnPageLoad({
-        cspNonce: cspNonce, 
-        isPageDynamic: isPageDynamic, 
+        cspNonce: cspNonce,
+        isPageDynamic: isPageDynamic,
         englishPageTitle: pageTitleKey | translateToEnglish }) }}
 {% endblock %}


### PR DESCRIPTION


## Proposed changes
 Adds attributes to `govukErrorSummary` in `base.njk`
### What changed

<!-- Describe the changes in detail - the "what"-->
Added `attributes: { autoFocus: true, tabindex: 0 }` so that when an error occurs the error summary is in focus

<img width="626" alt="Screenshot 2024-04-15 at 17 11 06" src="https://github.com/govuk-one-login/ipv-core-front/assets/7995998/b7f26517-ad14-4065-9447-967b6de7d315">

### Why did it change
Currently the focus is on `skip to main content `link at the top of the page, but should be on the error as per guidance in https://design-system.service.gov.uk/components/error-summary/#options-error-summary-second-example--error-list


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
- https://govukverify.atlassian.net/browse/PYIC-5637

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


