### PR TITLE
PY-5960: fix bug in page name constant

### DIFF
--- a/src/constants/ipv-pages.js
+++ b/src/constants/ipv-pages.js
@@ -1,7 +1,7 @@
 module.exports = Object.freeze({
   CONFIRM_ADDRESS: "confirm-address",
   CONFIRM_NAME_DATE_BIRTH: "confirm-name-date-birth",
-  CONFIRM_DETAILS: "confirm-details",
+  CONFIRM_DETAILS: "confirm-your-details",
   NO_PHOTO_ID_EXIT_FIND_ANOTHER_WAY: "no-photo-id-exit-find-another-way",
   NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY:
     "no-photo-id-security-questions-find-another-way",


### PR DESCRIPTION
## Proposed changes
Currently the page name for `confirm-details` in constants does not match the template path `confirm-your-details`

This means that the user details will not be fetched, which we need to populate the form

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-5960

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

