### PR TITLE
PYIC-5828: add welsh translations to pages

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -620,7 +620,7 @@
       "headerCoiNoAddress": "Rydych wedi rhoi eich enw newydd i ni",
       "content": {
         "paragraph1": "Byddwch angen rhoi eich cyfeiriad cartref presennol (a’ch cyfeiriad blaenorol, os ydych chi wedi symud yn ddiweddar) pan fyddwch yn parhau.",
-        "paragraph1CoiAddress": "TBC",
+        "paragraph1CoiAddress": "Bydd angen i chi roi eich cyfeiriad cartref presennol (a chyfeiriad blaenorol os ydych wedi symud yn ddiweddar) pan fyddwch yn parhau.",
         "paragraph1CoiNoAddress": "Bydd angen i ni wirio eich manylion pan fyddwch yn parhau."
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -678,18 +678,16 @@
     "updateNameDateBirth": {
       "title": "Diweddaru eich enw neu ddyddiad geni",
       "header": "Diweddaru eich enw neu ddyddiad geni",
-      "titleCoi": "TODO: Update your full name or date of birth",
-      "headerCoi": "TODO: Update your full name or date of birth",
+      "titleCoi": "Diweddaru eich enw llawn neu ddyddiad geni",
+      "headerCoi": "Diweddaru eich enw llawn neu ddyddiad geni",
       "content": {
-        "paragraph1": "I ddiweddaru eich enw neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
-        "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
-        "warningTextFallback": "Rhybudd",
+        "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
         "radioButtonHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",
           "no": "Ewch yn ôl i wirio eich manylion eto",
           "noHint": "",
-          "noHintCoi": "TODO: You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
+          "noHintCoi": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
@@ -1129,39 +1127,36 @@
       }
     },
     "pageUpdateName": {
-      "title": "Update your name using the GOV.UK ID Check app",
-      "header": "Update your name using the GOV.UK ID Check app",
+      "title": "Diweddaru eich enw gan ddefnyddio'r ap GOV.UK ID Check",
+      "header": "Diweddaru eich enw gan ddefnyddio'r ap GOV.UK ID Check",
       "content": {
-        "paragraph1": "To update your details, you need to prove your identity again with your new details.",
-        "paragraph2": "You'll need:",
-        "list1": "photo ID with the name you want GOV.UK One Login to use",
-        "list2": "to tell us where you've lived for the last 3 months",
-        "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
-        "warningText": "You may not be able to use your GOV.UK One Login if we cannot confirm your identity using your new details.",
-        "warningTextFallback": "Warning",
-        "subHeading1": "If there is a mistake in your name",
-        "paragraph4": "If there is a mistake in your name, do not try to prove your identity again unless the GOV.UK One Login support team has told you to.",
-        "paragraph5": "For example, if your name is missing letters or a hyphen, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> instead.",
-        "subHeading2": "If you need to use the service now",
-        "paragraph6": "Your proof of identity is still valid even if your details are out of date.",
-        "paragraph7": "You can use your saved details to access the service you need to use.",
-        "subHeading3": "What would you like to do?",
+        "paragraph1": "I ddiweddaru eich enw, mae angen i chi brofi eich hunaniaeth eto gyda'ch enw newydd.",
+        "paragraph2": "Byddwch angen:",
+        "list1": "ID gyda llun gyda'r enw rydych chi ei eisiau GOV.UK One Login ei ddefnyddio",
+        "list2": "dweud wrthym ble rydych chi wedi byw am y 3 mis diwethaf",
+        "paragraph3": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">ba ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
+        "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
+        "warningTextFallback": "Rhybudd",
+        "subHeading1": "Os oes camgymeriad yn eich enw",
+        "paragraph4": "Os oes camgymeriad yn eich enw, peidiwch â cheisio profi eich hunaniaeth eto oni bai bod tîm cymorth GOV.UK One Login wedi dweud wrthych i wneud hynny.",
+        "paragraph5": "Er enghraifft, os yw'ch enw gyda llythrennau ar goll neu gysylltnod, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a> yn lle hynny.",
+        "subHeading2": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "updateDetailsButtonText": "Update your details using the GOV.UK ID Check app",
-          "updateDetailsButtonTextHint": "We'll guide you through this",
-          "continueServiceButtonText": "Continue to the service you were trying to use",
-          "continueServiceButtonTextHint": "You can update your details later",
-          "goBackButtonText": "Go back and check your details again",
-          "separateOptionsInFormText": "or"
+          "updateDetailsButtonText": "Diweddaru eich enw gan ddefnyddio'r ap GOV.UK ID Check",
+          "updateDetailsButtonTextHint": "Byddwn yn eich tywys drwy hyn.",
+          "continueServiceButtonText": "Parhau i ddefnyddio'r gwasanaeth roeddech yn ceisio ei ddefnyddio",
+          "continueServiceButtonTextHint": "Gallwch ddiweddaru'ch manylion yn nes ymlaen.",
+          "goBackButtonText": "Ewch yn ôl i wirio eich manylion eto",
+          "separateOptionsInFormText": "neu"
         },
         "formErrorMessage": {
-          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryTitleText": "Mae problem",
           "errorSummaryDescriptionText": "Select how you want to continue",
           "errorRadioMessage": "Select how you want to continue"
         },
         "cannotUseInformation": {
-          "summary": "I cannot use the GOV.UK ID Check app",
-          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Contact the GOV.UK One Login team if you cannot use the app.</p>We'll need to delete your details so you can prove your identity again with your new details.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a></p>"
+          "summary": "Os na allwch ddefnyddio'r ap GOV.UK ID Check",
+          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Cysylltwch â'r tîm GOV.UK One Login os na allwch ddefnyddio'r ap GOV.UK ID Check.</p>Efallai y bydd angen i chi ddileu'ch GOV.UK One Login. Yna gallwch greu un newydd a cheisio profi eich hunaniaeth eto gyda'ch manylion newydd.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Cysylltu â'r tîm GOV.UK One Login (agor mewn tab newydd).</a></p>"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1156,8 +1156,8 @@
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
-          "errorSummaryDescriptionText": "Select how you want to continue",
-          "errorRadioMessage": "Select how you want to continue"
+          "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
         },
         "cannotUseInformation": {
           "summary": "Os na allwch ddefnyddio'r ap GOV.UK ID Check",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -682,6 +682,8 @@
       "headerCoi": "Diweddaru eich enw llawn neu ddyddiad geni",
       "content": {
         "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
+        "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
+        "warningTextFallback": "Rhybudd",
         "radioButtonHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1140,7 +1140,10 @@
         "subHeading1": "Os oes camgymeriad yn eich enw",
         "paragraph4": "Os oes camgymeriad yn eich enw, peidiwch â cheisio profi eich hunaniaeth eto oni bai bod tîm cymorth GOV.UK One Login wedi dweud wrthych i wneud hynny.",
         "paragraph5": "Er enghraifft, os yw'ch enw gyda llythrennau ar goll neu gysylltnod, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a> yn lle hynny.",
-        "subHeading2": "Beth hoffech chi ei wneud?",
+        "subHeading2": "Os ydych angen defnyddio'r gwasanaeth nawr",
+        "paragraph6": "Mae eich prawf hunaniaeth yn dal i fod yn ddilys hyd yn oed os yw'ch manylion ddim yn gyfredol.",
+        "paragraph7": "Gallwch ddefnyddio'ch manylion sydd wedi'u harbed i gael mynediad i'r gwasanaeth rydych angen ei ddefnyddio.",
+        "subHeading3": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "updateDetailsButtonText": "Diweddaru eich enw gan ddefnyddio'r ap GOV.UK ID Check",
           "updateDetailsButtonTextHint": "Byddwn yn eich tywys drwy hyn.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -787,6 +787,8 @@
       "headerCoi": "Update your full name or date of birth",
       "content": {
         "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
+        "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
+        "warningTextFallback": "Warning",
         "radioButtonHeading": "What would you like to do?",
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your name or date of birth",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -786,9 +786,7 @@
       "titleCoi": "Update your full name or date of birth",
       "headerCoi": "Update your full name or date of birth",
       "content": {
-        "paragraph1": "To update your name or date of birth, you need to contact the GOV.UK One Login team.",
-        "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
-        "warningTextFallback": "Warning",
+        "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
         "radioButtonHeading": "What would you like to do?",
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your name or date of birth",
@@ -1133,22 +1131,19 @@
       "title": "Update your name using the GOV.UK ID Check app",
       "header": "Update your name using the GOV.UK ID Check app",
       "content": {
-        "paragraph1": "To update your details, you need to prove your identity again with your new details.",
+        "paragraph1": "To update your name, you need to prove your identity again with your new name.",
         "paragraph2": "You'll need:",
         "list1": "photo ID with the name you want GOV.UK One Login to use",
         "list2": "to tell us where you've lived for the last 3 months",
         "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
-        "warningText": "You may not be able to use your GOV.UK One Login if we cannot confirm your identity using your new details.",
+        "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
         "warningTextFallback": "Warning",
         "subHeading1": "If there is a mistake in your name",
         "paragraph4": "If there is a mistake in your name, do not try to prove your identity again unless the GOV.UK One Login support team has told you to.",
         "paragraph5": "For example, if your name is missing letters or a hyphen, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> instead.",
-        "subHeading2": "If you need to use the service now",
-        "paragraph6": "Your proof of identity is still valid even if your details are out of date.",
-        "paragraph7": "You can use your saved details to access the service you need to use.",
-        "subHeading3": "What would you like to do?",
+        "subHeading2": "What would you like to do?",
         "formRadioButtons": {
-          "updateDetailsButtonText": "Update your details using the GOV.UK ID Check app",
+          "updateDetailsButtonText": "Update your name using the GOV.UK ID Check app",
           "updateDetailsButtonTextHint": "We'll guide you through this",
           "continueServiceButtonText": "Continue to the service you were trying to use",
           "continueServiceButtonTextHint": "You can update your details later",
@@ -1161,8 +1156,8 @@
           "errorRadioMessage": "Select how you want to continue"
         },
         "cannotUseInformation": {
-          "summary": "I cannot use the GOV.UK ID Check app",
-          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Contact the GOV.UK One Login team if you cannot use the app.</p>We'll need to delete your details so you can prove your identity again with your new details.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a></p>"
+          "summary": "If you cannot use the GOV.UK ID Check app",
+          "text": "<p class=\"govuk-body govuk-!-margin-bottom-2\">Contact the GOV.UK One Login team if you cannot use the GOV.UK ID Check app.</p>You may need to delete your GOV.UK One Login. Then you can create a new one and try to prove your identity again with your new details.<p class=\"govuk-body govuk-!-margin-bottom-2\"></p><p class=\"govuk-body govuk-!-margin-bottom-2\"><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab).</a></p>"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1157,8 +1157,8 @@
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
-          "errorSummaryDescriptionText": "Select how you want to continue",
-          "errorRadioMessage": "Select how you want to continue"
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
         },
         "cannotUseInformation": {
           "summary": "If you cannot use the GOV.UK ID Check app",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1141,7 +1141,10 @@
         "subHeading1": "If there is a mistake in your name",
         "paragraph4": "If there is a mistake in your name, do not try to prove your identity again unless the GOV.UK One Login support team has told you to.",
         "paragraph5": "For example, if your name is missing letters or a hyphen, <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">contact the GOV.UK One Login team (opens in new tab)</a> instead.",
-        "subHeading2": "What would you like to do?",
+        "subHeading2": "If you need to use the service now",
+        "paragraph6": "Your proof of identity is still valid even if your details are out of date.",
+        "paragraph7": "You can use your saved details to access the service you need to use.",
+        "subHeading3": "What would you like to do?",
         "formRadioButtons": {
           "updateDetailsButtonText": "Update your name using the GOV.UK ID Check app",
           "updateDetailsButtonTextHint": "We'll guide you through this",

--- a/src/views/ipv/page/page-update-name.njk
+++ b/src/views/ipv/page/page-update-name.njk
@@ -37,10 +37,6 @@
   <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph4' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pageUpdateName.content.paragraph5' | translate( { url: contactUsUrl } ) | safe}}</p>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.subHeading2' | translate }}</h2>
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph6' | translate }}</p>
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph7' | translate }}</p>
-
   <form class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="pageUpdateNameOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% set radiosConfig = {
@@ -48,7 +44,7 @@
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.pageUpdateName.content.subHeading3' | translate,
+          text: 'pages.pageUpdateName.content.subHeading2' | translate,
           classes: "govuk-fieldset__legend--m"
         }
       },

--- a/src/views/ipv/page/page-update-name.njk
+++ b/src/views/ipv/page/page-update-name.njk
@@ -37,6 +37,10 @@
   <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph4' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pageUpdateName.content.paragraph5' | translate( { url: contactUsUrl } ) | safe}}</p>
 
+  <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.subHeading2' | translate }}</h2>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph6' | translate }}</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph7' | translate }}</p>
+
   <form class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="pageUpdateNameOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% set radiosConfig = {
@@ -44,7 +48,7 @@
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.pageUpdateName.content.subHeading2' | translate,
+          text: 'pages.pageUpdateName.content.subHeading3' | translate,
           classes: "govuk-fieldset__legend--m"
         }
       },

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -17,12 +17,6 @@
 
     <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translate }}</p>
 
-    {{ govukWarningText({
-        text: 'pages.updateNameDateBirth.content.warningText' | translate,
-        iconFallbackText: 'pages.updateNameDateBirth.content.warningTextFallback' | translate
-        }) }}
-
-
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {% set radiosConfig = {

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -17,6 +17,11 @@
 
     <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translate }}</p>
 
+    {{ govukWarningText({
+        text: 'pages.updateNameDateBirth.content.warningText' | translate,
+        iconFallbackText: 'pages.updateNameDateBirth.content.warningTextFallback' | translate
+        }) }}
+
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {% set radiosConfig = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the welsh translations for the `dcmaw-success`, `update-name` and `update-name-date-birth` pages.

### Why did it change
Translations had been updated since the work for the pages had been done.

[PYIC-5828](https://govukverify.atlassian.net/browse/PYIC-5828)

[PYIC-5828]: https://govukverify.atlassian.net/browse/PYIC-5828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ