### PR TITLE
PYIC-5741: Fixed back button wrong error screen

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -405,6 +405,19 @@ module.exports = {
       }
 
       if (req.method === "POST" && req.body.journey === undefined) {
+        const renderOptions = {
+          pageId,
+          csrfToken: req.csrfToken(),
+          pageErrorState: true,
+          context,
+        };
+
+        if (pageRequiresUserDetails(pageId)) {
+          renderOptions.userDetails = await fetchUserDetails(req);
+        }
+
+        req.renderOptions = renderOptions;
+
         res.render(getIpvPageTemplatePath(sanitize(pageId)), renderOptions);
       } else {
         next();

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -853,7 +853,11 @@ describe("journey middleware", () => {
         body: {},
         params: { pageId: "page-ipv-identity-document-start" },
         csrfToken: sinon.fake(),
-        session: { currentPage: "page-ipv-identity-document-start" },
+        session: {
+          currentPage: "page-ipv-identity-document-start",
+          save: sinon.fake.yields(null),
+        },
+        log: { error: sinon.fake() },
       };
     });
 
@@ -887,12 +891,31 @@ describe("journey middleware", () => {
       CoreBackServiceStub.getProvenIdentityUserDetails = sinon.stub();
 
       req.session.currentPage = "page-ipv-reuse";
+      req.params.pageId = "page-ipv-reuse";
+      req.method = "POST";
+
       await middleware.formRadioButtonChecked(req, res, next);
 
       expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.have.been
         .called;
       expect(res.render).to.not.have.been.called;
       expect(next).to.have.been.calledOnce;
+    });
+
+    it("should handle unexpected pages", async function () {
+      CoreBackServiceStub.getProvenIdentityUserDetails = sinon.stub();
+
+      req.session.currentPage = "page-ipv-reuse";
+      req.method = "POST";
+
+      await middleware.formRadioButtonChecked(req, res, next);
+
+      expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.not.have.been
+        .called;
+      expect(res.render).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(
+        "/ipv/page/pyi-attempt-recovery",
+      );
     });
 
     it("should call next in case of a successful execution", async function () {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed back button wrong error screen

### Why did it change

We weren't checking whether the user had gone back (we were trying to render an unexpected page) as part of the formRadioCheck validation for checking empty radio buttons.

This meant that if the user triggered the error screen on the previous page and then tried to go back, we would render a different page (even one that didn't exist such as `/ipv/dcmaw`, as the formRadioCheck would just try to render the current page if the journey body was empty, bypassing any unexpected page behaviour)

Now we are validating the expected page BEFORE running the formRadioCheck validation, to catch this error case and correctly route the user to the recoverable page.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5741](https://govukverify.atlassian.net/browse/PYIC-5741)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-5741]: https://govukverify.atlassian.net/browse/PYIC-5741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ