### PR TITLE
PYIC-5807: Added extra error case for update-details page, welsh translations

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -216,9 +216,13 @@ function checkJourneyAction(req) {
 // getCoiUpdateDetailsJourney determines the next journey based on the detailsToUpdate
 // field of the update-details page
 function getCoiUpdateDetailsJourney(detailsToUpdate) {
-  if (!detailsToUpdate) {
+  if (
+    !detailsToUpdate ||
+    (detailsToUpdate.includes("cancel") && detailsToUpdate.length > 1)
+  ) {
     return;
   }
+
   // convert to array if its a string
   if (typeof detailsToUpdate === "string") {
     detailsToUpdate = [detailsToUpdate];

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -216,16 +216,16 @@ function checkJourneyAction(req) {
 // getCoiUpdateDetailsJourney determines the next journey based on the detailsToUpdate
 // field of the update-details page
 function getCoiUpdateDetailsJourney(detailsToUpdate) {
+  // convert to array if its a string
+  if (typeof detailsToUpdate === "string") {
+    detailsToUpdate = [detailsToUpdate];
+  }
+
   if (
     !detailsToUpdate ||
     (detailsToUpdate.includes("cancel") && detailsToUpdate.length > 1)
   ) {
     return;
-  }
-
-  // convert to array if its a string
-  if (typeof detailsToUpdate === "string") {
-    detailsToUpdate = [detailsToUpdate];
   }
 
   if (detailsToUpdate.includes("cancel")) {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -221,50 +221,45 @@ function getCoiUpdateDetailsJourney(detailsToUpdate) {
     detailsToUpdate = [detailsToUpdate];
   }
 
-  if (
-    !detailsToUpdate ||
-    (detailsToUpdate.includes("cancel") && detailsToUpdate.length > 1)
-  ) {
+  if (isInvalidDetailsToUpdate(detailsToUpdate)) {
     return;
-  }
-
-  if (detailsToUpdate.includes("cancel")) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL;
-  }
-  // send to update-names-dob journey if dateOfBirth selected
-  if (detailsToUpdate.includes("dateOfBirth")) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB;
   }
 
   const hasAddress = detailsToUpdate.includes("address");
   const hasGivenNames = detailsToUpdate.includes("givenNames");
   const hasFamilyName = detailsToUpdate.includes("familyName");
 
-  // send to update-names-dob journey if both names selected
-  if (hasGivenNames && hasFamilyName) {
+  if (detailsToUpdate.includes("cancel")) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL;
+  }
+
+  if (
+    detailsToUpdate.includes("dateOfBirth") ||
+    (hasGivenNames && hasFamilyName)
+  ) {
     return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB;
   }
 
-  if (hasGivenNames) {
-    if (hasAddress) {
+  if (hasAddress) {
+    if (hasFamilyName) {
+      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME_ADDRESS;
+    } else if (hasGivenNames) {
       return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES_ADDRESS;
     } else {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES;
+      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS;
     }
+  } else if (hasFamilyName) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME;
+  } else if (hasGivenNames) {
+    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES;
   }
+}
 
-  if (hasFamilyName) {
-    if (hasAddress) {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME_ADDRESS;
-    } else {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME;
-    }
-  }
-
-  // send to address journey if just the address
-  if (hasAddress) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS;
-  }
+function isInvalidDetailsToUpdate(detailsToUpdate) {
+  return (
+    !detailsToUpdate ||
+    (detailsToUpdate.includes("cancel") && detailsToUpdate.length > 1)
+  );
 }
 
 function pageRequiresUserDetails(pageId) {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1261,6 +1261,13 @@ describe("journey middleware", () => {
       );
     });
 
+    it("should set journey to undefined if detailsToUpdate is cancel and address", async function () {
+      req.body.detailsToUpdate = ["cancel", "address"];
+      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal(undefined);
+    });
+
     it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is dateOfBirth", async function () {
       req.body.detailsToUpdate = "dateOfBirth";
       await middleware.formHandleUpdateDetailsCheckBox(req, res, next);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -755,29 +755,29 @@
       }
     },
     "pyiUpdateDetails": {
-      "title": "Update your details",
-      "header": "Update your details",
+      "title": "Diweddaru eich manylion",
+      "header": "Diweddaru eich manylion",
       "content": {
-        "summaryListHeading1": "Given names",
-        "summaryListHeading2": "Last name",
-        "summaryListHeading3": "Current home address",
-        "summaryListHeading4": "Date of birth",
+        "summaryListHeading1": "Enwau a roddwyd",
+        "summaryListHeading2": "Enw olaf",
+        "summaryListHeading3": "Cyfeiriad cartref presennol",
+        "summaryListHeading4": "Dyddiad geni",
         "checkboxes": {
-          "heading": "Which details do you need to update?",
-          "hint": "Select all that apply.",
-          "errorMessage": "Select at least one option",
-          "checkbox1": "Given names",
-          "checkbox1Hint": "This is your first name and middle names",
-          "checkbox2": "Last name",
-          "checkbox3": "Address",
-          "checkbox4": "Date of birth",
-          "checkbox5Divisor": "or",
-          "checkbox5": "I do not need to update my details"
+          "heading": "Pa fanylion ydych chi angen eu diweddaru?",
+          "hint": "Dewiswch bob un sy'n berthnasol.",
+          "errorMessage": "Dewiswch ba fanylion rydych angen eu diweddaru, neu dewiswch 'Nid wyf angen diweddaru fy manylion",
+          "checkbox1": "Enwau a roddwyd",
+          "checkbox1Hint": "Dyma eich enw cyntaf a'ch enwau canol",
+          "checkbox2": "Enw olaf",
+          "checkbox3": "Cyfeiriad",
+          "checkbox4": "Dyddiad geni",
+          "checkbox5Divisor": "neu",
+          "checkbox5": "Nid wyf angen diweddaru fy manylion"
         },
         "formErrorMessage": {
-          "errorSummaryTitleText": "There is a problem",
-          "errorSummaryDescriptionText": "Select which details you need to update",
-          "errorCheckboxMessage": "Select which details you need to update"
+          "errorSummaryTitleText": "Mae problem",
+          "errorSummaryDescriptionText": "Dewiswch ba fanylion rydych angen eu diweddaru, neu dewiswch 'Nid wyf angen diweddaru fy manylion",
+          "errorCheckboxMessage": "Dewiswch ba fanylion rydych angen eu diweddaru, neu dewiswch 'Nid wyf angen diweddaru fy manylion"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -469,7 +469,7 @@
         "checkboxes": {
           "heading": "Which details do you need to update?",
           "hint": "Select all that apply.",
-          "errorMessage": "Select at least one option",
+          "errorMessage": "Select which details you need to update, or select 'I do not need to update my details'",
           "checkbox1": "Given names",
           "checkbox1Hint": "This is your first name and middle names",
           "checkbox2": "Last name",
@@ -480,8 +480,8 @@
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
-          "errorSummaryDescriptionText": "Select which details you need to update",
-          "errorCheckboxMessage": "Select which details you need to update"
+          "errorSummaryDescriptionText": "Select which details you need to update, or select 'I do not need to update my details'",
+          "errorCheckboxMessage": "Select which details you need to update, or select 'I do not need to update my details'"
         }
       }
     },

--- a/src/views/ipv/page/update-details.njk
+++ b/src/views/ipv/page/update-details.njk
@@ -98,8 +98,8 @@
               ]
             } %}
             {% if errorState %}
-            {% set errorMessageObject = { 'text': 'pages.pyiUpdateDetails.content.checkboxes.errorMessage' | translate } %}
-            {% set checkboxConfig = checkboxConfig | setAttribute('errorMessage', errorMessageObject) %}
+              {% set errorMessageObject = { 'text': 'pages.pyiUpdateDetails.content.checkboxes.errorMessage' | translate } %}
+              {% set checkboxConfig = checkboxConfig | setAttribute('errorMessage', errorMessageObject) %}
             {% endif %}
             {{ govukCheckboxes(checkboxConfig) }}
             <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added extra error case for update-details page, welsh translations

### Why did it change

We needed an extra error handling case for users that have JS disabled and try selecting the cancel option WITH another option.

Added final design content and welsh translations

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5807](https://govukverify.atlassian.net/browse/PYIC-5807)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-5807]: https://govukverify.atlassian.net/browse/PYIC-5807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ