### PR TITLE
PYIC-5926: send x-forwarded-for as ip-address header

### DIFF
--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -15,10 +15,12 @@ const { createAxiosInstance } = require("../app/shared/axiosHelper");
 const axiosInstance = createAxiosInstance(API_BASE_URL);
 
 function generateAxiosConfig(url, req) {
+  const personalDataHeaders = createPersonalDataHeaders(url, req);
   return {
     headers: {
       "content-type": "application/json",
       "x-request-id": req.id,
+      "ip-address": personalDataHeaders["x-forwarded-for"] || "unknown", // Passing x-forwarded-for as ip-address because AWS appends its own incorrect IP address when using "x-forwarded-for"
       "feature-set": req.session.featureSet,
       ...(req.session.ipvSessionId && {
         "ipv-session-id": req.session.ipvSessionId,
@@ -26,7 +28,7 @@ function generateAxiosConfig(url, req) {
       ...(req.session.clientOauthSessionId && {
         "client-session-id": req.session.clientOauthSessionId,
       }),
-      ...createPersonalDataHeaders(url, req),
+      ...personalDataHeaders,
     },
     logger: req.log,
   };

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -19,7 +19,6 @@ function generateAxiosConfig(url, req) {
     headers: {
       "content-type": "application/json",
       "x-request-id": req.id,
-      "ip-address": req.ip || "unknown",
       "feature-set": req.session.featureSet,
       ...(req.session.ipvSessionId && {
         "ipv-session-id": req.session.ipvSessionId,

--- a/src/services/coreBackService.test.js
+++ b/src/services/coreBackService.test.js
@@ -11,6 +11,7 @@ const configStub = {
 };
 describe("CoreBackService", () => {
   let axiosInstanceStub = {};
+  let passthroughHeaders = {};
   let CoreBackService;
 
   let axiosStub = { createAxiosInstance: () => axiosInstanceStub };
@@ -28,20 +29,21 @@ describe("CoreBackService", () => {
   beforeEach(() => {
     axiosInstanceStub.post = sinon.fake();
     axiosInstanceStub.get = sinon.fake();
+    passthroughHeaders.createPersonalDataHeaders = sinon.stub().returns({
+      "txma-audit-encoded": "dummy-txma-header",
+      "x-forwarded-for": "127.0.0.2",
+    });
 
     CoreBackService = proxyquire("./coreBackService", {
       "../lib/config": configStub,
       "../app/shared/axiosHelper": axiosStub,
+      "@govuk-one-login/frontend-passthrough-headers": passthroughHeaders,
     });
   });
 
   it("should postJourneyEvent with correct parameters and headers", async () => {
     // Arrange
     const event = "test_event";
-    req.headers = {
-      "txma-audit-encoded": "dummy-txma-header",
-      "x-forwarded-for": "127.0.0.1",
-    };
 
     // Act
     await CoreBackService.postJourneyEvent(req, event);
@@ -54,11 +56,12 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
+          "ip-address": "127.0.0.2",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
           "txma-audit-encoded": "dummy-txma-header",
-          "x-forwarded-for": "127.0.0.1",
+          "x-forwarded-for": "127.0.0.2",
         },
         logger: undefined,
       },
@@ -68,10 +71,6 @@ describe("CoreBackService", () => {
   it("should postSessionInitialise with correct parameters and headers", async () => {
     // Arrange
     const authParams = { someAuthParam: "someValue" };
-    req.headers = {
-      "txma-audit-encoded": "dummy-txma-header",
-      "x-forwarded-for": "127.0.0.1",
-    };
 
     // Act
     await CoreBackService.postSessionInitialise(req, authParams);
@@ -84,11 +83,12 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
+          "ip-address": "127.0.0.2",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
           "txma-audit-encoded": "dummy-txma-header",
-          "x-forwarded-for": "127.0.0.1",
+          "x-forwarded-for": "127.0.0.2",
         },
         logger: undefined,
       },
@@ -99,10 +99,6 @@ describe("CoreBackService", () => {
     // Arrange
     const body = { test_param: "someValue" };
     const errorDetails = { error_param: "anotherValue" };
-    req.headers = {
-      "txma-audit-encoded": "dummy-txma-header",
-      "x-forwarded-for": "127.0.0.1",
-    };
 
     // Act
     await CoreBackService.postCriCallback(req, body, errorDetails);
@@ -115,11 +111,12 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
+          "ip-address": "127.0.0.2",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
           "txma-audit-encoded": "dummy-txma-header",
-          "x-forwarded-for": "127.0.0.1",
+          "x-forwarded-for": "127.0.0.2",
         },
         logger: undefined,
       },
@@ -130,10 +127,6 @@ describe("CoreBackService", () => {
     // Arrange
     const body = { test_param: "someValue" };
     const errorDetails = { error_param: "anotherValue" };
-    req.headers = {
-      "txma-audit-encoded": "dummy-txma-header",
-      "x-forwarded-for": "127.0.0.1",
-    };
 
     // Act
     await CoreBackService.getProvenIdentityUserDetails(req, body, errorDetails);
@@ -142,11 +135,12 @@ describe("CoreBackService", () => {
       headers: {
         "content-type": "application/json",
         "x-request-id": "test_request_id",
+        "ip-address": "127.0.0.2",
         "feature-set": "test_feature_set",
         "ipv-session-id": "test_ipv_session_id",
         "client-session-id": "test_client_session_id",
         "txma-audit-encoded": "dummy-txma-header",
-        "x-forwarded-for": "127.0.0.1",
+        "x-forwarded-for": "127.0.0.2",
       },
       logger: undefined,
     });

--- a/src/services/coreBackService.test.js
+++ b/src/services/coreBackService.test.js
@@ -54,7 +54,6 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
-          "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -85,7 +84,6 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
-          "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -117,7 +115,6 @@ describe("CoreBackService", () => {
         headers: {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
-          "ip-address": "127.0.0.1",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -145,7 +142,6 @@ describe("CoreBackService", () => {
       headers: {
         "content-type": "application/json",
         "x-request-id": "test_request_id",
-        "ip-address": "127.0.0.1",
         "feature-set": "test_feature_set",
         "ipv-session-id": "test_ipv_session_id",
         "client-session-id": "test_client_session_id",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Use x-forwarded-for as ip-address.

### What changed

- Sending  ip-address header with ip address value from  x-forwarded-for header.  

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To send correct ip address to core back API.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5926](https://govukverify.atlassian.net/browse/PYIC-5926)


[PYIC-5926]: https://govukverify.atlassian.net/browse/PYIC-5926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ