### PR TITLE
BAU: Revise inappropriate usages of path.join

### DIFF
--- a/src/app/credential-issuer/middleware.js
+++ b/src/app/credential-issuer/middleware.js
@@ -3,12 +3,11 @@ const { handleBackendResponse } = require("../ipv/middleware");
 const { logCoreBackCall, transformError } = require("../shared/loggerHelper");
 const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const coreBackService = require("../../services/coreBackService");
-const path = require("path");
 
 module.exports = {
   sendParamsToAPI: async (req, res, next) => {
     const callbackUrl = new URL(
-      path.join("credential-issuer", "callback"),
+      "credential-issuer/callback",
       EXTERNAL_WEBSITE_HOST,
     );
     callbackUrl.searchParams.set("id", req.query?.id);
@@ -54,7 +53,7 @@ module.exports = {
   sendParamsToAPIV2: async (req, res, next) => {
     const criId = req.params.criId;
     const callbackUrl = new URL(
-      path.join("credential-issuer", "callback", criId),
+      `credential-issuer/callback/${encodeURIComponent(criId)}`,
       EXTERNAL_WEBSITE_HOST,
     );
 

--- a/src/app/development/middleware.js
+++ b/src/app/development/middleware.js
@@ -9,7 +9,7 @@ const { pageRequiresUserDetails } = require("../ipv/middleware");
 const qrCodeHelper = require("../shared/qrCodeHelper");
 const appDownloadHelper = require("../shared/appDownloadHelper");
 const PAGES = require("../../constants/ipv-pages");
-const { getIpvPageTemplatePath, addNunjucksExt } = require("../../lib/paths");
+const { getIpvPageTemplatePath, getTemplatePath } = require("../../lib/paths");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
 
 async function allTemplatesGet(req, res, next) {
@@ -26,7 +26,7 @@ async function allTemplatesGet(req, res, next) {
         return { text: path.parse(file).name, value: path.parse(file).name };
       });
 
-      res.render(path.join("development", addNunjucksExt("all-templates")), {
+      res.render(getTemplatePath("development", "all-templates"), {
         templateRadioOptions: templateRadioOptions,
         csrfToken: req.csrfToken(),
       });
@@ -41,9 +41,9 @@ async function allTemplatesPost(req, res) {
   const language = req.body.language;
   const context = req.body.context;
 
-  let redirectUrl = path.join("/", "dev", "template", templateId, language);
+  let redirectUrl = `/dev/template/${encodeURIComponent(templateId)}/${encodeURIComponent(language)}`;
   if (context) {
-    redirectUrl += `?context=${context}`;
+    redirectUrl += `?context=${encodeURIComponent(context)}`;
   }
 
   return res.redirect(redirectUrl);
@@ -85,16 +85,8 @@ async function templatesDisplayGet(req, res) {
   );
 }
 
-// Remove this as part of PYIC-4278
-async function allTemplatesMoved(req, res) {
-  return res.render(
-    path.join("development", addNunjucksExt("all-templates-moved")),
-  );
-}
-
 module.exports = {
   allTemplatesGet,
   allTemplatesPost,
   templatesDisplayGet,
-  allTemplatesMoved,
 };

--- a/src/app/development/router.js
+++ b/src/app/development/router.js
@@ -7,14 +7,13 @@ const {
   allTemplatesPost,
   templatesDisplayGet,
 } = require("./middleware");
-const path = require("path");
 
 const csrfProtection = csrf({});
 
-router.post(path.join("/", "all-templates"), csrfProtection, allTemplatesPost);
-router.get(path.join("/", "all-templates"), csrfProtection, allTemplatesGet);
+router.post("/all-templates", csrfProtection, allTemplatesPost);
+router.get("/all-templates", csrfProtection, allTemplatesGet);
 router.get(
-  path.join("/", "template", ":templateId", ":language"),
+  "/template/:templateId/:language",
   csrfProtection,
   templatesDisplayGet,
 );

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -1,7 +1,6 @@
 const sanitize = require("sanitize-filename");
 
 const {
-  ENABLE_PREVIEW,
   APP_STORE_URL_ANDROID,
   APP_STORE_URL_APPLE,
 } = require("../../lib/config");
@@ -35,7 +34,7 @@ const appDownloadHelper = require("../shared/appDownloadHelper");
 const {
   getIpvPageTemplatePath,
   getIpvPagePath,
-  addNunjucksExt,
+  getTemplatePath,
 } = require("../../lib/paths");
 const PAGES = require("../../constants/ipv-pages");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
@@ -322,7 +321,7 @@ module.exports = {
         await handleJourneyResponse(req, res, action, currentPageId);
       } else {
         res.status(HTTP_STATUS_CODES.NOT_FOUND);
-        return res.render("errors/page-not-found.njk");
+        return res.render(getTemplatePath("errors", "page-not-found"));
       }
     } catch (error) {
       next(error);
@@ -333,15 +332,10 @@ module.exports = {
       const { pageId } = req.params;
       const { context } = req?.session || "";
 
-      // Remove this as part of PYIC-4278
-      if (ENABLE_PREVIEW && req.query.preview) {
-        return res.redirect(path.join("/", "ipv", "all-templates"));
-      }
-
       // handles page id validation first
       if (!isValidPage(pageId)) {
         res.status(HTTP_STATUS_CODES.NOT_FOUND);
-        return res.render("errors/page-not-found.njk");
+        return res.render(getTemplatePath("errors", "page-not-found"));
       }
 
       if (req.session?.ipvSessionId === null) {
@@ -432,7 +426,7 @@ module.exports = {
   },
 
   renderFeatureSetPage: async (req, res) => {
-    res.render(path.join("ipv", addNunjucksExt("page-featureset")), {
+    res.render(getTemplatePath("ipv", "page-featureset"), {
       featureSet: req.session.featureSet,
     });
   },

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -15,42 +15,33 @@ const {
   handleAppStoreRedirect,
 } = require("./middleware");
 
-// Remove this as part of PYIC-4278
-const { allTemplatesMoved } = require("../development/middleware");
-const { getRoutePath } = require("../../lib/paths");
-const path = require("path");
-const { UPDATE_DETAILS } = require("../../constants/ipv-pages");
+const {
+  PYI_ATTEMPT_RECOVERY,
+  UPDATE_DETAILS,
+} = require("../../constants/ipv-pages");
 
 const csrfProtection = csrf({});
 const parseForm = bodyParser.urlencoded({ extended: false });
 
-router.get(
-  path.join("/", "usefeatureset"),
-  validateFeatureSet,
-  renderFeatureSetPage,
-);
+function getPagePath(pageId) {
+  return `/page/${pageId}`;
+}
+
+router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
 
 router.get(
-  path.join("/", "page", "attempt-recovery"),
+  getPagePath(PYI_ATTEMPT_RECOVERY),
   csrfProtection,
   renderAttemptRecoveryPage,
 );
-router.get(
-  path.join("/", "page", ":pageId"),
-  csrfProtection,
-  handleJourneyPage,
-);
-// Remove this as part of PYIC-4278
-router.get(path.join("/", "all-templates"), allTemplatesMoved);
 
-router.get(
-  path.join("/", "app-redirect", ":specifiedPhoneType"),
-  handleAppStoreRedirect,
-);
+router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
+
+router.get("/app-redirect/:specifiedPhoneType", handleAppStoreRedirect);
 
 // Special case to handle determination of COI journey type based in the checkboxes selected
 router.post(
-  getRoutePath(UPDATE_DETAILS),
+  getPagePath(UPDATE_DETAILS),
   parseForm,
   csrfProtection,
   formHandleUpdateDetailsCheckBox,
@@ -59,12 +50,12 @@ router.post(
 );
 
 router.post(
-  getRoutePath(":pageId"),
+  getPagePath(":pageId"),
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
   handleJourneyAction,
 );
 
-router.get(path.join("/", "journey", ":pageId", ":action"), updateJourneyState);
+router.get("/journey/:pageId/:action", updateJourneyState);
 module.exports = router;

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -3,12 +3,7 @@ const express = require("express");
 const router = express.Router();
 
 const { setIpvSessionId, handleOAuthJourneyAction } = require("./middleware");
-const path = require("path");
 
-router.get(
-  path.join("/", "authorize"),
-  setIpvSessionId,
-  handleOAuthJourneyAction,
-);
+router.get("/authorize", setIpvSessionId, handleOAuthJourneyAction);
 
 module.exports = router;

--- a/src/handlers/internal-server-error-handler.js
+++ b/src/handlers/internal-server-error-handler.js
@@ -1,7 +1,7 @@
 const { HTTP_STATUS_CODES } = require("../app.constants");
 const axios = require("axios");
 const PAGES = require("../constants/ipv-pages");
-const { getIpvPageTemplatePath } = require("../lib/paths");
+const { getIpvPageTemplatePath, getTemplatePath } = require("../lib/paths");
 
 module.exports = {
   serverErrorHandler(err, req, res, next) {
@@ -17,7 +17,7 @@ module.exports = {
     }
 
     if (res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED) {
-      return res.render("errors/session-ended.njk");
+      return res.render(getTemplatePath("errors", "session-ended"));
     }
     res.err = err; // this is required so that the pino logger does not log new error with a different stack trace
     res.err?.status

--- a/src/handlers/page-not-found-handler.js
+++ b/src/handlers/page-not-found-handler.js
@@ -1,6 +1,5 @@
 const { HTTP_STATUS_CODES } = require("../app.constants");
-const path = require("path");
-const { addNunjucksExt } = require("../lib/paths");
+const { getTemplatePath } = require("../lib/paths");
 
 module.exports = {
   pageNotFoundHandler: (req, res, next) => {
@@ -9,6 +8,6 @@ module.exports = {
     }
 
     res.status(HTTP_STATUS_CODES.NOT_FOUND);
-    res.render(path.join("errors", addNunjucksExt("page-not-found")));
+    res.render(getTemplatePath("errors", "page-not-found"));
   },
 };

--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -1,24 +1,20 @@
 const path = require("path");
 
-function getRoutePath(page) {
-  return path.join("/", "page", page);
+function getIpvPagePath(pageId) {
+  return `/ipv/page/${encodeURIComponent(pageId)}`;
 }
 
-function getIpvPagePath(page) {
-  return path.join("/", "ipv", "page", page);
+function getIpvPageTemplatePath(pageId) {
+  return getTemplatePath("ipv", "page", pageId);
 }
 
-function getIpvPageTemplatePath(page) {
-  return path.join("ipv", "page", addNunjucksExt(page));
-}
-
-function addNunjucksExt(path) {
-  return `${path}.njk`;
+function getTemplatePath(...pathComponents) {
+  const pageId = pathComponents.splice(-1, 1);
+  return path.join(...pathComponents, `${pageId}.njk`);
 }
 
 module.exports = {
-  getRoutePath,
   getIpvPagePath,
   getIpvPageTemplatePath,
-  addNunjucksExt,
+  getTemplatePath,
 };

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -7,7 +7,6 @@ const {
 } = require("../lib/config");
 
 const { createAxiosInstance } = require("../app/shared/axiosHelper");
-const path = require("path");
 
 const axiosInstance = createAxiosInstance(API_BASE_URL);
 
@@ -36,11 +35,7 @@ function postJourneyEvent(req, event, currentPage) {
     requestConfig.params = { currentPage };
   }
 
-  return axiosInstance.post(
-    path.join(API_JOURNEY_EVENT, event),
-    {},
-    requestConfig,
-  );
+  return axiosInstance.post(`${API_JOURNEY_EVENT}/${event}`, {}, requestConfig);
 }
 
 function postSessionInitialise(req, authParams) {

--- a/src/views/development/all-templates-moved.njk
+++ b/src/views/development/all-templates-moved.njk
@@ -1,7 +1,0 @@
-{# Remove this as part of PYIC-4278 #}
-{% extends "shared/base.njk" %}
-{% set pageTitleKey = "All templates has moved" %}
-
-{% block content %}
-  <p class="govuk-body">The all templates page has moved to <a href="/dev/all-templates">here</a>. Please update any bookmarks you may have.</p>
-{% endblock %}


### PR DESCRIPTION
`path.join` is used to construct file paths, not URL paths.

If used inappropriately, it may generate invalid paths on different operating systems (i.e. Windows), because it will use the wrong path separator (i.e. a backslash).

At the same time, address PYIC-4278