### PR TITLE
PYIC-5809: added generation of update details journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -160,9 +164,9 @@
         "filename": "src/app/ipv/middleware.test.js",
         "hashed_secret": "ec420572bb867a4f38076e71a4ac3b712326e496",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 279
       }
     ]
   },
-  "generated_at": "2024-04-24T08:44:04Z"
+  "generated_at": "2024-04-30T13:58:12Z"
 }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -31,6 +31,7 @@ const { saveSessionAndRedirect } = require("../shared/redirectHelper");
 const coreBackService = require("../../services/coreBackService");
 const qrCodeHelper = require("../shared/qrCodeHelper");
 const PHONE_TYPES = require("../../constants/phone-types");
+const UPDATE_DETAILS_JOURNEY_TYPES = require("../../constants/update-details-journeys");
 const appDownloadHelper = require("../shared/appDownloadHelper");
 const {
   getIpvPageTemplatePath,
@@ -207,6 +208,47 @@ function checkJourneyAction(req) {
     logError(req, err);
 
     throw new Error("req.body?.journey is missing");
+  }
+}
+
+// getCoiUpdateDetailsJourney determines the next journey based on the detailsToUpdate
+// field of the update-details page
+function getCoiUpdateDetailsJourney(detailsToUpdate) {
+  if (!detailsToUpdate) {
+    return;
+  }
+  // convert to array if its a string
+  if (typeof detailsToUpdate === "string") {
+    detailsToUpdate = [detailsToUpdate];
+  }
+
+  if (detailsToUpdate.includes("cancel")) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL;
+  }
+  // send to update-names-dob journey if dateOfBirth selected
+  if (detailsToUpdate.includes("dateOfBirth")) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB;
+  }
+
+  const hasAddress = detailsToUpdate.includes("address");
+  const hasGivenNames = detailsToUpdate.includes("givenNames");
+  const hasLastName = detailsToUpdate.includes("lastName");
+
+  // send to update-names-dob journey if both names selected
+  if (hasGivenNames && hasLastName) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB;
+  }
+  if (hasGivenNames || hasLastName) {
+    // send to update-name-address journey if only one name and address selected
+    if (hasAddress) {
+      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME_ADDRESS;
+    }
+    // send to update-name journey if only one name selected and no address selected
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME;
+  }
+  // send to address journey if just the address
+  if (hasAddress) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS;
   }
 }
 
@@ -424,6 +466,14 @@ module.exports = {
         }
         next();
       }
+    } catch (error) {
+      next(error);
+    }
+  },
+  formHandleUpdateDetailsCheckBox: async (req, res, next) => {
+    try {
+      req.body.journey = getCoiUpdateDetailsJourney(req.body.detailsToUpdate);
+      next();
     } catch (error) {
       next(error);
     }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -8,6 +8,7 @@ const {
 } = require("../../lib/config");
 const qrCodeHelper = require("../shared/qrCodeHelper");
 const PHONE_TYPES = require("../../constants/phone-types");
+const UPDATE_DETAILS_JOURNEY_TYPES = require("../../constants/update-details-journeys");
 
 describe("journey middleware", () => {
   let req;
@@ -1219,6 +1220,121 @@ describe("journey middleware", () => {
       expect(
         middleware.handleJourneyResponse(req, res, "/journey/next"),
       ).to.be.rejectedWith("Unexpected backend response");
+    });
+  });
+
+  context("formHandleUpdateDetailsCheckBox middleware", () => {
+    beforeEach(() => {
+      req = {
+        body: {},
+        params: { pageId: "update-details" },
+        csrfToken: sinon.fake(),
+        session: {
+          currentPage: "update-details",
+          save: sinon.fake.yields(null),
+        },
+        log: { error: sinon.fake() },
+      };
+    });
+
+    it("should not set journey if detailsToUpdate is empty", async function () {
+      req.body.detailsToUpdate = [];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(undefined);
+    });
+
+    it("should not set journey if detailsToUpdate is undefined", async function () {
+      req.body.detailsToUpdate = undefined;
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(undefined);
+    });
+
+    it("should set journey to UPDATE_CANCEL if detailsToUpdate is cancel", async function () {
+      req.body.detailsToUpdate = "cancel";
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL,
+      );
+    });
+
+    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is dateOfBirth", async function () {
+      req.body.detailsToUpdate = "dateOfBirth";
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
+      );
+    });
+
+    it("should set journey to UPDATE_NAME if detailsToUpdate is givenNames", async function () {
+      req.body.detailsToUpdate = "givenNames";
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME,
+      );
+    });
+
+    it("should set journey to UPDATE_NAME if detailsToUpdate is lastName", async function () {
+      req.body.detailsToUpdate = ["lastName"];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME,
+      );
+    });
+
+    it("should set journey to UPDATE_ADDRESS if detailsToUpdate is address", async function () {
+      req.body.detailsToUpdate = "address";
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS,
+      );
+    });
+
+    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is givenNames and lastName", async function () {
+      req.body.detailsToUpdate = ["givenNames", "lastName"];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
+      );
+    });
+
+    it("should set journey to UPDATE_NAME_ADDRESS if detailsToUpdate is givenNames and address", async function () {
+      req.body.detailsToUpdate = ["givenNames", "address"];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME_ADDRESS,
+      );
+    });
+
+    it("should set journey to UPDATE_NAME_ADDRESS if detailsToUpdate is lastName and address", async function () {
+      req.body.detailsToUpdate = ["lastName", "address"];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAME_ADDRESS,
+      );
+    });
+
+    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is givenNames, lastName, dateOfBirth, address", async function () {
+      req.body.detailsToUpdate = [
+        "givenNames",
+        "lastName",
+        "dateOfBirth",
+        "address",
+      ];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(
+        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
+      );
     });
   });
 });

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -10,6 +10,7 @@ const {
   handleJourneyAction,
   renderFeatureSetPage,
   validateFeatureSet,
+  formHandleUpdateDetailsCheckBox,
   formRadioButtonChecked,
   handleAppStoreRedirect,
 } = require("./middleware");
@@ -18,6 +19,7 @@ const {
 const { allTemplatesMoved } = require("../development/middleware");
 const { getRoutePath } = require("../../lib/paths");
 const path = require("path");
+const { UPDATE_DETAILS } = require("../../constants/ipv-pages");
 
 const csrfProtection = csrf({});
 const parseForm = bodyParser.urlencoded({ extended: false });
@@ -44,6 +46,16 @@ router.get(path.join("/", "all-templates"), allTemplatesMoved);
 router.get(
   path.join("/", "app-redirect", ":specifiedPhoneType"),
   handleAppStoreRedirect,
+);
+
+// Special case to handle determination of COI journey type based in the checkboxes selected
+router.post(
+  getRoutePath(UPDATE_DETAILS),
+  parseForm,
+  csrfProtection,
+  formHandleUpdateDetailsCheckBox,
+  formRadioButtonChecked,
+  handleJourneyAction,
 );
 
 router.post(

--- a/src/constants/update-details-journeys.js
+++ b/src/constants/update-details-journeys.js
@@ -1,0 +1,7 @@
+module.exports = Object.freeze({
+  UPDATE_ADDRESS: "address",
+  UPDATE_NAMES_DOB: "names-dob",
+  UPDATE_NAME: "name",
+  UPDATE_NAME_ADDRESS: "name-address",
+  UPDATE_CANCEL: "cancel",
+});

--- a/src/views/ipv/page/update-details.njk
+++ b/src/views/ipv/page/update-details.njk
@@ -53,10 +53,11 @@
       rows: rows
     }) }}
 
-    <form id="confirmAddressActionForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <form id="updateDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             {% set checkboxConfig = {
-              name: "nationality",
+              idPrefix: "journey",
+              name: "detailsToUpdate",
               fieldset: {
                 legend: {
                   text: 'pages.pyiUpdateDetails.content.checkboxes.heading' | translate,


### PR DESCRIPTION
## Proposed changes

Add middleware to generate the journey based on the checkboxes selected when choosing to update details

### What changed

Adds specific middleware for the update-details page

### Why did it change

As part of continuity of identity, a user is able to select what they want to update (name, dob, address). The combination items that they select will determine the journey they need to take

### Issue tracking

- [PYIC-5809](https://govukverify.atlassian.net/browse/PYIC-5809)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-5809]: https://govukverify.atlassian.net/browse/PYIC-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ