### PR TITLE
PYIC-6598: fix a11y issues for confirm-details page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -777,7 +777,8 @@
           "checkbox4": "Date of birth"
         },
         "errorCheckBoxMessage": "Select which details you need to update",
-        "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date."
+        "warningTextContent": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
+        "warningTextFallback": "Warning"
       }
     },
     "updateNameDateBirth": {

--- a/src/views/ipv/page/confirm-your-details.njk
+++ b/src/views/ipv/page/confirm-your-details.njk
@@ -24,30 +24,53 @@
 
     <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{ 'pages.confirmDetails.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.confirmDetails.content.paragraph1' | translate }}</p>
-    <h3 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summaryHeading' | translate }}</h3>
+    <h2 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summaryHeading' | translate }}</h2>
 
-    <h3 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summary1' | translate }}</h3>
-    <p class="govuk-body">{{ userDetails.nameParts.givenName }}</p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    {% set rows = [
+      {
+        key: {
+          text: 'pages.confirmDetails.content.summary1' | translate
+        },
+        value: {
+          text: userDetails.nameParts.givenName
+        }
+      },
+      {
+        key: {
+          text: 'pages.confirmDetails.content.summary2' | translate
+        },
+        value: {
+          text: userDetails.nameParts.familyName
+        }
+      },
+      {
+        key: {
+          text: 'pages.confirmDetails.content.summary3' | translate
+        },
+        value: {
+          text: userDetails.addresses[0].addressDetailHtml | safe
+        }
+      },
+      {
+        key: {
+          text: 'pages.confirmDetails.content.summary4' | translate
+        },
+        value: {
+          text: userDetails.dateOfBirth | GDSDate
+        }
+      }
+    ] %}
 
-    <h3 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summary2' | translate }}</h3>
-    <p class="govuk-body">{{ userDetails.nameParts.familyName }}</p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-    <h3 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summary3' | translate }}</h3>
-    <p class="govuk-body">{{ userDetails.addresses[0].addressDetailHtml | safe }}</p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-    <h3 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summary4' | translate }}</h3>
-    <p class="govuk-body">{{ userDetails.dateOfBirth | GDSDate }}</p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    {{ govukSummaryList({
+      rows: rows
+    }) }}
 
     {{ govukDetails({
         summaryText: 'pages.confirmDetails.content.detailsTitle' | translate,
         text: 'pages.confirmDetails.content.detailsContent' | translate({ url: contactUsUrl }) | safe
     }) }}
 
-    <form id="confirmDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
+    <form id="confirmDetailsActionForm" action="§/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {% set checkboxConfig = {
@@ -130,8 +153,8 @@
         {{ govukRadios(radiosConfig) }}
 
         {{ govukWarningText({
-        text: 'pages.confirmDetails.content.warningText' | translate,
-        iconFallbackText: 'pages.confirmDetails.content.warningText' | translate
+        text: 'pages.confirmDetails.content.warningTextContent' | translate,
+        iconFallbackText: 'pages.confirmDetails.content.warningTextFallback' | translate
         }) }}
         <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
         {{ 'general.buttons.next' | translate }}

--- a/src/views/ipv/page/confirm-your-details.njk
+++ b/src/views/ipv/page/confirm-your-details.njk
@@ -70,7 +70,7 @@
         text: 'pages.confirmDetails.content.detailsContent' | translate({ url: contactUsUrl }) | safe
     }) }}
 
-    <form id="confirmDetailsActionForm" action="§/ipv/page/{{ pageId }}" method="POST">
+    <form id="confirmDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {% set checkboxConfig = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- updated page to use `SummaryList` component
- added h2 heading
- updated warning text in assistive text span

| Before | After |
| ------- | ------|
| <img width="436" alt="Screenshot 2024-06-04 at 12 10 33" src="https://github.com/govuk-one-login/ipv-core-front/assets/120715154/f04d19f1-cbe9-41ce-8494-419f5a5d2d08"> | <img width="512" alt="Screenshot 2024-06-04 at 12 10 00" src="https://github.com/govuk-one-login/ipv-core-front/assets/120715154/0513a709-2fb5-4565-8445-4daa08a9385f"> | 


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6598](https://govukverify.atlassian.net/browse/PYIC-6598)


[PYIC-6598]: https://govukverify.atlassian.net/browse/PYIC-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ