### PR TITLE
IPS-623: Add FE alarms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -953,6 +953,17 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
+  ECSFatalErrorMetricFilter:
+    Condition: IsNotDevelopment
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
+          MetricName: "ECSFatalerror-message"
+
   #
   # REST API Gateway
   #
@@ -1251,6 +1262,18 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 
+  APIGWFatalErrorMetricFilter:
+    Condition: IsNotDevelopment
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref APIGWAccessLogsGroup
+      FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
+          MetricName: "APIGWFatalerror-message"
+
   CoreFrontSessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -1339,6 +1362,12 @@ Resources:
               StringEquals:
                 kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
 
+####################################################################
+#                                                                  #
+# Monitoring & Alerts                                              #
+#                                                                  #
+####################################################################
+
   FrontLoadBalancer5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotDevelopment
@@ -1382,7 +1411,7 @@ Resources:
         - !ImportValue sns-topics-AlarmTopic
       OKActions:
         - !ImportValue sns-topics-AlarmTopic
-      InsufficientDataActions: [ ]
+      InsufficientDataActions: []
       EvaluationPeriods: 2
       DatapointsToAlarm: 2
       Threshold: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorLimit ]
@@ -1558,6 +1587,236 @@ Resources:
                   Value: !Sub check-existing-identity-${Environment}
             Period: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, lambdaInvokeCompareWindow ]
             Stat: Sum
+
+  FE5XXErrorAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
+      AlarmDescription: Trigger the alarm if errorThreshold exceeds 10% with a minimum of 150 invocations and a minimum of 5 errors in 5 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<150 || error<5,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations) * 100
+
+  FatalErrorAlarm:
+    Condition: IsNotDevelopment
+    DependsOn:
+      - "ECSFatalErrorMetricFilter"
+      - "APIGWFatalErrorMetricFilter"
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FatalErrorAlarm"
+      AlarmDescription: "Trigger an alarm when Fatal Error occurs"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      MetricName: FatalErrorMessage
+      Namespace: !Sub "${AWS::StackName}/LogMessages"
+      Statistic: Sum
+      Dimensions: []
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  FELatencyAlarmP95:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FELatencyAlarmP95"
+      AlarmDescription: Trigger the alarm if less than 95% of requests has a latency of less than 1 second with a minimum of 25 invocations in 2 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 1000
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: latencyThreshold
+          Label: latencyThreshold
+          ReturnData: true
+          Expression: IF(invocations<25,0,latency95Percentile)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: latency95Percentile
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Latency
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: p95
+
+  FELatencyAlarmP99:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FELatencyAlarmP99"
+      AlarmDescription: Trigger the alarm if less than 99% of requests has a latency of less than 2.5 second with a minimum of 150 invocations in 2 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 2500
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: latencyThreshold
+          Label: latencyThreshold
+          ReturnData: true
+          Expression: IF(invocations<150,0,latency99Percentile)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: latency99Percentile
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Latency
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: p99
+
+  FELowContainerTaskCountAlarm:
+    Condition: IsProduction
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FELowContainerTaskCountAlarm"
+      AlarmDescription: Trigger a warning if the running container task count drops below 2
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: LessThanOrEqualToThreshold
+      TreatMissingData: breaching
+      Metrics:
+        - Id: containerTaskCount
+          ReturnData: true
+          MetricStat:
+            Metric:
+              Namespace: ECS/ContainerInsights
+              MetricName: RunningTaskCount
+              Dimensions:
+                - Name: ClusterName
+                  Value: !Ref CoreFrontCluster
+                - Name: ServiceName
+                  Value: !GetAtt CoreFrontService.Name
+            Period: 60
+            Stat: Minimum
+
+  FELowContainerTaskCountCriticalAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FELowContainerTaskCountCriticalAlarm"
+      AlarmDescription: Trigger a critical alert if the running container task count drops below 1
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: LessThanOrEqualToThreshold
+      TreatMissingData: breaching
+      Metrics:
+        - Id: containerTaskCount
+          ReturnData: true
+          MetricStat:
+            Metric:
+              Namespace: ECS/ContainerInsights
+              MetricName: RunningTaskCount
+              Dimensions:
+                - Name: ClusterName
+                  Value: !Ref CoreFrontCluster
+                - Name: ServiceName
+                  Value: !GetAtt CoreFrontService.Name
+            Period: 60
+            Stat: Maximum
 
   ECSBlueGreenDeploymentStack:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
### What changed

Added the following alarms:
- FE5XXErrorAlarm
- FatalErrorAlarm
- FELatencyAlarmP95
- FELatencyAlarmP99
- FELowContainerTaskCountAlarm (in prod only, containers =< 1)
- FELowContainerTaskCountCriticalAlarm (containers = 0)

The topics and alarms are not yet linked to Pagerduty. They will be monitored in production and tweaked as necessary before this change is made.

### Why did it change

- Improved monitoring and alerts

### Issue tracking
- [IPS-623] (https://govukverify.atlassian.net/browse/IPS-623)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

Deployed to dev:

![image](https://github.com/govuk-one-login/ipv-core-front/assets/153090281/be536a4a-d4b8-4729-9f21-3af70ab837ad)


[IPS-623]: https://govukverify.atlassian.net/browse/IPS-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ