### PR TITLE
PYIC-7017: Update no-photo-id-security-questions-find-another-way for…

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -284,27 +284,38 @@
     },
     "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
+      "titleP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "titleDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "titleP1Dropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "header": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
+      "headerP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "headerDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
+      "headerP1Dropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
         "paragraph1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
+        "paragraph1P1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
         "paragraph1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
+        "paragraph1P1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
         "subHeading": "Os nad oes gennych ID gyda llun",
         "paragraph2": "Gallwch geisio profi eich hunaniaeth gyda'r gwasanaeth rydych angen ei ddefnyddio. Efallai y byddant yn cymryd mathau eraill o ID.",
         "subHeading2": "Os oes gennych ID gyda llun",
         "paragraph3": "Gallwch ddefnyddio ID gyda llun i brofi eich hunaniaeth gan ddefnyddio'r ap GOV.UK ID Check neu mewn Swyddfa Bost.",
         "details": {
           "label": "Mathau o ID gyda llun y gallwch ei ddefnyddio",
-          "text": "<p class=\"govuk-body\">Gallwch ddefnyddio: </p><ul class=\"govuk-list--bullet\"><li>Trwydded yrru cerdyn-llun yn y DU</li><li>Trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)</li><li>Pasbort y DU</li><li>pasbort o'r tu allan i'r DU</li><li>Cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)</li><li>Trwydded breswylio biometrig y DU (BRP)</li><li>Cerdyn preswylio biometrig y DU (BRC)</li><li>Trwydded Gweithwyr Ffiniol y DU (FWP)</li></ul>"
+          "text": "<p class=\"govuk-body\">Gallwch ddefnyddio: </p><ul class=\"govuk-list--bullet\"><li>Trwydded yrru cerdyn-llun yn y DU</li><li>Trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)</li><li>Pasbort y DU</li><li>pasbort o'r tu allan i'r DU</li><li>Cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)</li><li>Trwydded breswylio biometrig y DU (BRP)</li><li>Cerdyn preswylio biometrig y DU (BRC)</li><li>Trwydded Gweithwyr Ffiniol y DU (FWP)</li></ul>",
+          "textDropout": "<p class=\"govuk-body\">Gallwch ddefnyddio: </p><ul class=\"govuk-list--bullet\"><li>Trwydded yrru cerdyn-llun yn y DU</li><li>Trwydded yrru cerdyn-llun yr Undeb Ewropeaidd (UE)</li><li>Pasbort y DU</li><li>pasbort o'r tu allan i'r DU</li><li>Cerdyn adnabod cenedlaethol o wlad Ardal Economaidd Ewropeaidd (AEE)</li><li>Trwydded breswylio biometrig y DU (BRP)</li><li>Cerdyn preswylio biometrig y DU (BRC)</li><li>Trwydded Gweithwyr Ffiniol y DU (FWP)</li></ul>",
+          "textP1": "<p class=\"govuk-body\">For the GOV.UK ID Check app, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>UK passport</li><li>non-UK passport with a biometric chip</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul><p class=\"govuk-body\">At a Post Office, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li></ul>",
+          "textP1Dropout": "<p class=\"govuk-body\">For the GOV.UK ID Check app, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>UK passport</li><li>non-UK passport with a biometric chip</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul><p class=\"govuk-body\">At a Post Office, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li></ul>"
         },
         "subHeading3": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
-          "radioButton1Text": "Ewch i'r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
-          "radioButton2Text": "Profi eich hunaniaeth gyda'r ap GOV.UK ID Check",
-          "radioButton2TextHint": "Dangosir i chi sut i lawrlwytho a defnyddio'r ap.",
-          "radioButton3Text": "Profwch eich hunaniaeth mewn Swyddfa'r Post",
-          "radioButton3TextHint": "Byddwch yn rhoi manylion o'ch ID llun ar GOV.UK yn gyntaf."
+          "radioButtonBackToRpText": "Ewch i'r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
+          "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
+          "radioButtonAppText": "Profi eich hunaniaeth gyda'r ap GOV.UK ID Check",
+          "radioButtonAppTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio'r ap.",
+          "radioButtonPoText": "Profwch eich hunaniaeth mewn Swyddfa'r Post",
+          "radioButtonPoTextHint": "Byddwch yn rhoi manylion o'ch ID llun ar GOV.UK yn gyntaf.",
+          "separateOptionsInFormText": "or"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -285,27 +285,38 @@
 
     "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Sorry, we cannot confirm your identity this way",
+      "titleP1": "Sorry, we cannot confirm your identity this way",
       "titleDropout": "Find another way to prove your identity",
+      "titleP1Dropout": "Find another way to prove your identity",
       "header": "Sorry, we cannot confirm your identity this way",
+      "headerP1": "Sorry, we cannot confirm your identity this way",
       "headerDropout": "Find another way to prove your identity",
+      "headerP1Dropout": "Find another way to prove your identity",
       "content": {
         "paragraph1": "This is because you did not answer some of the security questions correctly.",
+        "paragraph1P1": "This is because you did not answer some of the security questions correctly.",
         "paragraph1Dropout": "We were not able to complete your identity check using security questions.",
+        "paragraph1P1Dropout": "We were not able to complete your identity check using security questions.",
         "subHeading": "If you do not have photo ID",
         "paragraph2": "You can try proving your identity with the service you need to use. They may take other types of ID.",
         "subHeading2": "If you have photo ID",
         "paragraph3": "You can use photo ID to prove your identity using the GOV.UK ID Check app or at a Post Office.",
         "details": {
           "label": "Types of photo ID you can use",
-          "text": "<p class=\"govuk-body\">You can use a: </p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul>"
+          "text": "<p class=\"govuk-body\">You can use a: </p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul>",
+          "textDropout": "<p class=\"govuk-body\">You can use a: </p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul>",
+          "textP1": "<p class=\"govuk-body\">For the GOV.UK ID Check app, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>UK passport</li><li>non-UK passport with a biometric chip</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul><p class=\"govuk-body\">At a Post Office, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li></ul>",
+          "textP1Dropout": "<p class=\"govuk-body\">For the GOV.UK ID Check app, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>UK passport</li><li>non-UK passport with a biometric chip</li><li>UK biometric residence permit (BRP)</li><li>UK biometric residence card (BRC)</li><li>UK Frontier Worker permit</li></ul><p class=\"govuk-body\">At a Post Office, you can use a:</p><ul class=\"govuk-list--bullet\"><li>UK photocard driving licence</li><li>European Union (EU) photocard driving licence</li><li>UK passport</li><li>non-UK passport</li><li>National identity card from a European Economic Area (EEA) country</li><li>UK biometric residence permit (BRP)</li></ul>"
         },
         "subHeading3": "What would you like to do?",
         "formRadioButtons": {
-          "radioButton1Text": "Go to the service you need to use and find out if they take other types of ID",
-          "radioButton2Text": "Prove your identity with the GOV.UK ID check app",
-          "radioButton2TextHint": "You’ll be shown how to download and use the app.",
-          "radioButton3Text": "Prove your identity at a Post Office",
-          "radioButton3TextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first."
+          "radioButtonBackToRpText": "Go to the service you need to use and find out if they take other types of ID",
+          "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
+          "radioButtonAppText": "Prove your identity with the GOV.UK ID check app",
+          "radioButtonAppTextHint": "You’ll be shown how to download and use the app.",
+          "radioButtonPoText": "Prove your identity at a Post Office",
+          "radioButtonPoTextHint": "You’ll be asked to enter details from your photo ID on GOV.UK first.",
+          "separateOptionsInFormText": "or"
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -24,11 +24,55 @@
 
   {{ govukDetails({
     summaryText: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.details.label' | translate,
-    text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.details.text' | translate | safe
+    text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.details.text' | translateWithContext(context) | safe
   }) }}
 
   <form id="noPhotoIdSecurityQuestionsFindAnotherWayForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    {% if context == "p1" or context == "p1Dropout" %}
+      {% set radioOptions =
+        [
+          {
+            value: "appTriage",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppText' | translate,
+            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppTextHint' | translate }
+          },
+          {
+            value: "f2f",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoText' | translate,
+            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoTextHint' | translate }
+          },
+          {
+            divider: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.separateOptionsInFormText' | translate
+          },
+          {
+            value: "end",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpP1Text' | translate
+          }
+        ]
+    %}
+    {% else %}
+      {% set radioOptions =
+        [
+          {
+            value: "end",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpText' | translate
+          },
+          {
+            value: "appTriage",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppText' | translate,
+            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppTextHint' | translate }
+          },
+          {
+            value: "f2f",
+            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoText' | translate,
+            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoTextHint' | translate }
+          }
+        ]
+      %}
+    {% endif %}
+
     {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
@@ -38,24 +82,7 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: [
-        {
-          value: "end",
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton1Text' | translate
-
-        },
-        {
-          value: "appTriage",
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton2Text' | translate,
-          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton2TextHint' | translate }
-
-        },
-        {
-          value: "f2f",
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton3Text' | translate,
-          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButton3TextHint' | translate }
-        }
-      ]
+      items: radioOptions
     } %}
 
     {% if errorState %}


### PR DESCRIPTION
… P1 journey

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

no-photo-id-security-questions-find-another-way for P1 journeys

### Why did it change

There's a different design for P1 at the moment

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7017](https://govukverify.atlassian.net/browse/PYIC-7017)

![image](https://github.com/user-attachments/assets/b01361cf-75d6-4e11-8035-5a0a7850f0c9)
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/d1833b7b-6f9c-4ab7-8f01-fbc24739d044">


[PYIC-7017]: https://govukverify.atlassian.net/browse/PYIC-7017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

