### PR TITLE
PYIC-5809: add errorHref to update details page

### DIFF
--- a/src/views/ipv/page/update-details.njk
+++ b/src/views/ipv/page/update-details.njk
@@ -9,6 +9,7 @@
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.pyiUpdateDetails.content.formErrorMessage.errorSummaryTitleText' | translate %}
 {% set errorText = 'pages.pyiUpdateDetails.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#updateDetailsActionForm" %}
 
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"


### PR DESCRIPTION
## Proposed changes

Add missing `errorHref` to update details page

### Why did it change

Currently the error message in the update details page does not link to the form containing the error

### Issue tracking
- https://govukverify.atlassian.net/browse/PYIC-5809

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

