### PR TITLE
SPT-712: Add header params to `RestDidCocumentMethod`

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -236,7 +236,7 @@ Resources:
   DevApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
     Condition: IsDevelopment
-    DependsOn: RestApiGwDeployment202404121033
+    DependsOn: RestApiGwDeployment202405141531
     Properties:
       DomainName: !Ref DevApiDomain
       ApiId: !Ref RestApiGateway
@@ -997,7 +997,7 @@ Resources:
         Types:
           - REGIONAL
 
-  RestApiGwDeployment202404121033:
+  RestApiGwDeployment202405141531:
     DependsOn:
       - RestApiGatewayMethod
       - RestDidDocumentMethod
@@ -1074,8 +1074,10 @@ Resources:
       AuthorizationType: NONE
       MethodResponses:
         - StatusCode: "200"
+          ResponseParameters:
+              method.response.header.Cache-Control: true
           ResponseModels:
-            application/json: Empty
+            application/did+json: Empty
         - StatusCode: "404"
           ResponseModels: {}
       Integration:
@@ -1087,6 +1089,8 @@ Resources:
         IntegrationResponses:
           - StatusCode: "200"
             SelectionPattern: "200"
+            ResponseParameters:
+              method.response.header.Cache-Control: "'max-age=3600, private'"
           - StatusCode: "404"
             SelectionPattern: ""
             ResponseTemplates:
@@ -1118,7 +1122,7 @@ Resources:
             comment: "API should have caching - not for our use case"
     Properties:
       StageName: !Sub ${Environment}
-      DeploymentId: !Ref RestApiGwDeployment202404121033
+      DeploymentId: !Ref RestApiGwDeployment202405141531
       RestApiId: !Ref RestApiGateway
       AccessLogSetting:
         DestinationArn: !GetAtt ApiGatewayAccessLogGroup.Arn


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

- Set header.Content-Type: application/did+json
- Set header.Cache-Control: max-age=3600, private

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

The [DID spec](https://www.w3.org/TR/did-core/#production) states that the media type should be set to application/did+json when publishing DID documents.

We, also, wish to use the cache control headers as a hint to RPs as to how often to retrieve the DID document.

