### PR TITLE
PLAT-4150: update ecs stack to v2.0.2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,28 +134,28 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 193
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 889
+        "line_number": 884
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 890
+        "line_number": 885
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 895
+        "line_number": 890
       }
     ],
     "src/app/ipv/middleware.test.js": [
@@ -168,5 +168,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-11T10:49:47Z"
+  "generated_at": "2024-04-23T09:18:40Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -37,6 +37,7 @@ Parameters:
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
     AllowedValues:
       - None
+      - ECSCanary50Percent5Minutes
       - CodeDeployDefault.ECSCanary10Percent5Minutes
       - CodeDeployDefault.ECSCanary10Percent15Minutes
       - CodeDeployDefault.ECSAllAtOnce
@@ -68,7 +69,6 @@ Conditions:
 Mappings:
   EnvironmentConfiguration:
     "130355686670": # core-dev01
-      lb400ErrorLimit: 10
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -89,7 +89,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::738810260032:root
     "175872367215": # core-dev02
-      lb400ErrorLimit: 10
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -110,7 +109,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::738810260032:root
     "457601271792": # Build
-      lb400ErrorLimit: 10
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -135,7 +133,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::429671060046:root
     "335257547869": # Staging
-      lb400ErrorLimit: 10
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -156,7 +153,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::444977453444:root
     "991138514218": # Integration
-      lb400ErrorLimit: 10
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 10
@@ -177,7 +173,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::298945768017:root
     "075701497069": # Production
-      lb400ErrorLimit: 20
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
       tg500ErrorLimit: 50
@@ -1439,7 +1434,7 @@ Resources:
 
   FrontTargetGroup5xxPercentErrors:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsNotDevelopment
+    Condition: UseCanaryDeployment
     Properties:
       AlarmName: FrontTargetGroup5xxPercentAlarm
       AlarmDescription: >
@@ -1601,20 +1596,18 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: UseCanaryDeployment
     Properties:
-      TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=RLuCcu0SXw5m6qJPl6LeqMrzYZEUR7Xp"
+      TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=9vFjXAXebnhiAago1o4zhHXwEGHub7ps" # v2.0.2
       Parameters:
         ECSClusterName: !Ref CoreFrontCluster
         ECSServiceName: !GetAtt CoreFrontService.Name
         TargetGroupName: !GetAtt PrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
         LoadBalancerListenerARN: !Ref PrivateLoadBalancerListener
-        LoadBalancerFullName: !GetAtt PrivateLoadBalancer.LoadBalancerFullName
         ECSServiceTaskDefinition: !Ref ECSServiceTaskDefinition
         DeploymentStrategy: !Ref DeploymentStrategy
         VpcId: !Sub ${VpcStackName}-VpcId
         ContainerName: app
         ContainerPort: 8080
-        ELB4XXAlarmThreshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lb400ErrorLimit ]
-        ELB5XXAlarmThreshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lb500ErrorLimit ]
+        CloudWatchAlarms: !Ref FrontTargetGroup5xxPercentErrors
         PermissionsBoundary: !If
           - UsePermissionsBoundary
           - !Ref PermissionsBoundary


### PR DESCRIPTION
## Proposed changes
[PLAT-4150]
Update ecs-canary-deployment stack to latest version for build environment trial
### What changed

- Updated ecs-canary-deployment to v2.0.2
- Removed unused mapping for deprecated DevPlatform alarms
- Added `FrontTargetGroup5xxPercentErrors` to deployment configuration

### Why did it change
Getting stack ready for canary deployment trial in build environment

[PLAT-4150]: https://govukverify.atlassian.net/browse/PLAT-4150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ