### PR TITLE
PYIC-6774: modifications to update name dob page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -688,7 +688,7 @@
         "warningTextFallback": "Rhybudd",
         "radioButtonHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",
+          "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw llawn neu ddyddiad geni",
           "no": "Ewch yn ôl i wirio eich manylion eto",
           "noHint": "",
           "noHintCoi": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf.",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -680,6 +680,8 @@
       "header": "Diweddaru eich enw neu ddyddiad geni",
       "titleCoi": "Diweddaru eich enw llawn neu ddyddiad geni",
       "headerCoi": "Diweddaru eich enw llawn neu ddyddiad geni",
+      "titleRepeatFraudCheck": "Diweddaru eich enw llawn neu ddyddiad geni",
+      "headerRepeatFraudCheck": "Diweddaru eich enw llawn neu ddyddiad geni",
       "content": {
         "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
         "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
@@ -689,7 +691,8 @@
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw neu ddyddiad geni",
           "no": "Ewch yn ôl i wirio eich manylion eto",
           "noHint": "",
-          "noHintCoi": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf."
+          "noHintCoi": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf.",
+          "noHintRepeatFraudCheck": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -786,16 +786,19 @@
       "header": "Update your name or date of birth",
       "titleCoi": "Update your full name or date of birth",
       "headerCoi": "Update your full name or date of birth",
+      "titleRepeatFraudCheck": "Update your full name or date of birth",
+      "headerRepeatFraudCheck": "Update your full name or date of birth",
       "content": {
         "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
         "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
         "warningTextFallback": "Warning",
         "radioButtonHeading": "What would you like to do?",
         "formRadioButtons": {
-          "yes": "Contact the GOV.UK One Login team to update your name or date of birth",
+          "yes": "Contact the GOV.UK One Login team to update your full name or date of birth",
           "no": "Go back and check your details again",
           "noHint": "",
-          "noHintCoi": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name"
+          "noHintCoi": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name.",
+          "noHintRepeatFraudCheck": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -17,10 +17,12 @@
 
     <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translate }}</p>
 
+    {% if context === "repeatFraudCheck" %}
     {{ govukWarningText({
         text: 'pages.updateNameDateBirth.content.warningText' | translate,
         iconFallbackText: 'pages.updateNameDateBirth.content.warningTextFallback' | translate
         }) }}
+    {% endif %}
 
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
## Proposed changes

Modifications to updateNameDateBirth page following UCD review

### What changed

 - Only show warning when repeatFraudCheck is the context
 - Use `full name `instead of `name` in radio button description
 - adds missing full stops
### Why did it change

following UCD review these slight inaccuracies were noted.

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6774

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

