### PR TITLE
BAU: Remove contact us link from sorry-could-not-confirm-details-page

### DIFF
--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -49,7 +49,4 @@
       {{ 'general.buttons.next' | translate }}
       </button>
   </form>
-
-
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
 {% endblock %}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove contact us link from sorry-could-not-confirm-details-page

### Why did it change

This link isn't required on this page, as one of the options is for contacting the Gov UK One login team.

### Screenshot after changes
![Screenshot 2024-05-15 at 13 50 02](https://github.com/govuk-one-login/ipv-core-front/assets/13836290/eaba7c67-7b43-43f3-8b1d-84de535a6976)

### Figma
![Screenshot 2024-05-15 at 13 48 23](https://github.com/govuk-one-login/ipv-core-front/assets/13836290/d3a65179-a9d7-46c6-83a0-f72821a487de)
