### PR TITLE
PYIC-7025: Verify all the pages involved in the journey with agreed UCD

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -731,17 +731,16 @@
       "title": "Rydych chi wedi dileu'r manylion yn eich GOV.UK One Login",
       "header": "Rydych chi wedi dileu'r manylion yn eich GOV.UK One Login",
       "content": {
-        "paragraph1": "Rydych wedi derbyn e-bost cadarnhau.",
-        "paragraph2F2f": "Nid yw llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
-        "paragraph2": "Nawr gallwch brofi eich hunaniaeth eto gan ddefnyddio'ch manylion newydd.",
-        "paragraph3F2f": "Nawr gallwch geisio profi eich hunaniaeth mewn ffordd arall.",
-        "paragraph3": "Byddwch angen:",
+        "paragraph1F2f": "Nid yw llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
+        "paragraph1": "Nawr gallwch brofi eich hunaniaeth eto gan ddefnyddio'ch manylion newydd.",
+        "paragraph2F2f": "Nawr gallwch geisio profi eich hunaniaeth mewn ffordd arall.",
+        "paragraph2": "Byddwch angen:",
         "requirements": [
           "ID gyda llun gyda'r enw rydych chi ei eisiau GOV.UK One Login ei ddefnyddio ",
           "dweud wrthym ble rydych chi wedi byw am y 3 mis diwetha"
         ],
-        "paragraph4": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
-        "paragraph4F2f": "Darganfyddwch am y <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">gwahanol ffyrdd i brofi eich hunaniaeth gyda GOV.UK One Login (agor mewn tab newydd)</a>.",
+        "paragraph3": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
+        "paragraph3F2f": "Darganfyddwch am y <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">gwahanol ffyrdd i brofi eich hunaniaeth gyda GOV.UK One Login (agor mewn tab newydd)</a>.",
         "submitButtonText": "Parhau i brofi eich hunaniaeth eto",
         "submitButtonTextF2f": "Parhau i brofi eich hunaniaeth eto"
       }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -731,16 +731,17 @@
       "title": "Rydych chi wedi dileu'r manylion yn eich GOV.UK One Login",
       "header": "Rydych chi wedi dileu'r manylion yn eich GOV.UK One Login",
       "content": {
-        "paragraph1F2f": "Nid yw llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
-        "paragraph1": "Nawr gallwch brofi eich hunaniaeth eto gan ddefnyddio'ch manylion newydd.",
-        "paragraph2F2f": "Nawr gallwch geisio profi eich hunaniaeth mewn ffordd arall.",
-        "paragraph2": "Byddwch angen:",
+        "paragraph1": "Rydych wedi derbyn e-bost cadarnhau.",
+        "paragraph2F2f": "Nid yw llythyr cwsmer Swyddfa'r Post bellach yn ddilys ac ni ddylech geisio ei ddefnyddio i brofi eich hunaniaeth.",
+        "paragraph2": "Nawr gallwch brofi eich hunaniaeth eto gan ddefnyddio'ch manylion newydd.",
+        "paragraph3F2f": "Nawr gallwch geisio profi eich hunaniaeth mewn ffordd arall.",
+        "paragraph3": "Byddwch angen:",
         "requirements": [
           "ID gyda llun gyda'r enw rydych chi ei eisiau GOV.UK One Login ei ddefnyddio ",
           "dweud wrthym ble rydych chi wedi byw am y 3 mis diwetha"
         ],
-        "paragraph3": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
-        "paragraph3F2f": "Darganfyddwch am y <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">gwahanol ffyrdd i brofi eich hunaniaeth gyda GOV.UK One Login (agor mewn tab newydd)</a>.",
+        "paragraph4": "Darganfyddwch <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">pa ID gyda llun y gallwch ei ddefnyddio i brofi eich hunaniaeth (agor mewn tab newydd)</a>.",
+        "paragraph4F2f": "Darganfyddwch am y <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">gwahanol ffyrdd i brofi eich hunaniaeth gyda GOV.UK One Login (agor mewn tab newydd)</a>.",
         "submitButtonText": "Parhau i brofi eich hunaniaeth eto",
         "submitButtonTextF2f": "Parhau i brofi eich hunaniaeth eto"
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -768,16 +768,17 @@
       "title": "You have deleted the details in your GOV.UK One Login",
       "header": "You have deleted the details in your GOV.UK One Login",
       "content": {
-        "paragraph1F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
-        "paragraph1": "You can now prove your identity again using your new details.",
-        "paragraph2F2f": "You can now try to prove your identity another way.",
-        "paragraph2": "You'll need:",
+        "paragraph1": "You've been sent a confirmation email.",
+        "paragraph2F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
+        "paragraph2": "You can now prove your identity again using your new details.",
+        "paragraph3F2f": "You can now try to prove your identity another way.",
+        "paragraph3": "You'll need:",
         "requirements": [
           "photo ID with the name you want GOV.UK One Login to use",
           "to tell us where you've lived for the last 3 months"
         ],
-        "paragraph3F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
-        "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
+        "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "paragraph4": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
         "submitButtonTextF2f": "Continue to prove your identity",
         "submitButtonText": "Continue to prove your identity again"
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -698,7 +698,7 @@
       "header": "Are you sure you want to delete your details and prove your identity again?",
       "headerF2f": "Are you sure you want to delete your details and prove your identity another way?",
       "content": {
-        "paragraph1": "Deleting the details saved in your GOV.UK One Login will not affect any other government account you may have such as Government Gateway or Universal Credit.",
+        "paragraph1": "Deleting the details saved in your GOV.UK One Login will not affect any other government account you may have, such as Government Gateway or Universal Credit.",
         "formRadioButtons": {
           "yes": "Yes, delete my details",
           "no": "No, cancel and go back to my current details",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -768,17 +768,16 @@
       "title": "You have deleted the details in your GOV.UK One Login",
       "header": "You have deleted the details in your GOV.UK One Login",
       "content": {
-        "paragraph1": "You've been sent a confirmation email.",
-        "paragraph2F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
-        "paragraph2": "You can now prove your identity again using your new details.",
-        "paragraph3F2f": "You can now try to prove your identity another way.",
-        "paragraph3": "You'll need:",
+        "paragraph1F2f": "Your Post Office customer letter is no longer valid and you should not try to use it to prove your identity. ",
+        "paragraph1": "You can now prove your identity again using your new details.",
+        "paragraph2F2f": "You can now try to prove your identity another way.",
+        "paragraph2": "You'll need:",
         "requirements": [
           "photo ID with the name you want GOV.UK One Login to use",
           "to tell us where you've lived for the last 3 months"
         ],
-        "paragraph4F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
-        "paragraph4": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
+        "paragraph3F2f": "Find out about <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">the different ways to prove your identity with GOV.UK One Login (opens in new tab)</a>.",
+        "paragraph3": "Find out <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.gov.uk/using-your-gov-uk-one-login/proving-your-identity\">what photo ID you can use to prove your identity (opens in new tab)</a>.",
         "submitButtonTextF2f": "Continue to prove your identity",
         "submitButtonText": "Continue to prove your identity again"
       }

--- a/src/views/ipv/page/pyi-details-deleted.njk
+++ b/src/views/ipv/page/pyi-details-deleted.njk
@@ -10,8 +10,9 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiDetailsDeleted.header' | translate }}</h1>
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph2' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) }}</p>
 
   {% if context !== "f2f" %}
     <ul class="govuk-list govuk-list--bullet">
@@ -21,7 +22,7 @@
     </ul>
   {% endif %}
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translateWithContext(context) | safe }}</p>
 
 {% include "shared/journey-next-form.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-details-deleted.njk
+++ b/src/views/ipv/page/pyi-details-deleted.njk
@@ -10,9 +10,8 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiDetailsDeleted.header' | translate }}</h1>
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translateWithContext(context) }}</p>
   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph2' | translateWithContext(context) }}</p>
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) }}</p>
 
   {% if context !== "f2f" %}
     <ul class="govuk-list govuk-list--bullet">
@@ -22,7 +21,7 @@
     </ul>
   {% endif %}
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph4' | translateWithContext(context) | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) | safe }}</p>
 
 {% include "shared/journey-next-form.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-details-deleted.njk
+++ b/src/views/ipv/page/pyi-details-deleted.njk
@@ -10,7 +10,10 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
       xmlns="http://www.w3.org/1999/html">{{ 'pages.pyiDetailsDeleted.header' | translate }}</h1>
 
-  <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
+  {% if context !== "f2f" %}
+    <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph1' | translate }}</p>
+  {% endif %}
+
   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph2' | translateWithContext(context) }}</p>
   <p class="govuk-body">{{ 'pages.pyiDetailsDeleted.content.paragraph3' | translateWithContext(context) }}</p>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
`/pyi-details-deleted/en?context=f2f`
- remove confirmation email text

`/pyi-confirm-delete-details`:
- minor: add missing comma

No other content changes from [designs](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=12082-3545&t=9FbZ7snjBwzCaeYp-0) required for:
- `/pyi-confirm-delete-details`
- `/pyi-f2f-delete-details`

Changes to `/page-ipv-pending/en?context=f2f-delete-details` done as part of https://github.com/govuk-one-login/ipv-core-front/pull/1495 ([PYIC-7013](https://govukverify.atlassian.net/browse/PYIC-7013))

### Why did it change
This is a sub-task ticket for [PYIC-6986](https://govukverify.atlassian.net/browse/PYIC-6986). Some small content changes needed as part of the F2F cancellation work to provide users with flexibility and alternatives to prove their identity before the 10 day wait period has elapsed, improving user experience and service accessibility.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7025](https://govukverify.atlassian.net/browse/PYIC-7025)


[PYIC-7013]: https://govukverify.atlassian.net/browse/PYIC-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-6986]: https://govukverify.atlassian.net/browse/PYIC-6986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-7025]: https://govukverify.atlassian.net/browse/PYIC-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ