### PR TITLE
PYIC-7010: rename prove identity bank account to prove identity no photo id, add content for NI Number page

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -132,11 +132,11 @@ describe("journey middleware", () => {
       req = {
         id: "1",
         url: "/ipv/page",
-        params: { pageId: "prove-identity-bank-account" },
+        params: { pageId: "prove-identity-no-photo-id" },
         session: {
           ipvSessionId: "ipv-session-id",
           ipAddress: "ip-address",
-          currentPage: "prove-identity-bank-account",
+          currentPage: "prove-identity-no-photo-id",
           save: sinon.fake.yields(null),
         },
         log: { info: sinon.fake(), error: sinon.fake() },
@@ -148,7 +148,7 @@ describe("journey middleware", () => {
       await middleware.handleJourneyPage(req, res);
 
       expect(res.render).to.have.been.calledWith(
-        "ipv/page/prove-identity-bank-account.njk",
+        "ipv/page/prove-identity-no-photo-id.njk",
       );
     });
 
@@ -158,7 +158,7 @@ describe("journey middleware", () => {
       await middleware.handleJourneyPage(req, res);
 
       expect(res.render).to.have.been.calledWith(
-        "ipv/page/prove-identity-bank-account.njk",
+        "ipv/page/prove-identity-no-photo-id.njk",
       );
       expect(res.status).to.have.been.calledWith(418);
       expect(req.session.currentPageStatusCode).to.equal(undefined);
@@ -227,7 +227,7 @@ describe("journey middleware", () => {
       await middleware.handleJourneyPage(req, res, next);
 
       expect(res.render).to.have.been.calledWith(
-        `ipv/page/prove-identity-bank-account.njk`,
+        `ipv/page/prove-identity-no-photo-id.njk`,
         sinon.match.has("pageErrorState", "some error state"),
       );
     });

--- a/src/constants/ipv-pages.js
+++ b/src/constants/ipv-pages.js
@@ -12,7 +12,7 @@ module.exports = Object.freeze({
   PAGE_IPV_SUCCESS: "page-ipv-success",
   PAGE_MULTIPLE_DOC_CHECK: "page-multiple-doc-check",
   PAGE_PRE_EXPERIAN_KBV_TRANSITION: "page-pre-experian-kbv-transition",
-  PROVE_IDENTITY_BANK_ACCOUNT: "prove-identity-bank-account",
+  PROVE_IDENTITY_NO_PHOTO_ID: "prove-identity-no-photo-id",
   PYI_ANOTHER_WAY: "pyi-another-way",
   PYI_ATTEMPT_RECOVERY: "pyi-attempt-recovery",
   PYI_CONFIRM_DELETE_DETAILS: "pyi-confirm-delete-details",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -901,38 +901,32 @@
         }
       }
     },
-    "proveIdentityBankAccount": {
+    "proveIdentityNoPhotoId": {
       "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
-      "titleNINumber": "Prove your identity with your National Insurance number and security questions",
+      "titleNinoOnly": "Prove your identity with your National Insurance number and security questions",
       "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
-      "headerNINumber": "Prove your identity with your National Insurance number and security questions",
+      "headerNinoOnly": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "Gallwch ddefnyddio unrhyw gyfrif cyfredol gyda banc neu gymdeithas adeiladu yn y DU i brofi eich hunaniaeth. Rhaid i'ch enw fod ar y cyfrif.",
         "subHeading": "Darparwch rhywfaint o fanylion personol",
         "paragraph2": "Byddwn yn gofyn i chi am eich:",
-        "paragraph2NINumber": "As well as your National Insurance number, we also need your:",
-        "personalDetails": [
-          "enw",
-          "dyddiad geni",
-          "cod didoli a rhif y cyfrif",
-          "rrhif Yswiriant Gwladol",
-          "cyfeiriad presennol (efallai y byddwch hefyd angen eich cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)"
-        ],
-        "personalDetailsNINumber": [
-          "name",
-          "date of birth",
-          "sort code and account number",
-          "current address (you might also need your previous address if you've recently moved)"
-        ],
+        "paragraph2NinoOnly": "As well as your National Insurance number, we also need your:",
+        "personalDetails": {
+          "name": "enw",
+          "dob": "dyddiad geni",
+          "accountNumber": "cod didoli a rhif y cyfrif",
+          "NINumber": "rrhif Yswiriant Gwladol",
+          "address": "cyfeiriad presennol (efallai y byddwch hefyd angen eich cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)"
+        },
         "subHeading2": "Atebwch rhai cwestiynau diogelwch",
         "paragraph3": "Yna byddwn yn gofyn rhywfaint o gwestiynau diogelwch i chi. Mae hyn yn ein helpu i wirio a yw'r manylion rydych wedi'u rhoi yn cael eu defnyddio gennych chi.",
-        "paragraph3NINumber": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
+        "paragraph3NinoOnly": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "A oes gennych gyfrif banc neu gymdeithas adeiladu cyfredol yn eich enw chi?",
-        "subHeading3NINumber": "Do you have a National Insurance number?",
+        "subHeading3NinoOnly": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Oes",
           "otherWayButtonText": "Na - profi fy hunaniaeth mewn ffordd arall",
-          "otherWayButtonTextNINumber": "Na"
+          "otherWayButtonTextNinoOnly": "Na"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -903,11 +903,14 @@
     },
     "proveIdentityBankAccount": {
       "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
+      "titleNINumber": "Prove your identity with your National Insurance number and security questions",
       "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
+      "headerNINumber": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "Gallwch ddefnyddio unrhyw gyfrif cyfredol gyda banc neu gymdeithas adeiladu yn y DU i brofi eich hunaniaeth. Rhaid i'ch enw fod ar y cyfrif.",
         "subHeading": "Darparwch rhywfaint o fanylion personol",
         "paragraph2": "Byddwn yn gofyn i chi am eich:",
+        "paragraph2NINumber": "As well as your National Insurance number, we also need your:",
         "personalDetails": [
           "enw",
           "dyddiad geni",
@@ -915,12 +918,21 @@
           "rrhif Yswiriant Gwladol",
           "cyfeiriad presennol (efallai y byddwch hefyd angen eich cyfeiriad blaenorol os ydych wedi symud yn ddiweddar)"
         ],
+        "personalDetailsNINumber": [
+          "name",
+          "date of birth",
+          "sort code and account number",
+          "current address (you might also need your previous address if you've recently moved)"
+        ],
         "subHeading2": "Atebwch rhai cwestiynau diogelwch",
         "paragraph3": "Yna byddwn yn gofyn rhywfaint o gwestiynau diogelwch i chi. Mae hyn yn ein helpu i wirio a yw'r manylion rydych wedi'u rhoi yn cael eu defnyddio gennych chi.",
+        "paragraph3NINumber": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "A oes gennych gyfrif banc neu gymdeithas adeiladu cyfredol yn eich enw chi?",
+        "subHeading3NINumber": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Oes",
-          "otherWayButtonText": "Na - profi fy hunaniaeth mewn ffordd arall"
+          "otherWayButtonText": "Na - profi fy hunaniaeth mewn ffordd arall",
+          "otherWayButtonTextNINumber": "Na"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -953,11 +953,14 @@
     },
     "proveIdentityBankAccount": {
       "title": "Prove your identity with bank or building society details and security questions",
+      "titleNINumber": "Prove your identity with your National Insurance number and security questions",
       "header": "Prove your identity with bank or building society details and security questions",
+      "headerNINumber": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
         "subHeading": "Provide some personal details",
         "paragraph2": "We'll ask you for your:",
+        "paragraph2NINumber": "As well as your National Insurance number, we also need your:",
         "personalDetails": [
           "name",
           "date of birth",
@@ -965,12 +968,21 @@
           "National Insurance number",
           "current address (you might also need your previous address if you've recently moved)"
         ],
+        "personalDetailsNINumber": [
+          "name",
+          "date of birth",
+          "sort code and account number",
+          "current address (you might also need your previous address if you've recently moved)"
+        ],
         "subHeading2": "Answer some security questions",
         "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
+        "paragraph3NINumber": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "Do you have a UK bank or building society current account in your name?",
+        "subHeading3NINumber": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Yes",
-          "otherWayButtonText": "No - prove my identity another way"
+          "otherWayButtonText": "No - prove my identity another way",
+          "otherWayButtonTextNINumber": "No"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -951,38 +951,32 @@
         }
       }
     },
-    "proveIdentityBankAccount": {
+    "proveIdentityNoPhotoId": {
       "title": "Prove your identity with bank or building society details and security questions",
-      "titleNINumber": "Prove your identity with your National Insurance number and security questions",
+      "titleNinoOnly": "Prove your identity with your National Insurance number and security questions",
       "header": "Prove your identity with bank or building society details and security questions",
-      "headerNINumber": "Prove your identity with your National Insurance number and security questions",
+      "headerNinoOnly": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
         "subHeading": "Provide some personal details",
         "paragraph2": "We'll ask you for your:",
-        "paragraph2NINumber": "As well as your National Insurance number, we also need your:",
-        "personalDetails": [
-          "name",
-          "date of birth",
-          "sort code and account number",
-          "National Insurance number",
-          "current address (you might also need your previous address if you've recently moved)"
-        ],
-        "personalDetailsNINumber": [
-          "name",
-          "date of birth",
-          "sort code and account number",
-          "current address (you might also need your previous address if you've recently moved)"
-        ],
+        "paragraph2NinoOnly": "As well as your National Insurance number, we also need your:",
+        "personalDetails": {
+          "name": "name",
+          "dob": "date of birth",
+          "accountNumber": "sort code and account number",
+          "NINumber": "National Insurance number",
+          "address": "current address (you might also need your previous address if you've recently moved)"
+        },
         "subHeading2": "Answer some security questions",
         "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
-        "paragraph3NINumber": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
+        "paragraph3NinoOnly": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "Do you have a UK bank or building society current account in your name?",
-        "subHeading3NINumber": "Do you have a National Insurance number?",
+        "subHeading3NinoOnly": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Yes",
           "otherWayButtonText": "No - prove my identity another way",
-          "otherWayButtonTextNINumber": "No"
+          "otherWayButtonTextNinoOnly": "No"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/prove-identity-no-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-photo-id.njk
@@ -1,7 +1,7 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleKey = 'pages.proveIdentityBankAccount.title' %}
+{% set pageTitleKey = 'pages.proveIdentityBankAccount.title' | translateWithContext(context) %}
 {% set googleTagManagerPageId = "proveIdentityBankAccount" %}
 
 {% set errorState = pageErrorState %}
@@ -10,19 +10,24 @@
 {% set errorHref = "#proveIdentityBankAccountOptionsForm" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityBankAccount.header' | translate }}</h1>
-  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph1' | translate }}</p>
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityBankAccount.header' | translateWithContext(context) }}</h1>
+  {% if context != "NINumber" %}
+    <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph1' | translate }}</p>
+    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading' | translate }}</h2>
+  {% endif %}
 
-  <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading' | translate }}</h2>
-  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph2' | translateWithContext(context) }}</p>
   <ul class="govuk-list govuk-list--bullet ">
-    {% for listItem in 'pages.proveIdentityBankAccount.content.personalDetails' | translate({ returnObjects: true }) %}
+    {% for listItem in 'pages.proveIdentityBankAccount.content.personalDetails' | translateWithContext(context, { returnObjects: true }) %}
       <li>{{ listItem }}</li>
     {% endfor %}
   </ul>
 
-  <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
-  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph3' | translate }}</p>
+  {% if context != "NINumber" %}
+    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
+  {% endif %}
+
+  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph3' | translateWithContext(context) }}</p>
 
   <form id="proveIdentityBankAccountOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
@@ -31,7 +36,7 @@
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.proveIdentityBankAccount.content.subHeading3' | translate,
+          text: 'pages.proveIdentityBankAccount.content.subHeading3' | translateWithContext(context),
           classes: "govuk-fieldset__legend--m"
         }
       },
@@ -42,7 +47,7 @@
         },
         {
           value: "end",
-          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.otherWayButtonText' | translate
+          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.otherWayButtonText' | translateWithContext(context)
         }
       ]
     } %}

--- a/src/views/ipv/page/prove-identity-no-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-photo-id.njk
@@ -1,59 +1,63 @@
 {% extends "shared/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% set pageTitleKey = 'pages.proveIdentityBankAccount.title' | translateWithContext(context) %}
-{% set googleTagManagerPageId = "proveIdentityBankAccount" %}
+{% set pageTitleKey = 'pages.proveIdentityNoPhotoId.title' | translateWithContext(context) %}
+{% set googleTagManagerPageId = "proveIdentityNoPhotoId" %}
 
 {% set errorState = pageErrorState %}
-{% set errorTitle = 'pages.proveIdentityBankAccount.content.formErrorMessage.errorSummaryTitleText' | translate %}
-{% set errorText = 'pages.proveIdentityBankAccount.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
-{% set errorHref = "#proveIdentityBankAccountOptionsForm" %}
+{% set errorTitle = 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#proveIdentityNoPhotoIdOptionsForm" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityBankAccount.header' | translateWithContext(context) }}</h1>
-  {% if context != "NINumber" %}
-    <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph1' | translate }}</p>
-    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading' | translate }}</h2>
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityNoPhotoId.header' | translateWithContext(context) }}</h1>
+  {% if context != "nino-only" %}
+    <p class="govuk-body">{{ 'pages.proveIdentityNoPhotoId.content.paragraph1' | translate }}</p>
+    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityNoPhotoId.content.subHeading' | translate }}</h2>
   {% endif %}
 
-  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph2' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.proveIdentityNoPhotoId.content.paragraph2' | translateWithContext(context) }}</p>
   <ul class="govuk-list govuk-list--bullet ">
-    {% for listItem in 'pages.proveIdentityBankAccount.content.personalDetails' | translateWithContext(context, { returnObjects: true }) %}
-      <li>{{ listItem }}</li>
-    {% endfor %}
+    <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.name' | translate }}</li>
+    <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.dob' | translate }}</li>
+    {% if context != "nino-only" %}
+      <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.accountNumber' | translate }}</li>
+      <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.NINumber' | translate }}</li>
+    {% endif %}
+    <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.address' | translate }}</li>
   </ul>
 
-  {% if context != "NINumber" %}
-    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityBankAccount.content.subHeading2' | translate }}</h2>
+  {% if context != "nino-only" %}
+    <h2 class="govuk-heading-m">{{ 'pages.proveIdentityNoPhotoId.content.subHeading2' | translate }}</h2>
   {% endif %}
 
-  <p class="govuk-body">{{ 'pages.proveIdentityBankAccount.content.paragraph3' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.proveIdentityNoPhotoId.content.paragraph3' | translateWithContext(context) }}</p>
 
-  <form id="proveIdentityBankAccountOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
+  <form id="proveIdentityNoPhotoIdOptionsForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.proveIdentityBankAccount.content.subHeading3' | translateWithContext(context),
+          text: 'pages.proveIdentityNoPhotoId.content.subHeading3' | translateWithContext(context),
           classes: "govuk-fieldset__legend--m"
         }
       },
       items: [
         {
           value: "next",
-          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.continueBankDetailsButtonText' | translate
+          text: 'pages.proveIdentityNoPhotoId.content.formRadioButtons.continueBankDetailsButtonText' | translate
         },
         {
           value: "end",
-          text: 'pages.proveIdentityBankAccount.content.formRadioButtons.otherWayButtonText' | translateWithContext(context)
+          text: 'pages.proveIdentityNoPhotoId.content.formRadioButtons.otherWayButtonText' | translateWithContext(context)
         }
       ]
     } %}
 
     {% if errorState %}
-      {% set errorMessageObject = { 'text': 'pages.proveIdentityBankAccount.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set errorMessageObject = { 'text': 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorRadioMessage' | translate } %}
       {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
     {% endif %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- rename prove identity bank account to prove identity no photo id
- add content for NI Number page

### What changed

- Renamed prove identity bank account to prove identity no photo id
- Added content for Prove identity NI number page

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To allow user to prove identity using NI number.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7010](https://govukverify.atlassian.net/browse/PYIC-7010)


New Page

<img width="728" alt="Screenshot 2024-07-16 at 13 29 22" src="https://github.com/user-attachments/assets/790088c0-20a4-4a39-a5cf-ce1553a05eee">

Existing page (URL changed)


<img width="763" alt="Screenshot 2024-07-16 at 10 01 59" src="https://github.com/user-attachments/assets/d88c61e1-bd54-4279-87ad-c96b66dffe5e">



[PYIC-7010]: https://govukverify.atlassian.net/browse/PYIC-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ