### PR TITLE
PYIC-6313: update error message for multiple-doc-check page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -860,8 +860,8 @@
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
-          "errorSummaryDescriptionText": "Dewiswch sut rydych eisiau parhau",
-          "errorRadioMessage": "Dewiswch sut rydych eisiau parhau"
+          "errorSummaryDescriptionText": "Dewiswch os ydych am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth",
+          "errorRadioMessage": "Dewiswch os ydych am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -861,8 +861,8 @@
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
-          "errorSummaryDescriptionText": "Select how you want to continue",
-          "errorRadioMessage": "Select how you want to continue"
+          "errorSummaryDescriptionText": "Select if you want to use your UK photocard driving licence or UK passport to prove your identity",
+          "errorRadioMessage": "Select if you want to use your UK photocard driving licence or UK passport to prove your identity"
         }
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Error message for unchecked radio button has been updated (both English and Welsh translations) for the `page-multiple-doc-check` page.

***Note:*** The ticket also asks for content updates to the `pyi-post-office` page no changes were needed as it already had the required error text.

### Why did it change
Content updates to match the final designs specifications.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6313](https://govukverify.atlassian.net/browse/PYIC-6313)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6313]: https://govukverify.atlassian.net/browse/PYIC-6313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ