### PR TITLE
PYIC-6863: use dynamic logout url for different env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -780,6 +780,14 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - templateCaching
+            - Name: LOGOUT_URL
+              Value: !If
+                - IsProduction
+                - "https://oidc.account.gov.uk/logout"
+                - !If
+                  - IsDevelopment
+                  - "https://oidc.dev.account.gov.uk/logout"
+                  - "https://oidc.${Environment}.account.gov.uk/logout"
           Secrets:
             - Name: DT_TENANT
               ValueFrom: !Join

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -38,4 +38,5 @@ module.exports = {
   TEMPLATE_CACHING: process.env.TEMPLATE_CACHING,
   SERVICE_DOMAIN: process.env.SERVICE_DOMAIN || "localhost",
   LANGUAGE_TOGGLE_ENABLED: process.env.LANGUAGE_TOGGLE === "true",
+  LOGOUT_URL: process.env.LOGOUT_URL || "https://oidc.account.gov.uk/logout",
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -6,6 +6,7 @@ const {
   SERVICE_URL,
   UA_DISABLED,
   GA4_DISABLED,
+  LOGOUT_URL,
 } = require("./config");
 const { generateNonce } = require("./strings");
 
@@ -17,6 +18,7 @@ module.exports = {
     res.locals.isGa4Disabled = GA4_DISABLED;
     res.locals.isUaDisabled = UA_DISABLED;
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
+    res.locals.logoutUrl = LOGOUT_URL;
 
     const contactUsUrl = new URL(CONTACT_URL);
     contactUsUrl.searchParams.set(

--- a/src/views/shared/sign-out-header.njk
+++ b/src/views/shared/sign-out-header.njk
@@ -29,7 +29,7 @@
       <nav aria-label="GOV.UK One Login menu" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
         <ul class="one-login-header__nav__list">
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link" href="https://oidc.account.gov.uk/logout">
+            <a class="one-login-header__nav__link" href="{{logoutUrl}}">
               {{ 'general.govuk.signOut' | translate }}
             </a>
           </li>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Use correct log out url for all env.

### What changed

- Use dynamic logout url for different env.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To make sure logout url is correct.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6863](https://govukverify.atlassian.net/browse/PYIC-6863)


[PYIC-6863]: https://govukverify.atlassian.net/browse/PYIC-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ