### PR TITLE
PYIC-7013: update page-ipv-pending

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -855,8 +855,11 @@
         "subHeading": "Os ydych eisoes wedi bod i Swyddfa’r Post",
         "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
         "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
-        "subHeading2": "Os ydych angen help",
-        "paragraph5": "Cysylltwch â ni os:",
+        "subHeading2": "Os ydych am brofi eich hunaniaeth mewn ffordd arall",
+        "paragraph5": "Os nad ydych bellach am brofi eich hunaniaeth mewn Swyddfa Bost, gallwch <a class=\"govuk-link\" href=\"/ipv/page/pyi-f2f-delete-details\">ddileu eich manylion a cheisio profi eich hunaniaeth mewn ffordd arall</a>.",
+        "paragraph6": "Byddwn yn dileu'ch manylion yn awtomatig os na fyddwch yn mynd i Swyddfa'r Post o fewn 10 diwrnod o gael eich e-bost cadarnhau.",
+        "subHeading3": "Os ydych angen help",
+        "paragraph7": "Cysylltwch â ni os:",
         "reasonsToContact": [
           "ydych angen help i orffen profi eich hunaniaeth gyda Swyddfa’r Post",
           "hoffech beidio â mynd i Swyddfa’r Post ac eisiau profi eich hunaniaeth mewn ffordd arall"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -856,7 +856,7 @@
         "paragraph3": "Mae eich gwiriad hunaniaeth yn dal i gael ei brosesu.",
         "paragraph4": "Byddwch yn cael e-bost pan fydd canlyniad i’ch gwiriad hunaniaeth – fel arfer o fewn diwrnod o fynd i Swyddfa’r Post.",
         "subHeading2": "Os ydych am brofi eich hunaniaeth mewn ffordd arall",
-        "paragraph5": "Os nad ydych bellach am brofi eich hunaniaeth mewn Swyddfa Bost, gallwch <a class=\"govuk-link\" href=\"/ipv/page/pyi-f2f-delete-details\">ddileu eich manylion a cheisio profi eich hunaniaeth mewn ffordd arall</a>.",
+        "paragraph5": "Os nad ydych bellach am brofi eich hunaniaeth mewn Swyddfa Bost, gallwch <a class=\"govuk-link\" href=\"/ipv/journey/page-ipv-pending/next\">ddileu eich manylion a cheisio profi eich hunaniaeth mewn ffordd arall</a>.",
         "paragraph6": "Byddwn yn dileu'ch manylion yn awtomatig os na fyddwch yn mynd i Swyddfa'r Post o fewn 10 diwrnod o gael eich e-bost cadarnhau.",
         "subHeading3": "Os ydych angen help",
         "paragraph7": "Cysylltwch â ni os:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -858,7 +858,7 @@
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You’ll get an email when there’s a result for your identity check - usually within a day of going to the Post Office.",
         "subHeading2": "If you want to prove your identity another way",
-        "paragraph5": "If you no longer want to prove your identity at a Post Office, you can <a class=\"govuk-link\" href=\"/ipv/page/pyi-f2f-delete-details\">delete your details and try to prove your identity another way</a>.",
+        "paragraph5": "If you no longer want to prove your identity at a Post Office, you can <a class=\"govuk-link\" href=\"/ipv/journey/page-ipv-pending/next\">delete your details and try to prove your identity another way</a>.",
         "paragraph6": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
         "subHeading3": "If you need help",
         "paragraph7": "Contact us if you:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -857,8 +857,11 @@
         "subHeading": "If you’ve already been to the Post Office",
         "paragraph3": "Your identity check is still being processed.",
         "paragraph4": "You’ll get an email when there’s a result for your identity check - usually within a day of going to the Post Office.",
-        "subHeading2": "If you need help",
-        "paragraph5": "Contact us if you:",
+        "subHeading2": "If you want to prove your identity another way",
+        "paragraph5": "If you no longer want to prove your identity at a Post Office, you can <a class=\"govuk-link\" href=\"/ipv/page/pyi-f2f-delete-details\">delete your details and try to prove your identity another way</a>.",
+        "paragraph6": "We will automatically delete your details if you do not go to the Post Office within 10 days of getting your confirmation email.",
+        "subHeading3": "If you need help",
+        "paragraph7": "Contact us if you:",
         "reasonsToContact": [
           "need help to finish proving your identity with the Post Office",
           "would prefer not to go to the Post Office and want to prove your identity another way"

--- a/src/views/ipv/page/page-ipv-pending.njk
+++ b/src/views/ipv/page/page-ipv-pending.njk
@@ -12,8 +12,14 @@
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph3' | translate }}</p>
   <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph4' | translate }}</p>
 
-  <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading2' | translate }}</h2>
-  <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph5' | translate }}</p>
+  {% if context == "f2f-delete-details" %}
+    <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading2' | translate }}</h2>
+    <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph5' | translate | safe }}</p>
+    <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph6' | translate }}</p>
+  {% endif %}
+
+  <h2 class="govuk-heading-m">{{'pages.pageIpvPending.content.subHeading3' | translate }}</h2>
+  <p class="govuk-body">{{'pages.pageIpvPending.content.paragraph7' | translate }}</p>
   <ul class="govuk-list  govuk-list--bullet">
     {% for listItem in 'pages.pageIpvPending.content.reasonsToContact' | translate({ returnObjects: true }) %}
       <li>{{ listItem }}</li>
@@ -21,7 +27,4 @@
   </ul>
 
   <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
-  {% if context == "f2f-delete-details" %}
-    {% include 'shared/journey-next-form.njk' %}
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updates `page-ipv-pending` to match [designs](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=11995-10179&t=qAI1sr3Dqqok7iOQ-0) when using `f2f-delete-details` context:
- removes continue button
- adds new content

`/page-ipv-pending/en?context=f2f-delete-details`:
<img width="522" alt="Screenshot 2024-07-11 at 14 37 53" src="https://github.com/govuk-one-login/ipv-core-front/assets/120715154/0b8e5086-ff5d-4858-a728-69178862387f">


### Why did it change

The current page only includes a ‘Continue’ button and no content to guide the user as to what that button does.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7013](https://govukverify.atlassian.net/browse/PYIC-7013)

[PYIC-7013]: https://govukverify.atlassian.net/browse/PYIC-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ