### PR TITLE
PYIC-4816: Fix validation content for triage smartphone

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -363,12 +363,12 @@
         },
         "subHeadingAppendix": "If you're not sure you'll be able to prove your identity with the app",
         "paragraphAppendix1": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
-        "paragraphAppendix2": "You can also prove your identity in person at a Post Office."
-      },
-      "formErrorMessage": {
-        "errorSummaryTitleText": "There is a problem",
-        "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
-        "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+        "paragraphAppendix2": "You can also prove your identity in person at a Post Office.",
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
+          "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+        }
       }
     },
     "pyiTriageSelectDevice": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -499,12 +499,12 @@
         },
         "subHeadingAppendix": "If you're not sure you'll be able to prove your identity with the app",
         "paragraphAppendix1": "You can still prove your identity online if you have a UK passport or UK driving licence and can answer some security questions.",
-        "paragraphAppendix2": "You can also prove your identity in person at a Post Office."
-      },
-      "formErrorMessage": {
-        "errorSummaryTitleText": "There is a problem",
-        "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
-        "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+        "paragraphAppendix2": "You can also prove your identity in person at a Post Office.",
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select whether you have an iPhone or Android phone",
+          "errorRadioMessage": "Select whether you have an iPhone or Android phone"
+        }
       }
     },
     "pyiTimeoutRecoverable": {


### PR DESCRIPTION
## Proposed changes

### What changed

- Moved formErrorMessage content to within the content object for pyiTriageSelectSmartphone

### Why did it change

- Because that page's validation message wouldn't show otherwise - and was spotted in QA

### Issue tracking

- [PYIC-4816](https://govukverify.atlassian.net/browse/PYIC-4816)


[PYIC-4816]: https://govukverify.atlassian.net/browse/PYIC-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ