### PR TITLE
PYIC-5637: call initAll for govuk javascript initialization

### DIFF
--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -58,7 +58,7 @@
             activeLanguage: htmlLang,
             class: "",
             languages: [
-            { 
+            {
               code: 'en',
               text: 'English',
               visuallyHidden: 'Change to English'
@@ -138,6 +138,7 @@
     {% block scripts %}{% endblock %}
     <script nonce='{{ cspNonce }}' src="{{ assetsCdnPath }}/public/javascripts/application.js"></script>
     <script nonce='{{ cspNonce }}'>
+        window.GOVUKFrontend.initAll()
         window.DI = window.DI || {};
         window.DI.httpStatusCode = {{ statusCode | d(200) }};
         window.DI.journeyState = "{{ googleTagManagerPageId }}";
@@ -152,7 +153,8 @@
       });
     </script>
     {{ ga4OnPageLoad({
-        cspNonce: cspNonce, 
-        isPageDynamic: isPageDynamic, 
+        cspNonce: cspNonce,
+        isPageDynamic: isPageDynamic,
         englishPageTitle: pageTitleKey | translateToEnglish }) }}
+
 {% endblock %}


### PR DESCRIPTION

## Proposed changes

Call initAll() function to initialise govuk javascript

### What changed

Adds a call to `window.GOVUKFrontend.initAll()` function, so that the default focus behaviour of the ErrorSummary gets set correctly. Followed guidance listed [here](https://frontend.design-system.service.gov.uk/v4/importing-css-assets-and-javascript/#add-the-javascript-file-to-your-html)  

<img width="626" alt="Screenshot 2024-04-15 at 17 11 06" src="https://github.com/govuk-one-login/ipv-core-front/assets/7995998/b7f26517-ad14-4065-9447-967b6de7d315">

### Why did it change
Currently the focus is on `skip to main content `link at the top of the page, but should be on the error as per guidance id [documentation](https://design-system.service.gov.uk/components/error-summary/#options-error-summary-second-example--error-list)


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
- https://govukverify.atlassian.net/browse/PYIC-5637

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


