### PR TITLE
PYIC-6093: Remove margin for proveIdentityBankAccount header

### DIFF
--- a/src/views/ipv/page/prove-identity-bank-account.njk
+++ b/src/views/ipv/page/prove-identity-bank-account.njk
@@ -21,7 +21,7 @@
     {% endfor %}
   </ul>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
+  <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph3' | translate }}</p>
 
   <form id="proveIdentityBankAccountOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove margin which carried over from old design pages

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6093](https://govukverify.atlassian.net/browse/PYIC-6093)

[PYIC-6093]: https://govukverify.atlassian.net/browse/PYIC-6093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ