### PR TITLE
PYIC-5809: rename action for go back in page-update-name to be more generic

### DIFF
--- a/src/views/ipv/page/page-update-name.njk
+++ b/src/views/ipv/page/page-update-name.njk
@@ -68,7 +68,7 @@
           divider: 'pages.pageUpdateName.content.formRadioButtons.separateOptionsInFormText' | translate
         },
         {
-          value: "page-ipv-reuse",
+          value: "back",
           text: 'pages.pageUpdateName.content.formRadioButtons.goBackButtonText' | translate
         }
       ]


### PR DESCRIPTION
## Proposed changes

### What changed

Update the goback action in update name page to be more generic since this [PR](https://github.com/govuk-one-login/ipv-core-back/pull/1910) makes this action name misleading


### Issue tracking

https://govukverify.atlassian.net/browse/PYIC-5809

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
