### PR TITLE
PYIC-5246: Update content of multiple-doc-check page and pyi-post-office page and Welsh translations

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -764,12 +764,13 @@
           "rydych yn gallu ateb rhai cwestiynau diogelwch"
         ],
         "paragraph2": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
-        "subHeading": "Sut ydych chi am barhau?",
+        "subHeading": "Ydych chi am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth?",
         "formRadioButtons": {
-          "continueDrivingLicenceButtonText": "Rhowch fanylion eich trwydded yrru cerdyn-llun y DU ac atebwch y cwestiynau diogelwch ar-lein",
-          "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
+          "continueDrivingLicenceButtonText": "trwydded yrru cerdyn-llun yn y DU",
+          "continuePassportButtonText": "pasbort y DU",
           "separateOptionsInFormText": "neu",
-          "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
+          "otherWayButtonText": "Nid oes gennyf unrhyw un o'r mathau hyn o ID gyda llun",
+          "otherWayButtonTextHint": "Efallai y bydd ffyrdd eraill o brofi eich hunaniaeth os oes gennych fath arall o ID gyda llun.",
           "otherWayButtonTextF2f": "Profi eich hunaniaeth mewn ffordd arall"
         },
         "formErrorMessage": {
@@ -934,13 +935,13 @@
       "title": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
       "header": "Profwch eich hunaniaeth mewn Swyddfa’r Post",
       "content": {
-        "paragraph1": "Gallwch brofi pwy ydych chi mewn Swyddfa’r Post yn lle hynny.",
+        "paragraph1": "Efallai y byddwch yn gallu profi eich hunaniaeth mewn Swyddfa Bost yn lle hynny.",
         "paragraph2": "Gofynnir i chi:",
         "postOfficeTodo": [
           "rhoi manylion o’ch ID gyda llun ar GOV.UK",
           "mynd i Swyddfa Bost lle byddant yn sganio’ch ID a thynnu llun ohonoch"
         ],
-        "paragraph3": "Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
+        "paragraph3": "Bydd hyn yn cymryd mwy o amser na phrofi eich hunaniaeth ar-lein. Fel arfer, byddwch yn cael canlyniad o fewn diwrnod o fynd i Swyddfa’r Post.",
         "subHeading": "Mathau o ID gyda llun y gallwch eu defnyddio mewn Swyddfa Bost",
         "paragraph4": "Byddwch angen un o’r canlynol:",
         "postOfficeRequirements": [

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -764,6 +764,7 @@
           "rydych yn gallu ateb rhai cwestiynau diogelwch"
         ],
         "paragraph2": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
+        "paragraph3": "Mae'n cymryd tua 10 munud i brofi eich hunaniaeth fel hyn.",
         "subHeading": "Ydych chi am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "trwydded yrru cerdyn-llun yn y DU",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -765,6 +765,7 @@
           "can answer some security questions"
         ],
         "paragraph2": "We use security questions to stop anyone who might have your details from pretending to be you.",
+        "paragraph3": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "Do you want to use your UK photocard driving licence or UK passport to prove your identity?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "UK photocard driving licence",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -765,12 +765,13 @@
           "can answer some security questions"
         ],
         "paragraph2": "We use security questions to stop anyone who might have your details from pretending to be you.",
-        "subHeading": "How do you want to continue?",
+        "subHeading": "Do you want to use your UK photocard driving licence or UK passport to prove your identity?",
         "formRadioButtons": {
-          "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",
-          "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
+          "continueDrivingLicenceButtonText": "UK photocard driving licence",
+          "continuePassportButtonText": "UK passport",
           "separateOptionsInFormText": "or",
-          "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
+          "otherWayButtonText": "I do not have either of these types of photo ID",
+          "otherWayButtonTextHint": "There may be other ways to prove your identity if you have another type of photo ID.",
           "otherWayButtonTextF2f": "Prove your identity another way"
         },
         "formErrorMessage": {
@@ -935,13 +936,13 @@
       "title": "Prove your identity at a Post Office",
       "header": "Prove your identity at a Post Office",
       "content": {
-        "paragraph1": "You can prove your identity at a Post Office instead.",
+        "paragraph1": "You may be able to prove your identity at a Post Office instead.",
         "paragraph2": "You’ll be asked to:",
         "postOfficeTodo": [
           "enter details from your photo ID on GOV.UK",
           "go to a Post Office where they’ll scan your ID and take a photo of you"
         ],
-        "paragraph3": "You’ll usually get a result within a day of going to the Post Office.",
+        "paragraph3": "This will take longer than proving your identity online. You’ll usually get a result within a day of going to the Post Office.",
         "subHeading": "Types of photo ID you can use at a Post Office",
         "paragraph4": "You’ll need one of the following:",
         "postOfficeRequirements": [

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -19,6 +19,7 @@
     {% endfor %}
   </ul>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph3' | translate | safe }}</p>
 
   <form id="multipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -45,7 +45,8 @@
         },
         {
           value: "end",
-          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translateWithContext(context)
+          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translateWithContext(context),
+          hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonTextHint' | translate }
         }
       ]
     } %}

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -19,7 +19,7 @@
     {% endfor %}
   </ul>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
-  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph3' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph3' | translate }}</p>
 
   <form id="multipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updates for the `page-multiple-doc-check` page:
- update h2
- update radio button contents (inc adding a hint to 'other' option
Updates for `pyi-post-office`:
- updates to paragraphs 1 and 3
Welsh translations also updated accordingly.

See the following for [figma](https://www.figma.com/file/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?type=design&node-id=18437-14581&mode=design&t=rHnlqPBDxpcUpaGS-4) designs and [Welsh translations](https://docs.google.com/document/d/1k6W66veKekAzl0cAQd6RdqDIjkvSocneM5_tPybb3aE/edit?pli=1)

**NOTE:** The designs include some text (`It takes about 10 minutes to prove your identity this way.`) which hasn't been marked as a change in the designs but doesn't exist on the existing `multiple-doc-check` page. The change for this is not included in this PR and will be done as a separate PR when the change has been approved.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5246](https://govukverify.atlassian.net/browse/PYIC-5246)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5246]: https://govukverify.atlassian.net/browse/PYIC-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ