### PR TITLE
PYIC-5973 Codify canary alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1437,6 +1437,53 @@ Resources:
             Period: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorWindow ]
             Stat: Sum
 
+  FrontTargetGroup5xxPercentErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
+    Properties:
+      AlarmName: FrontTargetGroup5xxPercentAlarm
+      AlarmDescription: >
+        The number of HTTP 5XX server error codes that originate from the
+        target group is greater than 5% of all traffic.
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue sns-topics-AlarmTopic
+      OKActions:
+        - !ImportValue sns-topics-AlarmTopic
+      InsufficientDataActions: [ ]
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 5
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+      - Id: e1
+        Label: ErrorPercent
+        ReturnData: true
+        Expression: (m1/m2)*100
+      - Id: m1
+        ReturnData: false
+        MetricStat:
+          Metric:
+            Namespace: AWS/ApplicationELB
+            MetricName: HTTPCode_Target_5XX_Count
+            Dimensions:
+              - Name: LoadBalancer
+                Value: !GetAtt PrivateLoadBalancer.LoadBalancerFullName
+          Period: 60
+          Stat: Sum
+      - Id: m2
+        ReturnData: false
+        MetricStat:
+          Metric:
+            Namespace: AWS/ApplicationELB
+            MetricName: RequestCount
+            Dimensions:
+            - Name: LoadBalancer
+              Value: !GetAtt PrivateLoadBalancer.LoadBalancerFullName
+          Period: 60
+          Stat: Sum
+
   LambdaInvocationsOutOfSync:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Codify canary alarm into template
> The number of HTTP 5XX server error codes that originate from the target group is greater than 5% of all traffic.

### Why did it change

Ready for the canary switch on

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5973](https://govukverify.atlassian.net/browse/PYIC-5973)


[PYIC-5973]: https://govukverify.atlassian.net/browse/PYIC-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ