### PR TITLE
PYIC-6062: Remove invalid use of path library

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -10,7 +10,6 @@ const {
   GA4_DISABLED,
 } = require("./config");
 const { generateNonce } = require("./strings");
-const path = require("path");
 
 module.exports = {
   setLocals: function (req, res, next) {
@@ -21,7 +20,7 @@ module.exports = {
     res.locals.isUaDisabled = UA_DISABLED;
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.assetsCdnPath = CDN_PATH;
-    res.locals.assetPath = path.join(CDN_DOMAIN || "/", "assets");
+    res.locals.assetPath = CDN_DOMAIN + "/assets";
 
     const contactUsUrl = new URL(CONTACT_URL);
     contactUsUrl.searchParams.set(


### PR DESCRIPTION
## Proposed changes

### What changed

- Fix CDN_DOMAIN wrangling
- path reduces double slashes down to a single slash so the url would look like: 
<img width="921" alt="Screenshot 2024-04-25 at 17 44 12" src="https://github.com/govuk-one-login/ipv-core-front/assets/144116535/ab5d0c9a-0525-4ad5-aefc-a19c65a334fb">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6062](https://govukverify.atlassian.net/browse/PYIC-6062)

Tested with dev env having assetDomain set and checked that this is in fact what existed before the changes which lead to its breakage.

[PYIC-6062]: https://govukverify.atlassian.net/browse/PYIC-6062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ