### PR TITLE
PYIC-7016: add multiple doc check context for nino p1 journey

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -806,35 +806,35 @@
           "gennych drwydded yrru y DU (llawn neu dros dro) neu basbort y DU",
           "rydych yn gallu ateb rhai cwestiynau diogelwch"
         ],
-        "requirementsNinoOnly": [
+        "requirementsNino": [
           "have a UK driving licence (full or provisional)",
           "UK passport",
           "National Insurance number"
         ],
         "paragraph2": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
         "paragraph2F2f": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
-        "paragraph2NinoOnly": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
+        "paragraph2Nino": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
         "paragraph3": "",
         "paragraph3F2f": "Mae'n cymryd tua 10 munud i brofi eich hunaniaeth fel hyn.",
-        "paragraph3NinoOnly": "It takes about 10 minutes to prove your identity this way.",
+        "paragraph3Nino": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "Sut ydych chi am barhau?",
         "subHeadingF2f": "Ydych chi am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth?",
-        "subHeadingNinoOnly": "What would you like to use to prove your identity?",
+        "subHeadingNino": "What would you like to use to prove your identity?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Rhowch fanylion eich trwydded yrru cerdyn-llun y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "continueDrivingLicenceButtonTextF2f": "trwydded yrru cerdyn-llun yn y DU",
           "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "continuePassportButtonTextF2f": "pasbort y DU",
-          "continueDrivingLicenceButtonTextNinoOnly": "UK photocard driving licence",
-          "continuePassportButtonTextNinoOnly": "UK passport",
-          "continueNinoButtonTextNinoOnly": "National Insurance number",
+          "continueDrivingLicenceButtonTextNino": "UK photocard driving licence",
+          "continuePassportButtonTextNino": "UK passport",
+          "continueNinoButtonTextNino": "National Insurance number",
           "separateOptionsInFormText": "neu",
           "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
           "otherWayButtonTextF2f": "Nid oes gennyf unrhyw un o'r mathau hyn o ID gyda llun",
           "otherWayButtonTextHint": "",
           "otherWayButtonTextHintF2f": "Efallai y bydd ffyrdd eraill o brofi eich hunaniaeth os oes gennych fath arall o ID gyda llun.",
-          "otherWayButtonTextNinoOnly": "I do not have any of these",
-          "otherWayButtonTextHintNinoOnly": ""
+          "otherWayButtonTextNino": "I do not have any of these",
+          "otherWayButtonTextHintNino": ""
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
@@ -921,14 +921,14 @@
     },
     "proveIdentityNoPhotoId": {
       "title": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
-      "titleNinoOnly": "Prove your identity with your National Insurance number and security questions",
+      "titleNino": "Prove your identity with your National Insurance number and security questions",
       "header": "Profi eich hunaniaeth gyda manylion banc neu gymdeithas adeiladu a chwestiynau diogelwch",
-      "headerNinoOnly": "Prove your identity with your National Insurance number and security questions",
+      "headerNino": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "Gallwch ddefnyddio unrhyw gyfrif cyfredol gyda banc neu gymdeithas adeiladu yn y DU i brofi eich hunaniaeth. Rhaid i'ch enw fod ar y cyfrif.",
         "subHeading": "Darparwch rhywfaint o fanylion personol",
         "paragraph2": "Byddwn yn gofyn i chi am eich:",
-        "paragraph2NinoOnly": "As well as your National Insurance number, we also need your:",
+        "paragraph2Nino": "As well as your National Insurance number, we also need your:",
         "personalDetails": {
           "name": "enw",
           "dob": "dyddiad geni",
@@ -938,13 +938,13 @@
         },
         "subHeading2": "Atebwch rhai cwestiynau diogelwch",
         "paragraph3": "Yna byddwn yn gofyn rhywfaint o gwestiynau diogelwch i chi. Mae hyn yn ein helpu i wirio a yw'r manylion rydych wedi'u rhoi yn cael eu defnyddio gennych chi.",
-        "paragraph3NinoOnly": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
+        "paragraph3Nino": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "A oes gennych gyfrif banc neu gymdeithas adeiladu cyfredol yn eich enw chi?",
-        "subHeading3NinoOnly": "Do you have a National Insurance number?",
+        "subHeading3Nino": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Oes",
           "otherWayButtonText": "Na - profi fy hunaniaeth mewn ffordd arall",
-          "otherWayButtonTextNinoOnly": "Na"
+          "otherWayButtonTextNino": "Na"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -802,21 +802,39 @@
           "gennych drwydded yrru y DU (llawn neu dros dro) neu basbort y DU",
           "rydych yn gallu ateb rhai cwestiynau diogelwch"
         ],
+        "requirementsF2f": [
+          "gennych drwydded yrru y DU (llawn neu dros dro) neu basbort y DU",
+          "rydych yn gallu ateb rhai cwestiynau diogelwch"
+        ],
+        "requirementsNinoOnly": [
+          "have a UK driving licence (full or provisional)",
+          "UK passport",
+          "National Insurance number"
+        ],
         "paragraph2": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
+        "paragraph2F2f": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
+        "paragraph2NinoOnly": "Rydym yn defnyddio cwestiynau diogelwch i atal unrhyw un a allai fod â’ch manylion rhag esgus bod yn chi.",
         "paragraph3": "",
         "paragraph3F2f": "Mae'n cymryd tua 10 munud i brofi eich hunaniaeth fel hyn.",
+        "paragraph3NinoOnly": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "Sut ydych chi am barhau?",
         "subHeadingF2f": "Ydych chi am ddefnyddio eich trwydded yrru cerdyn-llun y DU neu basbort y DU i brofi eich hunaniaeth?",
+        "subHeadingNinoOnly": "What would you like to use to prove your identity?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Rhowch fanylion eich trwydded yrru cerdyn-llun y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "continueDrivingLicenceButtonTextF2f": "trwydded yrru cerdyn-llun yn y DU",
           "continuePassportButtonText": "Rhowch fanylion eich pasbort y DU ac atebwch y cwestiynau diogelwch ar-lein",
           "continuePassportButtonTextF2f": "pasbort y DU",
+          "continueDrivingLicenceButtonTextNinoOnly": "UK photocard driving licence",
+          "continuePassportButtonTextNinoOnly": "UK passport",
+          "continueNinoButtonTextNinoOnly": "National Insurance number",
           "separateOptionsInFormText": "neu",
           "otherWayButtonText": "Mynd ymlaen i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i chwilio am ffyrdd eraill o brofi eich hunaniaeth",
           "otherWayButtonTextF2f": "Nid oes gennyf unrhyw un o'r mathau hyn o ID gyda llun",
           "otherWayButtonTextHint": "",
-          "otherWayButtonTextHintF2f": "Efallai y bydd ffyrdd eraill o brofi eich hunaniaeth os oes gennych fath arall o ID gyda llun."
+          "otherWayButtonTextHintF2f": "Efallai y bydd ffyrdd eraill o brofi eich hunaniaeth os oes gennych fath arall o ID gyda llun.",
+          "otherWayButtonTextNinoOnly": "I do not have any of these",
+          "otherWayButtonTextHintNinoOnly": ""
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -804,21 +804,39 @@
           "have a UK driving licence (full or provisional) or a UK passport",
           "can answer some security questions"
         ],
+        "requirementsF2f": [
+          "have a UK driving licence (full or provisional) or a UK passport",
+          "can answer some security questions"
+        ],
+        "requirementsNinoOnly": [
+          "have a UK driving licence (full or provisional)",
+          "UK passport",
+          "National Insurance number"
+        ],
         "paragraph2": "We use security questions to stop anyone who might have your details from pretending to be you.",
+        "paragraph2F2f": "We use security questions to stop anyone who might have your details from pretending to be you.",
+        "paragraph2NinoOnly": "You'll need to answer some security questions. We use security questions to stop anyone who might have your details from pretending to be you.",
         "paragraph3": "",
         "paragraph3F2f": "It takes about 10 minutes to prove your identity this way.",
+        "paragraph3NinoOnly": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "How do you want to continue?",
         "subHeadingF2f": "Do you want to use your UK photocard driving licence or UK passport to prove your identity?",
+        "subHeadingNinoOnly": "What would you like to use to prove your identity?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",
           "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
           "continueDrivingLicenceButtonTextF2f": "UK photocard driving licence",
           "continuePassportButtonTextF2f": "UK passport",
+          "continueDrivingLicenceButtonTextNinoOnly": "UK photocard driving licence",
+          "continuePassportButtonTextNinoOnly": "UK passport",
+          "continueNinoButtonTextNinoOnly": "National Insurance number",
           "separateOptionsInFormText": "or",
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
           "otherWayButtonTextF2f": "I do not have either of these types of photo ID",
           "otherWayButtonTextHint": "",
-          "otherWayButtonTextHintF2f": "There may be other ways to prove your identity if you have another type of photo ID."
+          "otherWayButtonTextHintF2f": "There may be other ways to prove your identity if you have another type of photo ID.",
+          "otherWayButtonTextNinoOnly": "I do not have any of these",
+          "otherWayButtonTextHintNinoOnly": ""
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -808,35 +808,35 @@
           "have a UK driving licence (full or provisional) or a UK passport",
           "can answer some security questions"
         ],
-        "requirementsNinoOnly": [
+        "requirementsNino": [
           "have a UK driving licence (full or provisional)",
           "UK passport",
           "National Insurance number"
         ],
         "paragraph2": "We use security questions to stop anyone who might have your details from pretending to be you.",
         "paragraph2F2f": "We use security questions to stop anyone who might have your details from pretending to be you.",
-        "paragraph2NinoOnly": "You'll need to answer some security questions. We use security questions to stop anyone who might have your details from pretending to be you.",
+        "paragraph2Nino": "You'll need to answer some security questions. We use security questions to stop anyone who might have your details from pretending to be you.",
         "paragraph3": "",
         "paragraph3F2f": "It takes about 10 minutes to prove your identity this way.",
-        "paragraph3NinoOnly": "It takes about 10 minutes to prove your identity this way.",
+        "paragraph3Nino": "It takes about 10 minutes to prove your identity this way.",
         "subHeading": "How do you want to continue?",
         "subHeadingF2f": "Do you want to use your UK photocard driving licence or UK passport to prove your identity?",
-        "subHeadingNinoOnly": "What would you like to use to prove your identity?",
+        "subHeadingNino": "What would you like to use to prove your identity?",
         "formRadioButtons": {
           "continueDrivingLicenceButtonText": "Enter your UK photocard driving licence details and answer security questions online",
           "continuePassportButtonText": "Enter your UK passport details and answer security questions online",
           "continueDrivingLicenceButtonTextF2f": "UK photocard driving licence",
           "continuePassportButtonTextF2f": "UK passport",
-          "continueDrivingLicenceButtonTextNinoOnly": "UK photocard driving licence",
-          "continuePassportButtonTextNinoOnly": "UK passport",
-          "continueNinoButtonTextNinoOnly": "National Insurance number",
+          "continueDrivingLicenceButtonTextNino": "UK photocard driving licence",
+          "continuePassportButtonTextNino": "UK passport",
+          "continueNinoButtonTextNino": "National Insurance number",
           "separateOptionsInFormText": "or",
           "otherWayButtonText": "Continue to the service you were trying to use to look for other ways to prove your identity",
           "otherWayButtonTextF2f": "I do not have either of these types of photo ID",
           "otherWayButtonTextHint": "",
           "otherWayButtonTextHintF2f": "There may be other ways to prove your identity if you have another type of photo ID.",
-          "otherWayButtonTextNinoOnly": "I do not have any of these",
-          "otherWayButtonTextHintNinoOnly": ""
+          "otherWayButtonTextNino": "I do not have any of these",
+          "otherWayButtonTextHintNino": ""
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
@@ -971,14 +971,14 @@
     },
     "proveIdentityNoPhotoId": {
       "title": "Prove your identity with bank or building society details and security questions",
-      "titleNinoOnly": "Prove your identity with your National Insurance number and security questions",
+      "titleNino": "Prove your identity with your National Insurance number and security questions",
       "header": "Prove your identity with bank or building society details and security questions",
-      "headerNinoOnly": "Prove your identity with your National Insurance number and security questions",
+      "headerNino": "Prove your identity with your National Insurance number and security questions",
       "content": {
         "paragraph1": "You can use any current account with a UK bank or building society to prove your identity. Your name must be on the account.",
         "subHeading": "Provide some personal details",
         "paragraph2": "We'll ask you for your:",
-        "paragraph2NinoOnly": "As well as your National Insurance number, we also need your:",
+        "paragraph2Nino": "As well as your National Insurance number, we also need your:",
         "personalDetails": {
           "name": "name",
           "dob": "date of birth",
@@ -988,13 +988,13 @@
         },
         "subHeading2": "Answer some security questions",
         "paragraph3": "We'll then ask you some security questions. This helps us check if the details you've given are being used by you.",
-        "paragraph3NinoOnly": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
+        "paragraph3Nino": "We’ll then ask you some security questions. We use these to stop anyone who might have your details from pretending to be you.",
         "subHeading3": "Do you have a UK bank or building society current account in your name?",
-        "subHeading3NinoOnly": "Do you have a National Insurance number?",
+        "subHeading3Nino": "Do you have a National Insurance number?",
         "formRadioButtons": {
           "continueBankDetailsButtonText": "Yes",
           "otherWayButtonText": "No - prove my identity another way",
-          "otherWayButtonTextNinoOnly": "No"
+          "otherWayButtonTextNino": "No"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -22,7 +22,7 @@
   ]
 %}
 
-{% if context == "nino-only" %}
+{% if context == "nino" %}
   {% set radioItems = (radioItems.push({
     value: "nino",
     text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueNinoButtonText' | translateWithContext(context)

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -10,7 +10,7 @@
 {% set errorHref = "#multipleDocCheckingForm" %}
 {% set isPageDynamic = true %}
 
-{% set readioItems = [
+{% set radioItems = [
     {
       value: "drivingLicence",
       text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translateWithContext(context)
@@ -23,13 +23,13 @@
 %}
 
 {% if context == "nino-only" %}
-  {% set readioItems = (readioItems.push({
+  {% set radioItems = (radioItems.push({
     value: "nino",
     text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueNinoButtonText' | translateWithContext(context)
-  }), readioItems) %}}
+  }), radioItems) %}}
 {% endif %}
 
-{% set readioItems = (readioItems.push(
+{% set radioItems = (radioItems.push(
   {
       divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
     },
@@ -37,7 +37,7 @@
       value: "end",
       text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translateWithContext(context),
       hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonTextHint' | translateWithContext(context) }
-  }), readioItems)
+  }), radioItems)
 %}}
 
 {% block content %}
@@ -62,7 +62,7 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: readioItems
+      items: radioItems
     } %}
 
     {% if errorState %}

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -10,15 +10,45 @@
 {% set errorHref = "#multipleDocCheckingForm" %}
 {% set isPageDynamic = true %}
 
+{% set readioItems = [
+    {
+      value: "drivingLicence",
+      text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translateWithContext(context)
+    },
+    {
+      value: "ukPassport",
+      text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translateWithContext(context)
+    }
+  ]
+%}
+
+{% if context == "nino-only" %}
+  {% set readioItems = (readioItems.push({
+    value: "nino",
+    text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueNinoButtonText' | translateWithContext(context)
+  }), readioItems) %}}
+{% endif %}
+
+{% set readioItems = (readioItems.push(
+  {
+      divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
+    },
+    {
+      value: "end",
+      text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translateWithContext(context),
+      hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonTextHint' | translateWithContext(context) }
+  }), readioItems)
+%}}
+
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageMultipleDocCheck.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph1' | translate | safe }}</p>
   <ul class="govuk-list govuk-list--bullet">
-    {% for listItem in 'pages.pageMultipleDocCheck.content.requirements' | translate({ returnObjects: true }) %}
+    {% for listItem in 'pages.pageMultipleDocCheck.content.requirements' | translateWithContext(context, { returnObjects: true }) %}
       <li>{{ listItem }}</li>
     {% endfor %}
   </ul>
-  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translate | safe }}</p>
+  <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph2' | translateWithContext(context) | safe }}</p>
   <p class="govuk-body">{{ 'pages.pageMultipleDocCheck.content.paragraph3' | translateWithContext(context) }}</p>
 
   <form id="multipleDocCheckingForm" action="/ipv/page/{{ pageId }}" method="POST">
@@ -32,24 +62,7 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: [
-        {
-          value: "drivingLicence",
-          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translateWithContext(context)
-        },
-        {
-          value: "ukPassport",
-          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translateWithContext(context)
-        },
-        {
-          divider: 'pages.pageMultipleDocCheck.content.formRadioButtons.separateOptionsInFormText' | translate
-        },
-        {
-          value: "end",
-          text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translateWithContext(context),
-          hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonTextHint' | translateWithContext(context) }
-        }
-      ]
+      items: readioItems
     } %}
 
     {% if errorState %}

--- a/src/views/ipv/page/prove-identity-no-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-photo-id.njk
@@ -11,7 +11,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityNoPhotoId.header' | translateWithContext(context) }}</h1>
-  {% if context != "nino-only" %}
+  {% if context != "nino" %}
     <p class="govuk-body">{{ 'pages.proveIdentityNoPhotoId.content.paragraph1' | translate }}</p>
     <h2 class="govuk-heading-m">{{ 'pages.proveIdentityNoPhotoId.content.subHeading' | translate }}</h2>
   {% endif %}
@@ -20,14 +20,14 @@
   <ul class="govuk-list govuk-list--bullet ">
     <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.name' | translate }}</li>
     <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.dob' | translate }}</li>
-    {% if context != "nino-only" %}
+    {% if context != "nino" %}
       <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.accountNumber' | translate }}</li>
       <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.NINumber' | translate }}</li>
     {% endif %}
     <li>{{ 'pages.proveIdentityNoPhotoId.content.personalDetails.address' | translate }}</li>
   </ul>
 
-  {% if context != "nino-only" %}
+  {% if context != "nino" %}
     <h2 class="govuk-heading-m">{{ 'pages.proveIdentityNoPhotoId.content.subHeading2' | translate }}</h2>
   {% endif %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Add Nino option for multiple doc check page.

### What changed

- Added Nino option to existing multiple doc check page.

<!-- Describe the changes in detail - the "what"-->


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7016](https://govukverify.atlassian.net/browse/PYIC-7016)

New page with nino-only context

<img width="750" alt="Screenshot 2024-07-19 at 09 46 57" src="https://github.com/user-attachments/assets/cffbb628-0d66-4c90-a09e-51bbf4766d96">

Existing page with f2f context

<img width="869" alt="Screenshot 2024-07-19 at 09 48 18" src="https://github.com/user-attachments/assets/5d9b2ca1-1162-493d-83d2-bd261ad30da0">


[PYIC-7016]: https://govukverify.atlassian.net/browse/PYIC-7016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ