### PR TITLE
LS-2142 Review Autoscaling Policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -594,8 +594,7 @@ Resources:
         Cooldown: 30
         MinAdjustmentMagnitude: 6
         StepAdjustments:
-          - MetricIntervalLowerBound: 0
-            MetricIntervalUpperBound: 20
+          - MetricIntervalUpperBound: 20
             ScalingAdjustment: 100
           - MetricIntervalLowerBound: 20
             MetricIntervalUpperBound: 30

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -79,7 +79,6 @@ Mappings:
       nodeOldSpaceLimit: "384"
       nodeEnv: "development"
       languageToggle: true
-      desiredTaskCount: 1
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
@@ -97,7 +96,6 @@ Mappings:
       nodeOldSpaceLimit: "384"
       nodeEnv: "development"
       languageToggle: true
-      desiredTaskCount: 1
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
@@ -113,13 +111,11 @@ Mappings:
       #fargateCPUsize: "2048"
       #fargateRAMsize: "4096"
       #nodeOldSpaceLimit: "3792"
-      #desiredTaskCount: 2
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
       nodeOldSpaceLimit: "1896"
       nodeEnv: "production"
       languageToggle: true
-      desiredTaskCount: 2
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
@@ -137,7 +133,6 @@ Mappings:
       nodeOldSpaceLimit: "256"
       nodeEnv: "production"
       languageToggle: true
-      desiredTaskCount: 1
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
@@ -155,7 +150,6 @@ Mappings:
       nodeOldSpaceLimit: "768"
       nodeEnv: "production"
       languageToggle: true
-      desiredTaskCount: 1
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.integration.account.gov.uk/contact-gov-uk-one-login"
@@ -173,7 +167,6 @@ Mappings:
       nodeOldSpaceLimit: "1792"
       nodeEnv: "production"
       languageToggle: true
-      desiredTaskCount: 2
       ga4Disabled: false
       uaDisabled: false
       contactUrl: "https://home.account.gov.uk/contact-gov-uk-one-login"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -585,7 +585,7 @@ Resources:
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 30
-        MinAdjustmentMagnitude: 6
+        MinAdjustmentMagnitude: 3
         StepAdjustments:
           - MetricIntervalUpperBound: 20
             ScalingAdjustment: 100

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -591,7 +591,7 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 120
+        Cooldown: 30
         MinAdjustmentMagnitude: 5
         StepAdjustments:
           - MetricIntervalLowerBound: 20

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -592,8 +592,11 @@ Resources:
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 30
-        MinAdjustmentMagnitude: 5
+        MinAdjustmentMagnitude: 6
         StepAdjustments:
+          - MetricIntervalLowerBound: 0
+            MetricIntervalUpperBound: 20
+            ScalingAdjustment: 100
           - MetricIntervalLowerBound: 20
             MetricIntervalUpperBound: 30
             ScalingAdjustment: 200

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -520,10 +520,6 @@ Resources:
           - UseCanaryDeployment
           - CODE_DEPLOY
           - ECS
-      DesiredCount: !FindInMap
-        - EnvironmentConfiguration
-        - !Ref AWS::AccountId
-        - desiredTaskCount
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 45
       LaunchType: FARGATE

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -632,14 +632,14 @@ Resources:
         - !Ref CoreFrontStepScaleOutPolicy
       AlarmDescription: "CoreFrontClusterOver60PercentCPU"
       ComparisonOperator: "GreaterThanThreshold"
-      DatapointsToAlarm: "2"
+      DatapointsToAlarm: "1"
       Dimensions:
         - Name: ClusterName
           Value: !Ref CoreFrontCluster
         - Name: ServiceName
           Value: !GetAtt CoreFrontService.Name
       Unit: "Percent"
-      EvaluationPeriods: "2"
+      EvaluationPeriods: "1"
       MetricName: "CPUUtilization"
       Namespace: "AWS/ECS"
       Statistic: "Average"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -546,7 +546,7 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 60
-      MinCapacity: 2
+      MinCapacity: 4
       ResourceId: !Join
         - '/'
         - - "service"


### PR DESCRIPTION
## Proposed changes

### What changed

See ticket LS-2142; but I reviewed the scaling policy against the perf test on the 7th June to see how the application and the scaling policies behaved.

### Why did it change

The application did not scale fast enough under load.

### Issue tracking

- [LS-2142](https://govukverify.atlassian.net/browse/LS-2142)

## Checklists

[ ] - Review of configuration to make sure this is appropriate for implementation within the IPV-Core FE.
[ ] - Need to understand the impact the stubs performance will have had on the core application.

[LS-2142]: https://govukverify.atlassian.net/browse/LS-2142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ