### PR TITLE
PYIC-6793: Send all unsupported attribute combos

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -29,7 +29,10 @@ const { saveSessionAndRedirect } = require("../shared/redirectHelper");
 const coreBackService = require("../../services/coreBackService");
 const qrCodeHelper = require("../shared/qrCodeHelper");
 const PHONE_TYPES = require("../../constants/phone-types");
-const UPDATE_DETAILS_JOURNEY_TYPES = require("../../constants/update-details-journeys");
+const {
+  SUPPORTED_COMBO_EVENTS,
+  UNSUPPORTED_COMBO_EVENTS,
+} = require("../../constants/update-details-journeys");
 const appDownloadHelper = require("../shared/appDownloadHelper");
 const {
   getIpvPageTemplatePath,
@@ -230,28 +233,31 @@ function getCoiUpdateDetailsJourney(detailsToUpdate) {
   const hasFamilyName = detailsToUpdate.includes("familyName");
 
   if (detailsToUpdate.includes("cancel")) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL;
+    return SUPPORTED_COMBO_EVENTS.UPDATE_CANCEL;
   }
 
   if (
     detailsToUpdate.includes("dateOfBirth") ||
     (hasGivenNames && hasFamilyName)
   ) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB;
+    return detailsToUpdate
+      .sort()
+      .map((details) => UNSUPPORTED_COMBO_EVENTS[details])
+      .join("-");
   }
 
   if (hasAddress) {
     if (hasFamilyName) {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME_ADDRESS;
+      return SUPPORTED_COMBO_EVENTS.UPDATE_FAMILY_NAME_ADDRESS;
     } else if (hasGivenNames) {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES_ADDRESS;
+      return SUPPORTED_COMBO_EVENTS.UPDATE_GIVEN_NAMES_ADDRESS;
     } else {
-      return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS;
+      return SUPPORTED_COMBO_EVENTS.UPDATE_ADDRESS;
     }
   } else if (hasFamilyName) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME;
+    return SUPPORTED_COMBO_EVENTS.UPDATE_FAMILY_NAME;
   } else if (hasGivenNames) {
-    return UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES;
+    return SUPPORTED_COMBO_EVENTS.UPDATE_GIVEN_NAMES;
   }
 }
 

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -8,7 +8,9 @@ const {
 } = require("../../lib/config");
 const qrCodeHelper = require("../shared/qrCodeHelper");
 const PHONE_TYPES = require("../../constants/phone-types");
-const UPDATE_DETAILS_JOURNEY_TYPES = require("../../constants/update-details-journeys");
+const {
+  SUPPORTED_COMBO_EVENTS,
+} = require("../../constants/update-details-journeys");
 
 describe("journey middleware", () => {
   let req;
@@ -1199,111 +1201,147 @@ describe("journey middleware", () => {
       };
     });
 
-    it("should not set journey if detailsToUpdate is empty", async function () {
-      req.body.detailsToUpdate = [];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(undefined);
+    describe("valid combinations of details to update", () => {
+      it("should not set journey if detailsToUpdate is empty", async function () {
+        req.body.detailsToUpdate = [];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(undefined);
+      });
+
+      it("should not set journey if detailsToUpdate is undefined", async function () {
+        req.body.detailsToUpdate = undefined;
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(undefined);
+      });
+
+      it("should set journey to UPDATE_CANCEL if detailsToUpdate is cancel", async function () {
+        req.body.detailsToUpdate = "cancel";
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(SUPPORTED_COMBO_EVENTS.UPDATE_CANCEL);
+      });
+
+      it("should set journey to undefined if detailsToUpdate is cancel and address", async function () {
+        req.body.detailsToUpdate = ["cancel", "address"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(undefined);
+      });
+
+      it("should set journey to UPDATE_GIVEN_NAMES if detailsToUpdate is givenNames", async function () {
+        req.body.detailsToUpdate = "givenNames";
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(
+          SUPPORTED_COMBO_EVENTS.UPDATE_GIVEN_NAMES,
+        );
+      });
+
+      it("should set journey to UPDATE_FAMILY_NAME if detailsToUpdate is lastName", async function () {
+        req.body.detailsToUpdate = ["familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(
+          SUPPORTED_COMBO_EVENTS.UPDATE_FAMILY_NAME,
+        );
+      });
+
+      it("should set journey to UPDATE_ADDRESS if detailsToUpdate is address", async function () {
+        req.body.detailsToUpdate = "address";
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(
+          SUPPORTED_COMBO_EVENTS.UPDATE_ADDRESS,
+        );
+      });
+
+      it("should set journey to UPDATE_GIVEN_NAME_ADDRESS if detailsToUpdate is givenNames and address", async function () {
+        req.body.detailsToUpdate = ["givenNames", "address"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(
+          SUPPORTED_COMBO_EVENTS.UPDATE_GIVEN_NAMES_ADDRESS,
+        );
+      });
+
+      it("should set journey to UPDATE_FAMILY_NAME_ADDRESS if detailsToUpdate is lastName and address", async function () {
+        req.body.detailsToUpdate = ["familyName", "address"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal(
+          SUPPORTED_COMBO_EVENTS.UPDATE_FAMILY_NAME_ADDRESS,
+        );
+      });
     });
 
-    it("should not set journey if detailsToUpdate is undefined", async function () {
-      req.body.detailsToUpdate = undefined;
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(undefined);
-    });
-
-    it("should set journey to UPDATE_CANCEL if detailsToUpdate is cancel", async function () {
-      req.body.detailsToUpdate = "cancel";
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_CANCEL,
-      );
-    });
-
-    it("should set journey to undefined if detailsToUpdate is cancel and address", async function () {
-      req.body.detailsToUpdate = ["cancel", "address"];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(undefined);
-    });
-
-    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is dateOfBirth", async function () {
-      req.body.detailsToUpdate = "dateOfBirth";
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
-      );
-    });
-
-    it("should set journey to UPDATE_GIVEN_NAMES if detailsToUpdate is givenNames", async function () {
-      req.body.detailsToUpdate = "givenNames";
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES,
-      );
-    });
-
-    it("should set journey to UPDATE_FAMILY_NAME if detailsToUpdate is lastName", async function () {
-      req.body.detailsToUpdate = ["familyName"];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME,
-      );
-    });
-
-    it("should set journey to UPDATE_ADDRESS if detailsToUpdate is address", async function () {
-      req.body.detailsToUpdate = "address";
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_ADDRESS,
-      );
-    });
-
-    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is givenNames and lastName", async function () {
-      req.body.detailsToUpdate = ["givenNames", "familyName"];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
-      );
-    });
-
-    it("should set journey to UPDATE_GIVEN_NAME_ADDRESS if detailsToUpdate is givenNames and address", async function () {
-      req.body.detailsToUpdate = ["givenNames", "address"];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_GIVEN_NAMES_ADDRESS,
-      );
-    });
-
-    it("should set journey to UPDATE_FAMILY_NAME_ADDRESS if detailsToUpdate is lastName and address", async function () {
-      req.body.detailsToUpdate = ["familyName", "address"];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_FAMILY_NAME_ADDRESS,
-      );
-    });
-
-    it("should set journey to UPDATE_NAMES_DOB if detailsToUpdate is givenNames, lastName, dateOfBirth, address", async function () {
-      req.body.detailsToUpdate = [
-        "givenNames",
-        "lastName",
-        "dateOfBirth",
-        "address",
-      ];
-      await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal(
-        UPDATE_DETAILS_JOURNEY_TYPES.UPDATE_NAMES_DOB,
-      );
+    describe("invalid combinations of details to update", () => {
+      it("should set journey to dob if detailsToUpdate is dateOfBirth", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob");
+      });
+      it("should set journey to dob-given if detailsToUpdate is dateOfBirth and givenNames", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "givenNames"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-given");
+      });
+      it("should set journey to dob-family if detailsToUpdate is dateOfBirth and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-family");
+      });
+      it("should set journey to address-dob if detailsToUpdate is dateOfBirth and address", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob");
+      });
+      it("should set journey to dob-family-given if detailsToUpdate is dateOfBirth, givenNames and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "givenNames", "familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-family-given");
+      });
+      it("should set journey to address-dob-given if detailsToUpdate is dateOfBirth, address and givenNames", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address", "givenNames"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-given");
+      });
+      it("should set journey to address-dob-family if detailsToUpdate is dateOfBirth, address and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address", "familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-family");
+      });
+      it("should set journey to address-dob-family-given if detailsToUpdate is dateOfBirth, address, givenNames and familyName", async function () {
+        req.body.detailsToUpdate = [
+          "dateOfBirth",
+          "address",
+          "givenNames",
+          "familyName",
+        ];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-family-given");
+      });
+      it("should set journey to family-given if detailsToUpdate is givenNames and familyName", async function () {
+        req.body.detailsToUpdate = ["givenNames", "familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("family-given");
+      });
+      it("should set journey to address-family-given if detailsToUpdate is address, givenNames, familyName", async function () {
+        req.body.detailsToUpdate = ["address", "givenNames", "familyName"];
+        await middleware.formHandleUpdateDetailsCheckBox(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-family-given");
+      });
     });
   });
 
@@ -1377,34 +1415,135 @@ describe("journey middleware", () => {
         },
       );
     });
-    it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName,givenNames", async function () {
-      req.body.detailsToUpdate = ["familyName", "givenNames"];
-      req.body.detailsCorrect = "no";
-      await middleware.formHandleCoiDetailsCheck(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal("names-dob");
+
+    describe("valid combinations of attributes", () => {
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is address", async function () {
+        req.body.detailsToUpdate = "address";
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-only");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is givenNames", async function () {
+        req.body.detailsToUpdate = ["givenNames"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("given-names-only");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName", async function () {
+        req.body.detailsToUpdate = ["familyName"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("family-name-only");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is givenNames and address", async function () {
+        req.body.detailsToUpdate = ["givenNames", "address"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("given-names-and-address");
+      });
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName and address", async function () {
+        req.body.detailsToUpdate = ["familyName", "address"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("family-name-and-address");
+      });
     });
-    it("should set correct journey if detailsCorrect is no and detailsToUpdate is familyName", async function () {
-      req.body.detailsToUpdate = ["familyName"];
-      req.body.detailsCorrect = "no";
-      await middleware.formHandleCoiDetailsCheck(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal("family-name-only");
+
+    describe("invalid combinations of attributes", () => {
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth and givenNames", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "givenNames"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-given");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "familyName"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-family");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth and address", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth, givenNames and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "givenNames", "familyName"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("dob-family-given");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth, address and givenNames", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address", "givenNames"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-given");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth, address and familyName", async function () {
+        req.body.detailsToUpdate = ["dateOfBirth", "address", "familyName"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-family");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth, address, givenNames and familyName", async function () {
+        req.body.detailsToUpdate = [
+          "dateOfBirth",
+          "address",
+          "givenNames",
+          "familyName",
+        ];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-dob-family-given");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is givenNames, familyName", async function () {
+        req.body.detailsToUpdate = ["familyName", "givenNames"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("family-given");
+      });
+
+      it("should set correct journey if detailsCorrect is no and detailsToUpdate is givenNames, familyName, address", async function () {
+        req.body.detailsToUpdate = ["address", "familyName", "givenNames"];
+        req.body.detailsCorrect = "no";
+        await middleware.formHandleCoiDetailsCheck(req, res, next);
+        expect(next).to.have.been.calledOnce;
+        expect(req.body.journey).to.equal("address-family-given");
+      });
     });
-    it("should set correct journey if detailsCorrect is no and detailsToUpdate is dateOfBirth,address", async function () {
-      req.body.detailsToUpdate = ["dateOfBirth", "address"];
-      req.body.detailsCorrect = "no";
-      await middleware.formHandleCoiDetailsCheck(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal("names-dob");
-    });
-    it("should set correct journey if detailsCorrect is no and detailsToUpdate is address", async function () {
-      req.body.detailsToUpdate = "address";
-      req.body.detailsCorrect = "no";
-      await middleware.formHandleCoiDetailsCheck(req, res, next);
-      expect(next).to.have.been.calledOnce;
-      expect(req.body.journey).to.equal("address-only");
-    });
+
     it("should set correct journey if detailsCorrect is yes and detailsToUpdate is not empty", async function () {
       req.body.detailsToUpdate = ["familyName", "givenNames"];
       req.body.detailsCorrect = "yes";

--- a/src/constants/update-details-journeys.js
+++ b/src/constants/update-details-journeys.js
@@ -1,9 +1,20 @@
-module.exports = Object.freeze({
+const SUPPORTED_COMBO_EVENTS = Object.freeze({
   UPDATE_ADDRESS: "address-only",
-  UPDATE_NAMES_DOB: "names-dob",
   UPDATE_GIVEN_NAMES: "given-names-only",
   UPDATE_FAMILY_NAME: "family-name-only",
   UPDATE_GIVEN_NAMES_ADDRESS: "given-names-and-address",
   UPDATE_FAMILY_NAME_ADDRESS: "family-name-and-address",
   UPDATE_CANCEL: "cancel",
 });
+
+const UNSUPPORTED_COMBO_EVENTS = Object.freeze({
+  address: "address",
+  givenNames: "given",
+  familyName: "family",
+  dateOfBirth: "dob",
+});
+
+module.exports = {
+  SUPPORTED_COMBO_EVENTS: SUPPORTED_COMBO_EVENTS,
+  UNSUPPORTED_COMBO_EVENTS: UNSUPPORTED_COMBO_EVENTS,
+};


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fraud are keen to understand all of the unsupported attribute combos that a user may ask for, in audit events. This requires us to capture that and send it over to the backend, rather than lumping invalid combos into one event.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6793](https://govukverify.atlassian.net/browse/PYIC-6793)


[PYIC-6793]: https://govukverify.atlassian.net/browse/PYIC-6793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ