### PR TITLE
PYIC-6833: Markup COI start page details with H3

### DIFF
--- a/src/views/ipv/page/page-ipv-reuse.njk
+++ b/src/views/ipv/page/page-ipv-reuse.njk
@@ -70,10 +70,16 @@
         rows: rows
     }) }}
 
-    {{ govukDetails({
-        summaryText: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translateWithContext(context),
-        text: 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translateWithContext(context, { url: contactUsUrl } ) | safe
-    }) }}
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <h3 class="govuk-!-margin-0 govuk-!-font-size-19 govuk-!-font-weight-regular govuk-details__summary-text">
+          {{ 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsLabel' | translateWithContext(context) }}
+        </h3>
+      </summary>
+      <div class="govuk-details__text">
+        {{ 'pages.pageIpvReuse.content.updateUserDetailsInformation.updateDetailsHtml' | translateWithContext(context, { url: contactUsUrl } ) | safe }}
+      </div>
+    </details>
 
     {% include 'shared/journey-next-form.njk' %}
 {% endblock %}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Markup COI start page details with H3

### Why did it change

The "If your details are wrong" dropdown in the details component of the reuse page needed to be marked as an H3 to fit properly with the other headings on the page, for accessibility reasons.

To do this we needed to stop using the nunjucks macro and instead include the html for the component directly. The macro does allow you to pass HTML in for the dropdown, but it all gets put inside a `span` element, and an h3 shouldn't be inside a span.

We also need to override the font size and weight from the h3. This is done tith the override classes made available by the design system.

### Screenshot
![Screenshot 2024-06-18 at 10 56 33](https://github.com/govuk-one-login/ipv-core-front/assets/13836290/b952c7ec-58d1-4a0c-9f39-c937dfe53f79)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6833](https://govukverify.atlassian.net/browse/PYIC-6833)


[PYIC-6833]: https://govukverify.atlassian.net/browse/PYIC-6833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ