### PR TITLE
PYIC-6395: Fix page-ipv-reuse ordering and content

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -876,7 +876,8 @@
         "paragraph4": "Efallai y bydd rhai o’r manylion hyn yn cael eu defnyddio i lenwi’r ffurflenni yn awtomatig yn y gwasanaeth rydych angen ei ddefnyddio.",
         "subHeading2": "Eich manylion",
         "userDetailsInformation": {
-          "fullName": "Enw",
+          "fullName": "Enw wat",
+          "fullNameCoi": "Enw llawn",
           "dateOfBirth": "Dyddiad geni",
           "currentAddress": "Cyfeiriad cartref presennol",
           "previousAddress": "Cyfeiriad blaenorol"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -878,6 +878,7 @@
         "subHeading2": "Your details",
         "userDetailsInformation": {
           "fullName": "Name",
+          "fullNameCoi": "Full name",
           "dateOfBirth": "Date of birth",
           "currentAddress": "Current home address",
           "previousAddress": "Previous address"

--- a/src/views/ipv/page/page-ipv-reuse.njk
+++ b/src/views/ipv/page/page-ipv-reuse.njk
@@ -10,7 +10,7 @@
         data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvReuse.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph1' | translate }}</p>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph2' | translate }}</p>
-    
+
     <h2 class="govuk-heading-m">{{ 'pages.pageIpvReuse.content.subHeading' | translate }}</h2>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph3' | translate }}</p>
     <p class="govuk-body">{{ 'pages.pageIpvReuse.content.paragraph4' | translate }}</p>
@@ -20,12 +20,15 @@
     {% set rows = [
         {
             key: {
-                text: 'pages.pageIpvReuse.content.userDetailsInformation.fullName' | translate
+                text: 'pages.pageIpvReuse.content.userDetailsInformation.fullName' | translateWithContext(context)
             },
             value: {
                 text: userDetails.name
             }
-        },
+        }
+    ] %}
+
+    {% set dobRow =
         {
             key: {
                 text: 'pages.pageIpvReuse.content.userDetailsInformation.dateOfBirth' | translate
@@ -34,9 +37,16 @@
                 text: userDetails.dateOfBirth | GDSDate
             }
         }
-    ] %}
+    %}
 
-    {% for addressDetail in userDetails.addresses %}
+    {% if context == "coi" %}
+        {% set addressesToDisplay = [userDetails.addresses[0]] %}
+    {% else %}
+        {% set rows = (rows.push(dobRow), rows) %}
+        {% set addressesToDisplay = userDetails.addresses %}
+    {% endif %}
+
+    {% for addressDetail in addressesToDisplay %}
         {% set addressRow =
             {
                 key:
@@ -51,6 +61,10 @@
         %}
         {% set rows =(rows.push(addressRow), rows) %}
     {% endfor %}
+
+    {% if context == "coi" %}
+        {% set rows = (rows.push(dobRow), rows) %}
+    {% endif %}
 
     {{ govukSummaryList({
         rows: rows


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix page-ip-reuse ordering and content

### Why did it change

This updates the ordering of the rows on the page-ipv-reuse page - the DOB should have been below the address.

This also ensures that we only show the current address for the COI version - previously we would have rendered previous addresses.

It also fixes the content for "Full name", in both English and Welsh.

### Screenshot
<img width="725" alt="Screenshot 2024-05-16 at 14 19 37" src="https://github.com/govuk-one-login/ipv-core-front/assets/13836290/270cf20b-fed1-4efa-a43f-155061cb1afe">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6395](https://govukverify.atlassian.net/browse/PYIC-6395)



[PYIC-6395]: https://govukverify.atlassian.net/browse/PYIC-6395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ