### PR TITLE
BAU: Update ids of radio buttons on confirm-your-details

### DIFF
--- a/src/views/ipv/page/confirm-your-details.njk
+++ b/src/views/ipv/page/confirm-your-details.njk
@@ -96,7 +96,7 @@
 
 
         {% set radiosConfig = {
-        idPrefix: "journey",
+        idPrefix: "up-to-date",
         name: "detailsCorrect",
         fieldset: {
             legend: {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update ids of radio buttons on confirm-your-details

### Why did it change

The new confirm-your-details page has radio buttons that conditionally reveal checkboxes.

The radio buttons id's were clashing with the first two checkboxes. This is because the same idPrefix had been used. Ids in html should be unique.

This changes the prefix for the radio buttons to differentiate them.
