### PR TITLE
PYIC-6091: Add URL slugs for new pages

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -359,11 +359,13 @@ module.exports = {
   handleJourneyAction: async (req, res, next) => {
     const currentPageId = req.params.pageId;
     const pagesUsingSessionId = [
-      PAGES.PYI_SUGGEST_OTHER_OPTIONS,
-      PAGES.PYI_CRI_ESCAPE,
-      PAGES.PYI_KBV_ESCAPE_M2B,
-      PAGES.PYI_ESCAPE_M2B,
+      PAGES.NO_PHOTO_ID_EXIT_FIND_ANOTHER_WAY,
+      PAGES.NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY,
       PAGES.PAGE_MULTIPLE_DOC_CHECK,
+      PAGES.PYI_CRI_ESCAPE,
+      PAGES.PYI_ESCAPE_M2B,
+      PAGES.PYI_KBV_ESCAPE_M2B,
+      PAGES.PYI_SUGGEST_OTHER_OPTIONS,
     ];
 
     try {

--- a/src/constants/ipv-pages.js
+++ b/src/constants/ipv-pages.js
@@ -2,7 +2,8 @@ module.exports = Object.freeze({
   CONFIRM_ADDRESS: "confirm-address",
   CONFIRM_NAME_DATE_BIRTH: "confirm-name-date-birth",
   NO_PHOTO_ID_EXIT_FIND_ANOTHER_WAY: "no-photo-id-exit-find-another-way",
-  NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY: "no-photo-id-security-questions-find-another-way",
+  NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY:
+    "no-photo-id-security-questions-find-another-way",
   PAGE_DCMAW_SUCCESS: "page-dcmaw-success",
   PAGE_FACE_TO_FACE_HANDOFF: "page-face-to-face-handoff",
   PAGE_IPV_BANK_ACCOUNT_START: "page-ipv-bank-account-start", // Remove in PYIC-6093

--- a/src/constants/ipv-pages.js
+++ b/src/constants/ipv-pages.js
@@ -1,9 +1,11 @@
 module.exports = Object.freeze({
   CONFIRM_ADDRESS: "confirm-address",
   CONFIRM_NAME_DATE_BIRTH: "confirm-name-date-birth",
+  NO_PHOTO_ID_EXIT_FIND_ANOTHER_WAY: "no-photo-id-exit-find-another-way",
+  NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY: "no-photo-id-security-questions-find-another-way",
   PAGE_DCMAW_SUCCESS: "page-dcmaw-success",
   PAGE_FACE_TO_FACE_HANDOFF: "page-face-to-face-handoff",
-  PAGE_IPV_BANK_ACCOUNT_START: "page-ipv-bank-account-start",
+  PAGE_IPV_BANK_ACCOUNT_START: "page-ipv-bank-account-start", // Remove in PYIC-6093
   PAGE_IPV_IDENTITY_DOCUMENT_START: "page-ipv-identity-document-start",
   PAGE_IPV_IDENTITY_POST_OFFICE_START: "page-ipv-identity-postoffice-start",
   PAGE_IPV_PENDING: "page-ipv-pending",
@@ -11,6 +13,7 @@ module.exports = Object.freeze({
   PAGE_IPV_SUCCESS: "page-ipv-success",
   PAGE_MULTIPLE_DOC_CHECK: "page-multiple-doc-check",
   PAGE_PRE_EXPERIAN_KBV_TRANSITION: "page-pre-experian-kbv-transition",
+  PROVE_IDENTITY_BANK_ACCOUNT: "prove-identity-bank-account",
   PYI_ANOTHER_WAY: "pyi-another-way",
   PYI_ATTEMPT_RECOVERY: "pyi-attempt-recovery",
   PYI_CONFIRM_DELETE_DETAILS: "pyi-confirm-delete-details",
@@ -23,10 +26,10 @@ module.exports = Object.freeze({
   PYI_DRIVING_LICENCE_NO_MATCH_ANOTHER_WAY:
     "pyi-driving-licence-no-match-another-way",
   PYI_ESCAPE: "pyi-escape",
-  PYI_ESCAPE_M2B: "pyi-escape-m2b",
+  PYI_ESCAPE_M2B: "pyi-escape-m2b", // Remove in PYIC-6093
   PYI_F2F_DELETE_DETAILS: "pyi-f2f-delete-details",
   PYI_F2F_TECHNICAL: "pyi-f2f-technical",
-  PYI_KBV_ESCAPE_M2B: "pyi-kbv-escape-m2b",
+  PYI_KBV_ESCAPE_M2B: "pyi-kbv-escape-m2b", // Remove in PYIC-6093
   PYI_NEW_DETAILS: "pyi-new-details",
   PYI_NO_MATCH: "pyi-no-match",
   PYI_PASSPORT_NO_MATCH: "pyi-passport-no-match",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -245,7 +245,64 @@
         }
       }
     },
+    "noPhotoIdExitFindAnotherWay": {
+      "title": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "content": {
+        "subHeading": "Os nad oes gennych ID gyda llun",
+        "paragraph1": "Gallwch geisio profi eich hunaniaeth gyda’r gwasanaeth rydych angen ei ddefnyddio. Efallai y byddant yn cymryd mathau eraill o ID.",
+        "subHeading2": "Os oes gennych ID gyda llun",
+        "paragraph2": "Gallwch ddefnyddio ID gyda llun i brofi eich hunaniaeth gan ddefnyddio’r ap GOV.UK ID Check neu mewn Swyddfa Bost.",
+        "details": {
+          "label": "Mathau o ID gyda llun y gallwch ei ddefnyddio",
+          "text": "<p class=\"govuk-body\">Gallwch ddefnyddio: </p><ul class=\"govuk-list--bullet\"><li>Trwydded yrru cerdyn-llun yn y DU</li><li>Trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)</li><li>Pasbort y DU</li><li>pasbort o’r tu allan i’r DU</li><li>Cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)</li><li>Trwydded breswylio biometrig y DU (BRP)</li><li>Cerdyn preswylio biometrig y DU (BRC)</li><li>Trwydded Gweithwyr Ffiniol y DU (FWP)</li></ul>"
+        },
+        "subHeading3": "Beth hoffech chi ei wneud?",
+        "formRadioButtons": {
+          "radioButton1Text": "Ewch i’r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
+          "radioButton2Text": "Defnyddiwch ID gyda llun i brofi eich hunaniaeth gyda GOV.UK One Login",
+          "separateOptionsInFormText": "Neu",
+          "radioButton3Text": "Ewch yn ôl a cheisio defnyddio’ch manylion banc i brofi eich hunaniaeth"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
+        }
+      }
+    },
     "pyiKbvEscapeM2b": {
+      "title": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
+      "titleDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "header": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
+      "headerDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "content": {
+        "paragraph1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
+        "paragraph1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "subHeading": "Os nad oes gennych ID gyda llun",
+        "paragraph2": "Gallwch geisio profi eich hunaniaeth gyda'r gwasanaeth rydych angen ei ddefnyddio. Efallai y byddant yn cymryd mathau eraill o ID.",
+        "subHeading2": "Os oes gennych ID gyda llun",
+        "paragraph3": "Gallwch ddefnyddio ID gyda llun i brofi eich hunaniaeth gan ddefnyddio'r ap GOV.UK ID Check neu mewn Swyddfa Bost.",
+        "details": {
+          "label": "Mathau o ID gyda llun y gallwch ei ddefnyddio",
+          "text": "<p class=\"govuk-body\">Gallwch ddefnyddio: </p><ul class=\"govuk-list--bullet\"><li>Trwydded yrru cerdyn-llun yn y DU</li><li>Trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)</li><li>Pasbort y DU</li><li>pasbort o'r tu allan i'r DU</li><li>Cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)</li><li>Trwydded breswylio biometrig y DU (BRP)</li><li>Cerdyn preswylio biometrig y DU (BRC)</li><li>Trwydded Gweithwyr Ffiniol y DU (FWP)</li></ul>"
+        },
+        "subHeading3": "Beth hoffech chi ei wneud?",
+        "formRadioButtons": {
+          "radioButton1Text": "Ewch i'r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
+          "radioButton2Text": "Profi eich hunaniaeth gyda'r ap GOV.UK ID Check",
+          "radioButton2TextHint": "Dangosir i chi sut i lawrlwytho a defnyddio'r ap.",
+          "radioButton3Text": "Profwch eich hunaniaeth mewn Swyddfa'r Post",
+          "radioButton3TextHint": "Byddwch yn rhoi manylion o'ch ID llun ar GOV.UK yn gyntaf."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
+        }
+      }
+    },
+    "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "titleDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "header": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
@@ -855,6 +912,34 @@
       }
     },
     "pageIpvBankAccountStart": {
+      "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
+      "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
+      "content": {
+        "paragraph1": "Gallwch ddefnyddio unrhyw gyfrif cyfredol gyda banc neu gymdeithas adeiladu yn y DU i brofi eich hunaniaeth. Rhaid i'ch enw fod ar y cyfrif.",
+        "subHeading": "Darparwch rhywfaint o fanylion personol",
+        "paragraph2": "Byddwn yn gofyn i chi am eich:",
+        "personalDetails": [
+          "enw",
+          "dyddiad geni",
+          "cod didoli a rhif y cyfrif",
+          "rrhif Yswiriant Gwladol",
+          "cyfeiriad presennol (efallai y byddwch hefyd angen eich cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)"
+        ],
+        "subHeading2": "Atebwch rhai cwestiynau diogelwch",
+        "paragraph3": "Yna byddwn yn gofyn rhywfaint o gwestiynau diogelwch i chi. Mae hyn yn ein helpu i wirio a yw'r manylion rydych wedi'u rhoi yn cael eu defnyddio gennych chi.",
+        "subHeading3": "A oes gennych gyfrif banc neu gymdeithas adeiladu cyfredol yn eich enw chi?",
+        "formRadioButtons": {
+          "continueBankDetailsButtonText": "Oes",
+          "otherWayButtonText": "Na - profi fy hunaniaeth mewn ffordd arall"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
+        }
+      }
+    },
+    "proveIdentityBankAccount": {
       "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
       "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch - GOV.UK",
       "content": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -245,7 +245,64 @@
         }
       }
     },
+    "noPhotoIdExitFindAnotherWay": {
+      "title": "Find another way to prove your identity",
+      "header": "Find another way to prove your identity",
+      "content": {
+        "subHeading": "If you do not have photo ID",
+        "paragraph1": "You can try proving your identity with the service you need to use. They may take other types of ID.",
+        "subHeading2": "If you have photo ID",
+        "paragraph2": "You can use photo ID to prove your identity using the GOV.UK ID Check app or at a Post Office.",
+        "details": {
+          "label": "Types of photo ID you can use",
+          "text": "<p class=\"govuk-body\">You can use a: </p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul>"
+        },
+        "subHeading3": "What would you like to do?",
+        "formRadioButtons": {
+          "radioButton1Text": "Go to the service you need to use and find out if they take other types of ID",
+          "radioButton2Text": "Use photo ID to prove your identity with GOV.UK One Login",
+          "separateOptionsInFormText": "or",
+          "radioButton3Text": "Go back and try using your bank details to prove your identity"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
+        }
+      }
+    },
     "pyiKbvEscapeM2b": {
+      "title": "Sorry, we cannot confirm your identity this way",
+      "titleDropout": "Find another way to prove your identity",
+      "header": "Sorry, we cannot confirm your identity this way",
+      "headerDropout": "Find another way to prove your identity",
+      "content": {
+        "paragraph1": "This is because you did not answer some of the security questions correctly.",
+        "paragraph1Dropout": "We were not able to complete your identity check using security questions.",
+        "subHeading": "If you do not have photo ID",
+        "paragraph2": "You can try proving your identity with the service you need to use. They may take other types of ID.",
+        "subHeading2": "If you have photo ID",
+        "paragraph3": "You can use photo ID to prove your identity using the GOV.UK ID Check app or at a Post Office.",
+        "details": {
+          "label": "Types of photo ID you can use",
+          "text": "<p class=\"govuk-body\">You can use a: </p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul>"
+        },
+        "subHeading3": "What would you like to do?",
+        "formRadioButtons": {
+          "radioButton1Text": "Go to the service you need to use and find out if they take other types of ID",
+          "radioButton2Text": "Prove your identity with the GOV.UK ID check app",
+          "radioButton2TextHint": "You’ll be shown how to download and use the app.",
+          "radioButton3Text": "Prove your identity at a Post Office",
+          "radioButton3TextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
+        }
+      }
+    },
+    "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Sorry, we cannot confirm your identity this way",
       "titleDropout": "Find another way to prove your identity",
       "header": "Sorry, we cannot confirm your identity this way",
@@ -903,6 +960,34 @@
       }
     },
     "pageIpvBankAccountStart": {
+      "title": "Prove your identity with bank or building society details and security questions",
+      "header": "Prove your identity with bank or building society details and security questions",
+      "content": {
+        "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
+        "subHeading": "Provide some personal details",
+        "paragraph2": "We'll ask you for your:",
+        "personalDetails": [
+          "name",
+          "date of birth",
+          "sort code and account number",
+          "National Insurance number",
+          "current address (you might also need your previous address if you've recently moved)"
+        ],
+        "subHeading2": "Answer some security questions",
+        "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
+        "subHeading3": "Do you have a UK bank or building society current account in your name?",
+        "formRadioButtons": {
+          "continueBankDetailsButtonText": "Yes",
+          "otherWayButtonText": "No - prove my identity another way"
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select yes if you have a UK bank or building society account in your name",
+          "errorRadioMessage": "Select yes if you have a UK bank or building society account in your name"
+        }
+      }
+    },
+    "proveIdentityBankAccount": {
       "title": "Prove your identity with bank or building society details and security questions",
       "header": "Prove your identity with bank or building society details and security questions",
       "content": {

--- a/src/views/components/no-photo-id-exit-find-another-way-form.njk
+++ b/src/views/components/no-photo-id-exit-find-another-way-form.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+<form id="noPhotoIdExitFindAnotherWayForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      {% set radioOptions = [
+        {
+          value: "end",
+          text: 'pages.noPhotoIdExitFindAnotherWay.content.formRadioButtons.radioButton1Text' | translate
+        },
+        {
+          value: "next",
+          text: 'pages.noPhotoIdExitFindAnotherWay.content.formRadioButtons.radioButton2Text' | translate
+        },
+        {
+          divider: 'pages.noPhotoIdExitFindAnotherWay.content.formRadioButtons.separateOptionsInFormText' | translate
+        },
+        {
+          value: "bankAccount",
+          text: 'pages.noPhotoIdExitFindAnotherWay.content.formRadioButtons.radioButton3Text' | translate
+        }
+      ] %}
+
+    {% if context === "abandon" %}
+      {% set radioOptions = radioOptions.slice(0, -2) %}
+    {% endif %}
+
+    {% set radiosConfig = {
+          idPrefix: "journey",
+          name: "journey",
+          fieldset: {
+            legend: {
+              text: 'pages.noPhotoIdExitFindAnotherWay.content.subHeading3' | translate,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: radioOptions
+        } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.noPhotoIdExitFindAnotherWay.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>

--- a/src/views/ipv/page/no-photo-id-exit-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-exit-find-another-way.njk
@@ -1,0 +1,37 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% set pageTitleKey = 'pages.noPhotoIdExitFindAnotherWay.title' %}
+
+{% set googleTagManagerPageId = "noPhotoIdExitFindAnotherWay" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.noPhotoIdExitFindAnotherWay.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.noPhotoIdExitFindAnotherWay.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#noPhotoIdExitFindAnotherWayForm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.noPhotoIdExitFindAnotherWay.header' | translate }}</h1>
+
+  <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdExitFindAnotherWay.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.noPhotoIdExitFindAnotherWay.content.paragraph1' | translate }}</p>
+
+  <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdExitFindAnotherWay.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.noPhotoIdExitFindAnotherWay.content.paragraph2' | translate }}</p>
+
+  {{ govukDetails({
+    summaryText: 'pages.noPhotoIdExitFindAnotherWay.content.details.label' | translate,
+    text: 'pages.noPhotoIdExitFindAnotherWay.content.details.text' | translate | safe
+  }) }}
+
+  {% include "components/no-photo-id-exit-find-another-way-form.njk" %}
+
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
+    </a>
+  </p>
+
+{% endblock %}

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -1,0 +1,78 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set pageTitleKey = 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.title' %}
+{% set googleTagManagerPageId = "noPhotoIdSecurityQuestionsFindAnotherWay" %}
+{% set isPageDynamic = true %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#noPhotoIdSecurityQuestionsFindAnotherWayForm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.header' | translateWithContext(context) }}</h1>
+  <p class="govuk-body">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.paragraph1' | translateWithContext(context) }}</p>
+
+  <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.paragraph2' | translate }}</p>
+
+
+  <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.paragraph3' | translate }}</p>
+
+  {{ govukDetails({
+    summaryText: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.details.label' | translate,
+    text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.details.text' | translate | safe
+  }) }}
+
+  <form id="noPhotoIdSecurityQuestionsFindAnotherWayForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading3' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "end",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton1Text' | translate
+
+        },
+        {
+          value: "appTriage",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton2Text' | translate,
+          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton2TextHint' | translate }
+
+        },
+        {
+          value: "f2f",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton3Text' | translate,
+          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton3TextHint' | translate }
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+      {{ 'general.shared.contactLinkText' | translate }}
+    </a>
+  </p>
+
+{% endblock %}

--- a/src/views/ipv/page/prove-identity-bank-account.njk
+++ b/src/views/ipv/page/prove-identity-bank-account.njk
@@ -1,0 +1,64 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleKey = 'pages.proveIdentityBankAccount.title' %}
+{% set googleTagManagerPageId = "proveIdentityBankAccount" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.proveIdentityBankAccount.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.proveIdentityBankAccount.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#proveIdentityBankAccountOptionsForm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityBankAccount.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph1' | translate }}</p>
+
+  <ul class="govuk-list" role="list">
+    <li>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.proveIdentityBankAccount.content.subHeading' | translate }}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.proveIdentityBankAccount.content.paragraph2' | translate }}</p>
+      <ul class="govuk-list govuk-list--bullet ">
+        {% for listItem in 'pages.proveIdentityBankAccount.content.personalDetails' | translate({ returnObjects: true }) %}
+          <li>{{ listItem }}</li>
+        {% endfor %}
+      </ul>
+    </li>
+  </ul>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph3' | translate }}</p>
+
+  <form id="proveIdentityBankAccountOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% set radiosConfig = {
+      idPrefix: "journey",
+      name: "journey",
+      fieldset: {
+        legend: {
+          text: 'pages.proveIdentityBankAccount.content.subHeading3' | translate,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "next",
+          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.continueBankDetailsButtonText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.otherWayButtonText' | translate
+        }
+      ]
+    } %}
+
+    {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.proveIdentityBankAccount.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+
+    {{ govukRadios(radiosConfig) }}
+    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
+      {{ 'general.buttons.next' | translate }}
+    </button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

- Add new pages
- Make copies of references, ready to delete previous references

### Why did it change

- Design change

### Issue tracking

- [PYIC-6000](https://govukverify.atlassian.net/browse/PYIC-6000)
- [PYIC-6091](https://govukverify.atlassian.net/browse/PYIC-6091)

[PYIC-6000]: https://govukverify.atlassian.net/browse/PYIC-6000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-6091]: https://govukverify.atlassian.net/browse/PYIC-6091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note the merging order will be:
1. This PR to include more pages with duplicated logic around them
2. The core-back PR for changing the references to the new pages. PYIC-6092
3. The other PR in core-front to remove old page references. PYIC-6093

So it should be tested:
- With new pages but normal core-back
- With new pages and updated core-back
- With new pages, updated core-back and removed old pages (final)

Results of testing PYIC-6091 in core-front and main for core-back:
- Manually tested English and Welsh on all 3 pages using "start-dev"
- E2e tests pass
<img width="580" alt="Screenshot 2024-04-25 at 15 56 48" src="https://github.com/govuk-one-login/ipv-core-front/assets/144116535/e110b787-d011-4a1e-ba46-b01a1c80bcc9">
