### PR TITLE
PYIC-6359: Fix ipvSessionId checking when rendering pages

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,9 +164,9 @@
         "filename": "src/app/ipv/middleware.test.js",
         "hashed_secret": "ec420572bb867a4f38076e71a4ac3b712326e496",
         "is_verified": false,
-        "line_number": 279
+        "line_number": 239
       }
     ]
   },
-  "generated_at": "2024-04-30T13:58:12Z"
+  "generated_at": "2024-05-13T11:18:40Z"
 }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -346,7 +346,7 @@ module.exports = {
         return res.render(getTemplatePath("errors", "page-not-found"));
       }
 
-      if (req.session?.ipvSessionId === null) {
+      if (!req.session?.ipvSessionId) {
         logError(
           req,
           {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix ipvSessionId checking when rendering pages

### Why did it change

When rendering a page we were checking that the ipvSessionId was not null in the users session. We weren't checking if it was undefined however. This meant that the user was shown the "attempt recovery" page instead of the technical error page.
