### PR TITLE
PYIC-5971: fix design issue m2b journey page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -115,7 +115,7 @@
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph1Nino": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda CThEF.",
-        "paragraph1BankAccount": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda’ch banc neu gymdeithas adeiladu",
+        "paragraph1BankAccount": "Nid oeddem yn gallu dod o hyd i wybodaeth sy’n cyfateb pan wnaethom wirio eich manylion gyda’ch banc neu gymdeithas adeiladu.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
         "subHeading": "Beth allwch chi ei wneud",
         "paragraph3": "Parhewch i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o brofi eich hunaniaeth.",
@@ -855,8 +855,8 @@
       }
     },
     "pageIpvBankAccountStart": {
-      "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
-      "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
+      "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
+      "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
       "content": {
         "paragraph1": "Gallwch ddefnyddio unrhyw gyfrif cyfredol gyda banc neu gymdeithas adeiladu yn y DU i brofi eich hunaniaeth. Rhaid i'ch enw fod ar y cyfrif.",
         "subHeading": "Darparwch rhywfaint o fanylion personol",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -108,7 +108,7 @@
       }
     },
     "pyiNoMatch": {
-      "title": "Sorry, we could not confirm your details",
+      "title": "Sorry, we cannot confirm your identity",
       "titleRepeatFraudCheck": "Sorry, we could not confirm your details",
       "header": "Sorry, we cannot confirm your identity",
       "headerRepeatFraudCheck": "Sorry, we could not confirm your details",

--- a/src/views/ipv/page/page-ipv-bank-account-start.njk
+++ b/src/views/ipv/page/page-ipv-bank-account-start.njk
@@ -13,19 +13,15 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvBankAccountStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph1' | translate }}</p>
 
-  <ul class="govuk-list" role="list">
-    <li>
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading' | translate }}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageIpvBankAccountStart.content.paragraph2' | translate }}</p>
-      <ul class="govuk-list govuk-list--bullet ">
-        {% for listItem in 'pages.pageIpvBankAccountStart.content.personalDetails' | translate({ returnObjects: true }) %}
-          <li>{{ listItem }}</li>
-        {% endfor %}
-      </ul>
-    </li>
+  <h2 class="govuk-heading-m">{{ 'pages.pageIpvBankAccountStart.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph2' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet ">
+    {% for listItem in 'pages.pageIpvBankAccountStart.content.personalDetails' | translate({ returnObjects: true }) %}
+      <li>{{ listItem }}</li>
+    {% endfor %}
   </ul>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.pageIpvBankAccountStart.content.subHeading2' | translate }}</h2>
+  <h2 class="govuk-heading-m">{{ 'pages.pageIpvBankAccountStart.content.subHeading2' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.pageIpvBankAccountStart.content.paragraph3' | translate }}</p>
 
   <form id="pageIpvBankAccountStartOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">

--- a/src/views/shared/base.njk
+++ b/src/views/shared/base.njk
@@ -31,7 +31,7 @@
     {%- if pageErrorState %}
         {{ 'general.govuk.errorTitlePrefix' | translate }}
     {% endif %}
-    {%- if pageTitleKey %}{{ pageTitleKey | translateWithContextOrFallback(context) }} – GOV.UK{% endif %}
+    {%- if pageTitleKey %}{{ pageTitleKey | translateWithContextOrFallback(context) }} – GOV.UK One Login{% endif %}
 {%- endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Add `GOV.UK One Login` in all page title.
- Remove unwanted margin from h2, UL tag, m2b no photo id journey.
- Add missing `.` in welsh translation m2b no photo id journey.

### What changed

- Added default title suffix `GOV.UK One Login`
- Removed unwanted html tags, css classes from m2b no photo id journey.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- Recommended changes by UCD after review.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5971](https://govukverify.atlassian.net/browse/PYIC-5971)

<img width="789" alt="Screenshot 2024-04-25 at 15 51 05" src="https://github.com/govuk-one-login/ipv-core-front/assets/3963744/f9608fd0-57bc-4606-8033-86bb08c88a7f">

[PYIC-5971]: https://govukverify.atlassian.net/browse/PYIC-5971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ