### PR TITLE
BAU Assets incident fix - remove CDN_DOMAIN fallback

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,7 +32,7 @@ module.exports = {
   GA4_DISABLED: process.env.GA4_DISABLED,
   UA_DISABLED: process.env.UA_DISABLED,
   CDN_PATH: process.env.CDN_PATH,
-  CDN_DOMAIN: process.env.CDN_DOMAIN || "https://assets.build.account.gov.uk",
+  CDN_DOMAIN: process.env.CDN_DOMAIN,
   CONTACT_URL:
     process.env.CONTACT_URL ||
     "https://home.build.account.gov.uk/contact-gov-uk-one-login",


### PR DESCRIPTION
## Proposed changes

### What changed

Remove fallback default for the CDN_DOMAIN config var

### Why did it change

Setting the fallback has broken assets in prod - this should be empty for prod where assets aren't served from a CDN (https://github.com/govuk-one-login/ipv-core-front/blob/8dcd191a405d938518b24c13286d5c0a116702c3/src/app.js#L73)

