### PR TITLE
PYIC-6397: Add back link to update-detail page

### DIFF
--- a/src/views/ipv/page/update-details.njk
+++ b/src/views/ipv/page/update-details.njk
@@ -10,6 +10,8 @@
 {% set errorTitle = 'pages.pyiUpdateDetails.content.formErrorMessage.errorSummaryTitleText' | translate %}
 {% set errorText = 'pages.pyiUpdateDetails.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
 {% set errorHref = "#updateDetailsActionForm" %}
+{% set showBack = true %}
+{% set hrefBack = "/ipv/journey/update-details/back" %}
 
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add back link to update-detail page. See the core-back PR that allows this here: https://github.com/govuk-one-login/ipv-core-back/pull/1926

### Why did it change

This adds the back link to return to the reuse page, as requested by UCD.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6397](https://govukverify.atlassian.net/browse/PYIC-6397)


[PYIC-6397]: https://govukverify.atlassian.net/browse/PYIC-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ