### PR TITLE
PYIC-5960: fix user details bug when error ocurrs and typo

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -486,11 +486,9 @@ module.exports = {
       if (req.body.detailsCorrect === "yes") {
         // user has selected that their details are correct
         req.body.journey = "next";
-        next();
       } else if (req.body.detailsCorrect === "no" && req.body.detailsToUpdate) {
         // user has chosen details to update - so we set the correct journey
         req.body.journey = getCoiUpdateDetailsJourney(req.body.detailsToUpdate);
-        next();
       } else if (
         !req.body.detailsCorrect ||
         (req.body.detailsCorrect === "no" && !req.body.detailsToUpdate)
@@ -506,8 +504,9 @@ module.exports = {
         if (pageRequiresUserDetails(currentPage)) {
           renderOptions.userDetails = await fetchUserDetails(req);
         }
-        res.render(getIpvPageTemplatePath(currentPage), renderOptions);
+        return res.render(getIpvPageTemplatePath(currentPage), renderOptions);
       }
+      next();
     } catch (error) {
       next(error);
     }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -486,9 +486,11 @@ module.exports = {
       if (req.body.detailsCorrect === "yes") {
         // user has selected that their details are correct
         req.body.journey = "next";
+        next();
       } else if (req.body.detailsCorrect === "no" && req.body.detailsToUpdate) {
         // user has chosen details to update - so we set the correct journey
         req.body.journey = getCoiUpdateDetailsJourney(req.body.detailsToUpdate);
+        next();
       } else if (
         !req.body.detailsCorrect ||
         (req.body.detailsCorrect === "no" && !req.body.detailsToUpdate)
@@ -501,9 +503,11 @@ module.exports = {
           csrfToken: req.csrfToken(),
           context: context,
         };
-        return res.render(getIpvPageTemplatePath(currentPage), renderOptions);
+        if (pageRequiresUserDetails(currentPage)) {
+          renderOptions.userDetails = await fetchUserDetails(req);
+        }
+        res.render(getIpvPageTemplatePath(currentPage), renderOptions);
       }
-      next();
     } catch (error) {
       next(error);
     }

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1412,5 +1412,24 @@ describe("journey middleware", () => {
       expect(next).to.have.been.calledOnce;
       expect(req.body.journey).to.equal("next");
     });
+    it("should not get user details if the page does not require it", async function () {
+      CoreBackServiceStub.getProvenIdentityUserDetails = sinon.fake.returns({});
+      req.session.currentPage = "check-name-date-birth";
+      req.session.context = undefined;
+      await middleware.formHandleCoiDetailsCheck(req, res, next);
+
+      expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.not.have.been
+        .called;
+      expect(next).to.not.have.been.called;
+      expect(res.render).to.have.been.calledWith(
+        "ipv/page/check-name-date-birth.njk",
+        {
+          errorState: "radiobox",
+          pageId: "check-name-date-birth",
+          csrfToken: undefined,
+          context: undefined,
+        },
+      );
+    });
   });
 });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1330,7 +1330,11 @@ describe("journey middleware", () => {
       expect(req.body.journey).to.equal("next");
     });
     it("should set the correct error if detailsCorrect is empty and detailsToUpdate is empty", async function () {
+      CoreBackServiceStub.getProvenIdentityUserDetails = sinon.fake.returns({});
       await middleware.formHandleCoiDetailsCheck(req, res, next);
+
+      expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.have.been
+        .called;
       expect(next).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         "ipv/page/confirm-your-details.njk",
@@ -1339,13 +1343,23 @@ describe("journey middleware", () => {
           errorState: "radiobox",
           pageId: "confirm-your-details",
           csrfToken: undefined,
+          userDetails: {
+            name: undefined,
+            nameParts: { givenName: undefined, familyName: undefined },
+            dateOfBirth: undefined,
+            addresses: undefined,
+          },
         },
       );
     });
     it("should set the correct error if detailsCorrect is no and detailsToUpdate is empty", async function () {
+      CoreBackServiceStub.getProvenIdentityUserDetails = sinon.fake.returns({});
       req.body.detailsToUpdate = "";
       req.body.detailsCorrect = "no";
       await middleware.formHandleCoiDetailsCheck(req, res, next);
+
+      expect(CoreBackServiceStub.getProvenIdentityUserDetails).to.have.been
+        .called;
       expect(next).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         "ipv/page/confirm-your-details.njk",
@@ -1354,6 +1368,12 @@ describe("journey middleware", () => {
           errorState: "checkbox",
           pageId: "confirm-your-details",
           csrfToken: undefined,
+          userDetails: {
+            name: undefined,
+            nameParts: { givenName: undefined, familyName: undefined },
+            dateOfBirth: undefined,
+            addresses: undefined,
+          },
         },
       );
     });

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -1377,12 +1377,40 @@ describe("journey middleware", () => {
         },
       );
     });
-    it("should set correct journey if detailsCorrect is no and detailsToUpdate is not empty", async function () {
+    it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName,givenNames", async function () {
       req.body.detailsToUpdate = ["familyName", "givenNames"];
       req.body.detailsCorrect = "no";
       await middleware.formHandleCoiDetailsCheck(req, res, next);
       expect(next).to.have.been.calledOnce;
       expect(req.body.journey).to.equal("names-dob");
+    });
+    it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName", async function () {
+      req.body.detailsToUpdate = ["familyName"];
+      req.body.detailsCorrect = "no";
+      await middleware.formHandleCoiDetailsCheck(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal("family-name-only");
+    });
+    it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth,address", async function () {
+      req.body.detailsToUpdate = ["dateOfBirth", "address"];
+      req.body.detailsCorrect = "no";
+      await middleware.formHandleCoiDetailsCheck(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal("names-dob");
+    });
+    it("should set correct journey if detailsCorrect is no and detailsToUpdate is address", async function () {
+      req.body.detailsToUpdate = "address";
+      req.body.detailsCorrect = "no";
+      await middleware.formHandleCoiDetailsCheck(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal("address-only");
+    });
+    it("should set correct journey if detailsCorrect is yes and detailsToUpdate is not empty", async function () {
+      req.body.detailsToUpdate = ["familyName", "givenNames"];
+      req.body.detailsCorrect = "yes";
+      await middleware.formHandleCoiDetailsCheck(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(req.body.journey).to.equal("next");
     });
   });
 });

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -759,7 +759,7 @@
         "summary3": "Current home address",
         "summary4": "Date of birth",
         "detailsTitle": "There is a mistake in my name",
-        "detailsContent": "<p class=\"govuk-body\">Contact the GOV.UK One Login team if there is a mistake in your name. For example, if your name is missing letters or a hypen</p><p class=\"govuk-body\">Do not try to update your details unless the GOV.UK One Login support team has told you to.</p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a>.",
+        "detailsContent": "<p class=\"govuk-body\">Contact the GOV.UK One Login team if there is a mistake in your name. For example, if your name is missing letters or a hyphen.</p><p class=\"govuk-body\">Do not try to update your details unless the GOV.UK One Login support team has told you to.</p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a>.",
         "formTitle": "Are your details up to date?",
         "formRadioButtons": {
           "yes": "Yes",


### PR DESCRIPTION
## Proposed changes

In the new check-details page, when an error ocurrs the user details are not fetched and so not displayed when the page renders. 

### What changed

- Add a call to `fetchUserDetails` in `formHandleCoiDetailsCheck` middlware function
- Fixed typo in hypen -> hyphen
- add some more tests


### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-5960

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

