### PR TITLE
PYIC-5560: Add iphone/ android device sniffing

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -39,8 +39,8 @@ const {
 const PAGES = require("../../constants/ipv-pages");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
 const {
-  preferenceSniffedPhoneType,
-  modifyJourneyOnSniffing,
+  sniffPhoneType,
+  getJourneyOnSniffing,
 } = require("../shared/deviceSniffingHelper");
 
 const directoryPath = path.join(__dirname, "/../../views/ipv/page");
@@ -227,7 +227,7 @@ function isValidPage(pageId) {
 }
 
 function handleAppStoreRedirect(req, res, next) {
-  const specifiedPhoneType = preferenceSniffedPhoneType(req);
+  const specifiedPhoneType = sniffPhoneType(req, req.params.specifiedPhoneType);
 
   try {
     switch (specifiedPhoneType) {
@@ -420,7 +420,7 @@ module.exports = {
         res.render(getIpvPageTemplatePath(sanitize(pageId)), renderOptions);
       } else {
         if (req.body?.journey === "appTriage") {
-          modifyJourneyOnSniffing(req);
+          req.body.journey = getJourneyOnSniffing(req);
         }
         next();
       }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1156,6 +1156,7 @@ describe("journey middleware", () => {
   context("redirect to app store", () => {
     beforeEach(() => {
       req = {
+        headers: {},
         body: {},
         params: {},
       };

--- a/src/app/shared/deviceSniffingHelper.js
+++ b/src/app/shared/deviceSniffingHelper.js
@@ -1,0 +1,37 @@
+const UAParser = require("ua-parser-js");
+const PHONE_TYPES = require("../../constants/phone-types");
+const OS_TYPES = require("../../constants/os-types");
+
+function modifyJourneyOnSniffing(req) {
+  const parser = new UAParser(req.headers["user-agent"]);
+
+  if (parser.getDevice()["type"] === "mobile") {
+    req.body.journey += "Smartphone";
+    switch (parser.getOS()["name"]) {
+      case OS_TYPES.IOS:
+        req.body.journey += "Iphone";
+        break;
+      case OS_TYPES.ANDROID:
+        req.body.journey += "Android";
+        break;
+    }
+  }
+}
+
+function preferenceSniffedPhoneType(req) {
+  const parser = new UAParser(req.headers["user-agent"]);
+
+  switch (parser.getOS()["name"]) {
+    case OS_TYPES.IOS:
+      return PHONE_TYPES.IPHONE;
+    case OS_TYPES.ANDROID:
+      return PHONE_TYPES.ANDROID;
+    default:
+      return req.params.specifiedPhoneType;
+  }
+}
+
+module.exports = {
+  modifyJourneyOnSniffing,
+  preferenceSniffedPhoneType,
+};

--- a/src/app/shared/deviceSniffingHelper.js
+++ b/src/app/shared/deviceSniffingHelper.js
@@ -2,23 +2,26 @@ const UAParser = require("ua-parser-js");
 const PHONE_TYPES = require("../../constants/phone-types");
 const OS_TYPES = require("../../constants/os-types");
 
-function modifyJourneyOnSniffing(req) {
+function getJourneyOnSniffing(req) {
   const parser = new UAParser(req.headers["user-agent"]);
+  let journeyEvent = req.body.journey;
 
   if (parser.getDevice()["type"] === "mobile") {
-    req.body.journey += "Smartphone";
+    journeyEvent += "Smartphone";
     switch (parser.getOS()["name"]) {
       case OS_TYPES.IOS:
-        req.body.journey += "Iphone";
+        journeyEvent += "Iphone";
         break;
       case OS_TYPES.ANDROID:
-        req.body.journey += "Android";
+        journeyEvent += "Android";
         break;
     }
   }
+
+  return journeyEvent;
 }
 
-function preferenceSniffedPhoneType(req) {
+function sniffPhoneType(req, fallback) {
   const parser = new UAParser(req.headers["user-agent"]);
 
   switch (parser.getOS()["name"]) {
@@ -27,11 +30,11 @@ function preferenceSniffedPhoneType(req) {
     case OS_TYPES.ANDROID:
       return PHONE_TYPES.ANDROID;
     default:
-      return req.params.specifiedPhoneType;
+      return fallback;
   }
 }
 
 module.exports = {
-  modifyJourneyOnSniffing,
-  preferenceSniffedPhoneType,
+  getJourneyOnSniffing,
+  sniffPhoneType,
 };

--- a/src/app/shared/deviceSniffingHelper.test.js
+++ b/src/app/shared/deviceSniffingHelper.test.js
@@ -48,11 +48,7 @@ describe("User Agent Functions", () => {
 
   describe("sniffPhoneType", () => {
     beforeEach(() => {
-      req = {
-        params: {
-          specifiedPhoneType: "default",
-        },
-      };
+      req = {};
     });
 
     it("should return IPHONE for iOS user agents", () => {
@@ -60,7 +56,7 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
       };
-      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
+      const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.IPHONE);
     });
 
@@ -69,7 +65,7 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
       };
-      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
+      const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.ANDROID);
     });
 
@@ -78,8 +74,8 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
       };
-      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
-      expect(result).to.equal("default");
+      const result = sniffPhoneType(req, "fallback");
+      expect(result).to.equal("fallback");
     });
   });
 });

--- a/src/app/shared/deviceSniffingHelper.test.js
+++ b/src/app/shared/deviceSniffingHelper.test.js
@@ -1,0 +1,85 @@
+const { expect } = require("chai");
+const PHONE_TYPES = require("../../constants/phone-types");
+const {
+  modifyJourneyOnSniffing,
+  preferenceSniffedPhoneType,
+} = require("./deviceSniffingHelper");
+
+describe("User Agent Functions", () => {
+  let req;
+
+  describe("modifyJourneyOnSniffing", () => {
+    beforeEach(() => {
+      req = {
+        body: {
+          journey: "appTriage",
+        },
+      };
+    });
+
+    it("should append 'Smartphone' to journey for mobile devices", () => {
+      req.headers = {
+        // Windows Phone
+        "user-agent":
+          "Mozilla/5.0 (Windows Phone 10.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0) like Gecko",
+      };
+      modifyJourneyOnSniffing(req);
+      expect(req.body.journey).to.equal("appTriageSmartphone");
+    });
+
+    it("should append 'Iphone' for iOS devices", () => {
+      req.headers = {
+        "user-agent":
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+      };
+      modifyJourneyOnSniffing(req);
+      expect(req.body.journey).to.equal("appTriageSmartphoneIphone");
+    });
+
+    it("should append 'Android' for Android devices", () => {
+      req.headers = {
+        "user-agent":
+          "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+      };
+      modifyJourneyOnSniffing(req);
+      expect(req.body.journey).to.equal("appTriageSmartphoneAndroid");
+    });
+  });
+
+  describe("preferenceSniffedPhoneType", () => {
+    beforeEach(() => {
+      req = {
+        params: {
+          specifiedPhoneType: "default",
+        },
+      };
+    });
+
+    it("should return IPHONE for iOS user agents", () => {
+      req.headers = {
+        "user-agent":
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+      };
+      const result = preferenceSniffedPhoneType(req);
+      expect(result).to.equal(PHONE_TYPES.IPHONE);
+    });
+
+    it("should return ANDROID for Android user agents", () => {
+      req.headers = {
+        "user-agent":
+          "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+      };
+      const result = preferenceSniffedPhoneType(req);
+      expect(result).to.equal(PHONE_TYPES.ANDROID);
+    });
+
+    it("should return specifiedPhoneType when OS is not iOS or Android", () => {
+      req.headers = {
+        "user-agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+      };
+      const result = preferenceSniffedPhoneType(req);
+      expect(result).to.equal("default");
+    });
+  });
+});

--- a/src/app/shared/deviceSniffingHelper.test.js
+++ b/src/app/shared/deviceSniffingHelper.test.js
@@ -1,14 +1,14 @@
 const { expect } = require("chai");
 const PHONE_TYPES = require("../../constants/phone-types");
 const {
-  modifyJourneyOnSniffing,
-  preferenceSniffedPhoneType,
+  getJourneyOnSniffing,
+  sniffPhoneType,
 } = require("./deviceSniffingHelper");
 
 describe("User Agent Functions", () => {
   let req;
 
-  describe("modifyJourneyOnSniffing", () => {
+  describe("getJourneyOnSniffing", () => {
     beforeEach(() => {
       req = {
         body: {
@@ -23,8 +23,8 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Windows Phone 10.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0) like Gecko",
       };
-      modifyJourneyOnSniffing(req);
-      expect(req.body.journey).to.equal("appTriageSmartphone");
+      const journeyEvent = getJourneyOnSniffing(req);
+      expect(journeyEvent).to.equal("appTriageSmartphone");
     });
 
     it("should append 'Iphone' for iOS devices", () => {
@@ -32,8 +32,8 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
       };
-      modifyJourneyOnSniffing(req);
-      expect(req.body.journey).to.equal("appTriageSmartphoneIphone");
+      const journeyEvent = getJourneyOnSniffing(req);
+      expect(journeyEvent).to.equal("appTriageSmartphoneIphone");
     });
 
     it("should append 'Android' for Android devices", () => {
@@ -41,12 +41,12 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
       };
-      modifyJourneyOnSniffing(req);
-      expect(req.body.journey).to.equal("appTriageSmartphoneAndroid");
+      const journeyEvent = getJourneyOnSniffing(req);
+      expect(journeyEvent).to.equal("appTriageSmartphoneAndroid");
     });
   });
 
-  describe("preferenceSniffedPhoneType", () => {
+  describe("sniffPhoneType", () => {
     beforeEach(() => {
       req = {
         params: {
@@ -60,7 +60,7 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
       };
-      const result = preferenceSniffedPhoneType(req);
+      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
       expect(result).to.equal(PHONE_TYPES.IPHONE);
     });
 
@@ -69,7 +69,7 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
       };
-      const result = preferenceSniffedPhoneType(req);
+      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
       expect(result).to.equal(PHONE_TYPES.ANDROID);
     });
 
@@ -78,7 +78,7 @@ describe("User Agent Functions", () => {
         "user-agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
       };
-      const result = preferenceSniffedPhoneType(req);
+      const result = sniffPhoneType(req, req.params.specifiedPhoneType);
       expect(result).to.equal("default");
     });
   });

--- a/src/constants/os-types.js
+++ b/src/constants/os-types.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze({
+  IOS: "iOS",
+  ANDROID: "Android",
+});


### PR DESCRIPTION
## Proposed changes

### What changed

I spent an hr looking into this, to abstract logic and add new sniffing logic

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5560](https://govukverify.atlassian.net/browse/PYIC-5560)

### Testing

- Manual testing:
  - iPhone journey works for MAM and DAD!
- E2E testing for core-back and front changes
  - This passed: 
<img width="585" alt="Screenshot 2024-04-29 at 14 11 07" src="https://github.com/govuk-one-login/ipv-core-front/assets/144116535/598348da-3153-4d6c-95a0-5b450dc1b35f">


- This PR should be merged after the core-back PR to add more events into the journey map

[PYIC-5560]: https://govukverify.atlassian.net/browse/PYIC-5560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ