### PR TITLE
SPT-51: Fixed SpotKeysS3Bucket KMS key permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1364,7 +1364,7 @@ Resources:
             Resource: "*"
             Condition:
               StringEquals:
-                kms:ViaService: "s3.amazonaws.com"
+                kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
 
   FrontLoadBalancer5xxErrors:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

### What changed

The correct value for the kms:ViaService is s3.<region>.amazonaws.com
however it was set to s3.amazonaws.com so the request from spot was
rejected.

### Why did it change

Request from SPOT were failing with the error:
> ```An error occurred (AccessDenied) when calling the PutObject operation: User: ***redacted*** is not authorized to perform: kms:GenerateDataKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access```

### Issue tracking

- SPT-51

## Checklists

### Environment variables or secrets

None

### Other considerations

None