### PR TITLE
BAU: Add missing leading slash if no CDN_DOMAIN

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -21,7 +21,7 @@ module.exports = {
     res.locals.isUaDisabled = UA_DISABLED;
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.assetsCdnPath = CDN_PATH;
-    res.locals.assetPath = path.join(CDN_DOMAIN, "assets");
+    res.locals.assetPath = path.join(CDN_DOMAIN || "/", "assets");
 
     const contactUsUrl = new URL(CONTACT_URL);
     contactUsUrl.searchParams.set(


### PR DESCRIPTION
## Proposed changes

### What changed

- Fix for when `CDN_DOMAIN` not set in production