### PR TITLE
PYIC-6735: Only send plain appTriage events

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -43,7 +43,6 @@ const PAGES = require("../../constants/ipv-pages");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
 const {
   sniffPhoneType,
-  getJourneyOnSniffing,
 } = require("../shared/deviceSniffingHelper");
 
 const directoryPath = path.join(__dirname, "/../../views/ipv/page");
@@ -469,9 +468,6 @@ module.exports = {
 
         res.render(getIpvPageTemplatePath(sanitize(pageId)), renderOptions);
       } else {
-        if (req.body?.journey === "appTriage") {
-          req.body.journey = getJourneyOnSniffing(req);
-        }
         next();
       }
     } catch (error) {

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -41,9 +41,7 @@ const {
 } = require("../../lib/paths");
 const PAGES = require("../../constants/ipv-pages");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
-const {
-  sniffPhoneType,
-} = require("../shared/deviceSniffingHelper");
+const { sniffPhoneType } = require("../shared/deviceSniffingHelper");
 
 const directoryPath = path.join(__dirname, "/../../views/ipv/page");
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Only send a single type of app triage event

### Why did it change

Strategic app work has been put on hold and this simplifies the code in the meantime

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6735](https://govukverify.atlassian.net/browse/PYIC-6735)


[PYIC-6735]: https://govukverify.atlassian.net/browse/PYIC-6735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ