### PR TITLE
BAU: Add govuk assets to copy-images command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "watch-sass": "sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed --watch",
     "copy-locales": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ ",
-    "copy-images": "copyfiles -u 3 src/assets/images/** dist/public/images",
+    "copy-images": "copyfiles -u 3 src/assets/images/** dist/public/images && copyfiles -u 5 node_modules/govuk-frontend/govuk/assets/images/** dist/public/images",
     "lint": "prettier --check src test && eslint .",
     "lint-fix": "prettier --write src test && eslint --fix .",
     "test": "mocha",


### PR DESCRIPTION
## Proposed changes

### What changed

- the dist/public/images directory now looks like this:
<img width="323" alt="Screenshot 2024-05-01 at 10 42 24" src="https://github.com/govuk-one-login/ipv-core-front/assets/144116535/f80eb294-ba63-4c8c-bf3f-73458602e5af">
- which is due to now including govuk-frontend assets

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->