### PR TITLE
PYIC-5809: coi context for updateNameDateBirth

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -635,6 +635,8 @@
     "updateNameDateBirth": {
       "title": "Diweddaru eich enw neu ddyddiad geni",
       "header": "Diweddaru eich enw neu ddyddiad geni",
+      "titleCoi": "TODO: Update your full name or date of birth",
+      "headerCoi": "TODO: Update your full name or date of birth",
       "content": {
         "paragraph1": "I ddiweddaru eich enw neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
         "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
@@ -642,7 +644,8 @@
         "radioButtonHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",
-          "no": "Ewch yn ôl i wirio eich manylion eto"
+          "no": "Ewch yn ôl i wirio eich manylion eto",
+          "noHintCoi": "TODO: You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -645,6 +645,7 @@
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",
           "no": "Ewch yn ôl i wirio eich manylion eto",
+          "noHint": "",
           "noHintCoi": "TODO: You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -718,6 +718,7 @@
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your name or date of birth",
           "no": "Go back and check your details again",
+          "noHint": "",
           "noHintCoi": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -708,6 +708,8 @@
     "updateNameDateBirth": {
       "title": "Update your name or date of birth",
       "header": "Update your name or date of birth",
+      "titleCoi": "Update your full name or date of birth",
+      "headerCoi": "Update your full name or date of birth",
       "content": {
         "paragraph1": "To update your name or date of birth, you need to contact the GOV.UK One Login team.",
         "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
@@ -715,7 +717,8 @@
         "radioButtonHeading": "What would you like to do?",
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your name or date of birth",
-          "no": "Go back and check your details again"
+          "no": "Go back and check your details again",
+          "noHintCoi": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -13,14 +13,14 @@
 
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
-        xmlns="http://www.w3.org/1999/html">{{ 'pages.updateNameDateBirth.header' | translate }}</h1>
+        xmlns="http://www.w3.org/1999/html">{{ 'pages.updateNameDateBirth.header' | translateWithContext(context) }}</h1>
 
     <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translate }}</p>
 
     {{ govukWarningText({
         text: 'pages.updateNameDateBirth.content.warningText' | translate,
         iconFallbackText: 'pages.updateNameDateBirth.content.warningTextFallback' | translate
-        }) }}   
+        }) }}
 
 
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
@@ -36,12 +36,15 @@
             },
             items: [
                     {
-                    value: "contact",
-                    text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translate
+                        value: "contact",
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translate
                     },
                     {
-                    value: "end",
-                    text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translateWithContext(context)
+                        value: "end",
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translate,
+                        hint: {
+                            text: 'pages.updateNameDateBirth.content.formRadioButtons.noHint' | translateWithContext(context)
+                        }
                     }
                 ]
         }
@@ -51,7 +54,7 @@
         {% set errorMessageObject = { 'text': 'pages.updateNameDateBirth.content.formErrorMessage.errorRadioMessage' | translate } %}
         {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
         {% endif %}
-        
+
         {{ govukRadios(radiosConfig) }}
         <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
         {{ 'general.buttons.next' | translate }}


### PR DESCRIPTION
## Proposed changes
Slight tweaks to updateNameDateBirth page when COI context is supplied to match the wording in the ticket

### What changed

updateNameDateBirth page and associated translations

- [PYIC-5809](https://govukverify.atlassian.net/browse/PYIC-5809)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-5809]: https://govukverify.atlassian.net/browse/PYIC-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ