### PR TITLE
BAU Remove PagerDuty action for canary alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1444,12 +1444,6 @@ Resources:
       AlarmDescription: >
         The number of HTTP 5XX server error codes that originate from the
         target group is greater than 5% of all traffic.
-      ActionsEnabled: true
-      AlarmActions:
-        - !ImportValue sns-topics-AlarmTopic
-      OKActions:
-        - !ImportValue sns-topics-AlarmTopic
-      InsufficientDataActions: [ ]
       EvaluationPeriods: 2
       DatapointsToAlarm: 2
       Threshold: 5


### PR DESCRIPTION
Remove actions for the alarm created for core-front canary monitoring - the actions topic is wired to PagerDuty but we don't want this alarm to be a PD alert since it's specifically designed for canary monitoring so runs over a very short window and may be overly sensitive.

If a canary deployment fails we'll still see a notification of the failure in #di-ipv-core-notifications.