### PR TITLE
PYIC-4859: Add /journey/:pageId/:action route comment

### DIFF
--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -69,5 +69,8 @@ router.post(
   handleJourneyAction,
 );
 
+// Enables a link in the frontend to iterate the journey state
+// This is needed because some redirects must be done with links, not forms
 router.get("/journey/:pageId/:action", updateJourneyState);
+
 module.exports = router;


### PR DESCRIPTION
## Proposed changes

### What changed

- Add /journey/:pageId/:action route comment

### Why did it change

- To make the updateJourneyState make more sense. The naming seemed fine to me though, just needed some context on its use.

### Issue tracking

- [PYIC-4859](https://govukverify.atlassian.net/browse/PYIC-4859)


[PYIC-4859]: https://govukverify.atlassian.net/browse/PYIC-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ