### PR TITLE
update confirm details page following ucd review

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -750,7 +750,7 @@
         "summary4": "Dyddiad geni",
         "detailsTitle": "Os oes camgymeriad yn eich enw",
         "detailsContent": "<p class=\"govuk-body\">Cysylltwch â'r tîm GOV.UK One Login os oes camgymeriad yn eich enw. Er enghraifft, os yw'ch enw gyda llythrennau ar goll neu gysylltnod.</p><p class=\"govuk-body\">Peidiwch â cheisio diweddaru eich manylion oni bai bod tîm cymorth GOV.UK One Login wedi dweud wrthych i wneud hynny.</p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Cysylltu â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>.",
-        "formTitle": "A yw eich manylion yn gyfredol?",
+        "formTitle": "<h2 class=\"govuk-heading-m\">A yw eich manylion yn gyfredol?</h2>",
         "formRadioButtons": {
           "yes": "Oes",
           "no": "Na - mae angen i mi ddiweddaru fy manylion"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -760,7 +760,7 @@
         "summary4": "Date of birth",
         "detailsTitle": "If there is a mistake in your name",
         "detailsContent": "<p class=\"govuk-body\">Contact the GOV.UK One Login team if there is a mistake in your name. For example, if your name is missing letters or a hyphen.</p><p class=\"govuk-body\">Do not try to update your details unless the GOV.UK One Login support team has told you to.</p><a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"{{url}}\">Contact the GOV.UK One Login team (opens in new tab)</a>.",
-        "formTitle": "Are your details up to date?",
+        "formTitle": "<h2 class=\"govuk-heading-m\">Are your details up to date?</h2>",
         "formRadioButtons": {
           "yes": "Yes",
           "no": "No - I need to update my details"

--- a/src/views/ipv/page/confirm-your-details.njk
+++ b/src/views/ipv/page/confirm-your-details.njk
@@ -24,7 +24,7 @@
 
     <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{ 'pages.confirmDetails.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.confirmDetails.content.paragraph1' | translate }}</p>
-    <h2 class="govuk-heading-s">{{ 'pages.confirmDetails.content.summaryHeading' | translate }}</h2>
+    <h2 class="govuk-heading-m">{{ 'pages.confirmDetails.content.summaryHeading' | translate }}</h2>
 
     {% set rows = [
       {
@@ -123,7 +123,7 @@
         name: "detailsCorrect",
         fieldset: {
             legend: {
-            text: 'pages.confirmDetails.content.formTitle' | translate,
+            text: 'pages.confirmDetails.content.formTitle' | translate | safe,
             classes: "govuk-fieldset__legend--m"
             }
         },


### PR DESCRIPTION
## Proposed changes


Changes to confirm-your-details page
### What changed

 - ‘Your details’ heading needs changing from govuk-heading-s to govuk-heading-m
- Apply an h2 to the form legend for 

### Why did it change

Changes requested following ucd review

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6837

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
