### PR TITLE
PYIC-5598: Standardise page creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This guide explains how to:
 * [clone the repo and install the dependencies](#cloning-and-installing-ipv-core-front)
 * [run ipv-core-front locally](#running-ipv-core-front-locally)
 * [use pre-commit to verify your commits](#using-pre-commit-to-verify-your-commits)
+* [creating a new page](src/views/README.md)
 
 ## Cloning and installing ipv-core-front
 

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -319,11 +319,6 @@ async function handleUnexpectedPage(req, res, pageId) {
 }
 
 module.exports = {
-  renderAttemptRecoveryPage: async (req, res) => {
-    res.render(getIpvPageTemplatePath(PAGES.PYI_ATTEMPT_RECOVERY), {
-      csrfToken: req.csrfToken(),
-    });
-  },
   updateJourneyState: async (req, res, next) => {
     try {
       const currentPageId = req.params.pageId;

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -319,6 +319,11 @@ async function handleUnexpectedPage(req, res, pageId) {
 }
 
 module.exports = {
+  renderAttemptRecoveryPage: async (req, res) => {
+    res.render(getIpvPageTemplatePath(PAGES.PYI_ATTEMPT_RECOVERY), {
+      csrfToken: req.csrfToken(),
+    });
+  },
   updateJourneyState: async (req, res, next) => {
     try {
       const currentPageId = req.params.pageId;

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -621,15 +621,6 @@ describe("journey middleware", () => {
     });
   });
 
-  context("renderAttemptRecoveryPage", () => {
-    it("should render attempt recovery page", () => {
-      middleware.renderAttemptRecoveryPage(req, res);
-      expect(res.render).to.have.been.calledWith(
-        "ipv/page/pyi-attempt-recovery.njk",
-      );
-    });
-  });
-
   context(
     "handleJourneyAction: handling journey action with ukPassport, drivingLicence, end",
     () => {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -621,6 +621,15 @@ describe("journey middleware", () => {
     });
   });
 
+  context("renderAttemptRecoveryPage", () => {
+    it("should render attempt recovery page", () => {
+      middleware.renderAttemptRecoveryPage(req, res);
+      expect(res.render).to.have.been.calledWith(
+        "ipv/page/pyi-attempt-recovery.njk",
+      );
+    });
+  });
+
   context(
     "handleJourneyAction: handling journey action with ukPassport, drivingLicence, end",
     () => {

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -4,6 +4,7 @@ const bodyParser = require("body-parser");
 const router = express.Router();
 
 const {
+  renderAttemptRecoveryPage,
   updateJourneyState,
   handleJourneyPage,
   handleJourneyAction,
@@ -16,6 +17,7 @@ const {
 } = require("./middleware");
 
 const {
+  PYI_ATTEMPT_RECOVERY,
   UPDATE_DETAILS,
   CONFIRM_DETAILS,
 } = require("../../constants/ipv-pages");
@@ -28,6 +30,12 @@ function getPagePath(pageId) {
 }
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
+
+router.get(
+  getPagePath(PYI_ATTEMPT_RECOVERY),
+  csrfProtection,
+  renderAttemptRecoveryPage,
+);
 
 router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
 

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -4,7 +4,6 @@ const bodyParser = require("body-parser");
 const router = express.Router();
 
 const {
-  renderAttemptRecoveryPage,
   updateJourneyState,
   handleJourneyPage,
   handleJourneyAction,

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -17,7 +17,6 @@ const {
 } = require("./middleware");
 
 const {
-  PYI_ATTEMPT_RECOVERY,
   UPDATE_DETAILS,
   CONFIRM_DETAILS,
 } = require("../../constants/ipv-pages");
@@ -30,12 +29,6 @@ function getPagePath(pageId) {
 }
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
-
-router.get(
-  getPagePath(PYI_ATTEMPT_RECOVERY),
-  csrfProtection,
-  renderAttemptRecoveryPage,
-);
 
 router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
 

--- a/src/views/README.md
+++ b/src/views/README.md
@@ -1,0 +1,159 @@
+# Pages
+
+Updated: 01/08/2024
+
+## How they work
+
+### Rendering
+
+#### Intro
+
+- Nunjucks files are templates which are rendered by the Express app.
+- The Express handler returns the `res.render(<path to template>, renderOptions)`.
+- Requests are routed in `app/ipv/router.js` with generic route handlers.
+
+#### Hydrating the template
+
+From a number of sources:
+1. `renderOptions` provides dynamic variables, which may be different for each render:
+   - `context`
+     - General input indicating the need for different content.
+   - `pageId`
+     - The id of the page itself so the page form posts to the same URL.
+   - `csrfToken`
+     - Token passed into hidden input on page to be submitted with the rest of the form data.
+   - (optional params)
+     - `userDetails`
+       - User information, for the appropriate screens
+     - `qrCode`
+       - QR code to download the mobile doc checking app, dynamically input because can be IOS/ Android.
+     - `appDownloadUrl`
+       - Link to download the mobile doc checking app.
+     - `pageErrorState`
+       - Boolean indicating a form validating error on that page.
+     - `errorState`
+       - String indicating type of form error (`checkbox`/ `radiobox`).
+2. English/ Welsh content in `src/locales`.
+3. The `res.locals` variable set in `locales.js`.
+
+#### How the data is accessed
+
+1. `renderOptions`:
+   - Variables here can be referenced in Nunjucks like `"{{contactUsUrl}}"`.
+2. English/ Welsh content:
+   - These values are referenced in the template in single quotation marks, e.g.:
+    ```
+    {% set errorTitle = 'pages.pageMultipleDocCheck.content.formErrorMessage.errorSummaryTitleText' | translate %}
+    ```
+   - `translate` & variants are defined in `src/config/nunjucks.js`.
+     - It takes the reference as a key to find the content saved in `src/locales` files for english/ welsh.
+     - It can take secondary params, e.g.: `context`, which adds a suffix to the reference it's going to find.
+3. `locales.js`:
+    - the `res.locals` variable attributes are provided as variables in the Nunjucks file, to be accessible like `"{{contactUsUrl}}"`.
+
+## Creating a new page
+
+Assuming this page wants a radio input on it
+
+1. Add a Nunjucks template in `src/views/ipv/page`, e.g. `prove-identity-no-other-photo-id`
+
+Breaking this example down:
+- Needed as contains the common stylesheets, layout.
+    ```html
+    {% extends "shared/base.njk" %}
+    ```
+  - Relevant details:
+    - `pageTitleKey` is used for finding title from content, and `pageErrorState` may trigger an "Error: " prefix.
+    `showLanguageToggle` toggles the language toggle.
+    - `showBack` toggles the back link.
+    - `errorState` toggles error summary, which includes: `errorTitle`, `errorText` and `errorHref`.
+    - `googleTagManagerPageId` sets state.
+
+- Import common, standard GovUK components.
+    ```html
+    {% from "govuk/components/button/macro.njk" import govukButton %}
+    {% from "govuk/components/radios/macro.njk" import govukRadios %}
+    ```
+
+- Sets the page title using English/ Welsh content.
+    ```html
+    {% set pageTitleKey = 'pages.proveIdentityNoOtherPhotoId.title' %}
+    ```
+
+- Sets the tag for analytics.
+    ```html
+    {% set googleTagManagerPageId = "proveIdentityNoOtherPhotoId" %}
+    ```
+
+- Variables for indicating errors, used in shared/base.njk as well.
+    ```html
+    {% set errorState = pageErrorState %}
+    {% set errorTitle = 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorSummaryTitleText' | translate %}
+    {% set errorText = 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+    {% set errorHref = "#proveIdentityNoOtherPhotoIdForm" %}
+    ```
+  - `errorHref` should reference the form's id, so it hash-links there.
+
+- The form which POSTs to the same URL as the page.
+    ```html
+    <form id="proveIdentityNoOtherPhotoIdForm" action="/ipv/page/{{ pageId }}" method="POST">
+    ```
+
+- Hidden input for carrying the token from the GET request to the POST request.
+    ```html
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    ```
+  - `req.csrfToken()` creates the token in the GET route handler
+  - The result is saved in here
+  - And `csrfProtection()` checks it, in the POST route handler.
+  - Arguably not a required security feature since our forms only lead to change in position on a journey map.
+
+- Variable with the config for the govukRadios component. Represents key value pair where key is "journey".
+    ```html
+    {% set radiosConfig = {...} %}
+    ```
+  - The values given to the radio map directly with the event the state associated will produce, so keep to camelCase.
+
+- This is the conditionally-visible error message inside radio.
+    ```html
+    {% if errorState %}
+        {% set errorMessageObject = { 'text': 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorRadioMessage' | translate } %}
+        {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+    {% endif %}
+    ```
+
+- We populate standard govUk components here.
+    ```html
+    {{ govukRadios(radiosConfig) }}
+    {{ govukButton({
+        id: "submitButton",
+        text: 'general.buttons.next' | translate
+    }) }}
+    ```
+
+- This is a (relatively) common link we have at the end of the page.
+    ```html
+    {% include "components/contact-us-link.njk" %}
+    ```
+    - The `contactUsUrl` is created in `locales.js` to include the `fromUrl` query.
+    - The link attributes are a blanket policy of GDS
+
+2. GET requests at `/page/:pageId` will be automatically handled with:
+   ```javascript
+   router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
+   ```
+3. POST requests, with:
+    ```javascript
+    router.post(
+        getPagePath(":pageId"),
+        parseForm,
+        csrfProtection,
+        formRadioButtonChecked,
+        handleJourneyAction,
+    );
+    ```
+
+### Notes
+
+- When adding in a feature, check if a specific govUk component exists before styling a generic tag.
+- When updating a journey map to use the page it must produce consistent events, for a certain `context`, across the journey maps. This is enforced with unit tests.

--- a/src/views/README.md
+++ b/src/views/README.md
@@ -34,7 +34,7 @@ From a number of sources:
      - `errorState`
        - String indicating type of form error (`checkbox`/ `radiobox`).
 2. English/ Welsh content in `src/locales`.
-3. The `res.locals` variable set in `locales.js`.
+3. The `res.locals` variable set in `localesjs`.
 
 #### How the data is accessed
 
@@ -48,7 +48,7 @@ From a number of sources:
    - `translate` & variants are defined in `src/config/nunjucks.js`.
      - It takes the reference as a key to find the content saved in `src/locales` files for english/ welsh.
      - It can take secondary params, e.g.: `context`, which adds a suffix to the reference it's going to find.
-3. `locales.js`:
+3. `locals.js`:
     - the `res.locals` variable attributes are provided as variables in the Nunjucks file, to be accessible like `"{{contactUsUrl}}"`.
 
 ## Creating a new page
@@ -69,7 +69,7 @@ Breaking this example down:
     - `errorState` toggles error summary, which includes: `errorTitle`, `errorText` and `errorHref`.
     - `googleTagManagerPageId` sets state.
 
-- Import common, standard GovUK components.
+- Import common, standard GovUK components if they are needed.
     ```html
     {% from "govuk/components/button/macro.njk" import govukButton %}
     {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -106,7 +106,6 @@ Breaking this example down:
   - `req.csrfToken()` creates the token in the GET route handler
   - The result is saved in here
   - And `csrfProtection()` checks it, in the POST route handler.
-  - Arguably not a required security feature since our forms only lead to change in position on a journey map.
 
 - Variable with the config for the govukRadios component. Represents key value pair where key is "journey".
     ```html
@@ -114,7 +113,7 @@ Breaking this example down:
     ```
   - The values given to the radio map directly with the event the state associated will produce, so keep to camelCase.
 
-- This is the conditionally-visible error message inside radio.
+- This is the conditionally-visible error message within the form.
     ```html
     {% if errorState %}
         {% set errorMessageObject = { 'text': 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorRadioMessage' | translate } %}
@@ -135,7 +134,7 @@ Breaking this example down:
     ```html
     {% include "components/contact-us-link.njk" %}
     ```
-    - The `contactUsUrl` is created in `locales.js` to include the `fromUrl` query.
+    - The `contactUsUrl` is created in `locals.js` to include the `fromUrl` query.
     - The link attributes are a blanket policy of GDS
 
 2. GET requests at `/page/:pageId` will be automatically handled with:
@@ -157,3 +156,6 @@ Breaking this example down:
 
 - When adding in a feature, check if a specific govUk component exists before styling a generic tag.
 - When updating a journey map to use the page it must produce consistent events, for a certain `context`, across the journey maps. This is enforced with unit tests.
+- Nunjucks docs: https://mozilla.github.io/nunjucks/
+- Design System docs: https://design-system.service.gov.uk/
+- Design System components (standard gov uk): https://design-system.service.gov.uk/components/

--- a/src/views/components/contact-us-link.njk
+++ b/src/views/components/contact-us-link.njk
@@ -1,0 +1,5 @@
+<p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
+        {{ 'general.shared.contactLinkText' | translate }}
+    </a>
+</p>

--- a/src/views/components/no-photo-id-exit-find-another-way-form.njk
+++ b/src/views/components/no-photo-id-exit-find-another-way-form.njk
@@ -42,7 +42,8 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>

--- a/src/views/components/pyi-escape-m2b-form.njk
+++ b/src/views/components/pyi-escape-m2b-form.njk
@@ -42,7 +42,8 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>

--- a/src/views/errors/page-not-found.njk
+++ b/src/views/errors/page-not-found.njk
@@ -17,5 +17,5 @@
     "href": 'general.shared.govUKHomepageButtonHref' | translate
   }) }}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/errors/session-ended.njk
+++ b/src/views/errors/session-ended.njk
@@ -14,5 +14,5 @@
     "href": 'general.shared.govUKHomepageButtonHref' | translate
   }) }}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/confirm-your-details.njk
+++ b/src/views/ipv/page/confirm-your-details.njk
@@ -10,20 +10,18 @@
 {% set googleTagManagerPageId = "confirmDetails" %}
 {% set isPageDynamic = false %}
 
-{% set errorTitle = 'pages.confirmDetails.content.errorSummaryTitleText' | translate %}
-{% set errorHref = "#confirmDetailsActionForm" %}
-
 {% if errorState == "radiobox" %}
     {% set errorText = 'pages.confirmDetails.content.errorRadioMessage' | translate %}
 {% else %}
     {% set errorText = 'pages.confirmDetails.content.errorCheckBoxMessage' | translate %}
 {% endif %}
-
+{% set errorTitle = 'pages.confirmDetails.content.errorSummaryTitleText' | translate %}
+{% set errorHref = "#confirmDetailsActionForm" %}
 
 {% block content %}
-
     <h1 class="govuk-heading-l" id="header" data-page="{{googleTagManagerPageId}}">{{ 'pages.confirmDetails.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.confirmDetails.content.paragraph1' | translate }}</p>
+
     <h2 class="govuk-heading-m">{{ 'pages.confirmDetails.content.summaryHeading' | translate }}</h2>
 
     {% set rows = [
@@ -64,15 +62,13 @@
     {{ govukSummaryList({
       rows: rows
     }) }}
-
     {{ govukDetails({
         summaryText: 'pages.confirmDetails.content.detailsTitle' | translate,
         text: 'pages.confirmDetails.content.detailsContent' | translate({ url: contactUsUrl }) | safe
     }) }}
 
     <form id="confirmDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {% set checkboxConfig = {
             idPrefix: "journey",
             name: "detailsToUpdate",
@@ -129,36 +125,34 @@
         },
         items: [
             {
-            value: "yes",
-            text: 'pages.confirmDetails.content.formRadioButtons.yes' | translate
+                value: "yes",
+                text: 'pages.confirmDetails.content.formRadioButtons.yes' | translate
             },
             {
-            value: "no",
-            text: 'pages.confirmDetails.content.formRadioButtons.no' | translate,
-            conditional: {
-                html: checkboxHtml
-            },
-            checked:  errorState == "checkbox"
+                value: "no",
+                text: 'pages.confirmDetails.content.formRadioButtons.no' | translate,
+                conditional: {
+                    html: checkboxHtml
+                },
+                checked:  errorState == "checkbox"
             }
         ]
         } %}
 
-
         {% if errorState == "radiobox" %}
-        {% set errorText = 'pages.confirmDetails.content.errorRadioMessage' | translate %}
-        {% set radiosErrorMessageObject = { 'text': 'pages.confirmDetails.content.errorRadioMessage' | translate } %}
-        {% set radiosConfig = radiosConfig | setAttribute('errorMessage', radiosErrorMessageObject) %}
+            {% set errorText = 'pages.confirmDetails.content.errorRadioMessage' | translate %}
+            {% set radiosErrorMessageObject = { 'text': 'pages.confirmDetails.content.errorRadioMessage' | translate } %}
+            {% set radiosConfig = radiosConfig | setAttribute('errorMessage', radiosErrorMessageObject) %}
         {% endif %}
 
         {{ govukRadios(radiosConfig) }}
-
         {{ govukWarningText({
-        text: 'pages.confirmDetails.content.warningTextContent' | translate,
-        iconFallbackText: 'pages.confirmDetails.content.warningTextFallback' | translate
+            text: 'pages.confirmDetails.content.warningTextContent' | translate,
+            iconFallbackText: 'pages.confirmDetails.content.warningTextFallback' | translate
         }) }}
-        <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-        {{ 'general.buttons.next' | translate }}
-        </button>
+        {{ govukButton({
+          id: "submitButton",
+          text: 'general.buttons.next' | translate
+        }) }}
     </form>
-
 {% endblock %}

--- a/src/views/ipv/page/find-another-way-access-service.njk
+++ b/src/views/ipv/page/find-another-way-access-service.njk
@@ -13,7 +13,6 @@
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.findAnotherWayAccessService.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.findAnotherWayAccessService.content.paragraph1' | translate }}</p>
 
-
   <form id="findAnotherWayAccessServiceActionForm" action="/ipv/page/{{ pageId }}" method="POST">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
       {% set radiosConfig = {
@@ -26,30 +25,30 @@
               }
           },
           items: [
-                  {
+              {
                   value: "contact",
                   text: 'pages.findAnotherWayAccessService.content.formRadioButtons.contactOption' | translate,
                   hint: { text: 'pages.findAnotherWayAccessService.content.formRadioButtons.contactOptionHint' | translate }
-                  },
-                  {
+              },
+              {
                   value: "end",
                   text: 'pages.findAnotherWayAccessService.content.formRadioButtons.endOption' | translate
-                  }
+              }
               ]
       }
       %}
 
       {% if errorState %}
-      {% set errorMessageObject = { 'text': 'pages.findAnotherWayAccessService.content.formErrorMessage.errorRadioMessage' | translate } %}
-      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+          {% set errorMessageObject = { 'text': 'pages.findAnotherWayAccessService.content.formErrorMessage.errorRadioMessage' | translate } %}
+          {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
       {% endif %}
 
       {{ govukRadios(radiosConfig) }}
-      <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-      </button>
+      {{ govukButton({
+          id: "submitButton",
+          text: 'general.buttons.next' | translate
+      }) }}
   </form>
 
-
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/no-photo-id-exit-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-exit-find-another-way.njk
@@ -4,7 +4,6 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitleKey = 'pages.noPhotoIdExitFindAnotherWay.title' %}
-
 {% set googleTagManagerPageId = "noPhotoIdExitFindAnotherWay" %}
 
 {% set errorState = pageErrorState %}
@@ -28,10 +27,5 @@
 
   {% include "components/no-photo-id-exit-find-another-way-form.njk" %}
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
-
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -18,7 +18,6 @@
   <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.paragraph2' | translate }}</p>
 
-
   <h2 class="govuk-heading-m">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading2' | translate }}</h2>
   <p class="govuk-body">{{ 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.paragraph3' | translate }}</p>
 
@@ -64,15 +63,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
-
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/page-dcmaw-success.njk
+++ b/src/views/ipv/page/page-dcmaw-success.njk
@@ -11,7 +11,6 @@
   {% include 'shared/journey-next-form.njk' %}
 
   {% if context == "coiAddress" or context == "coiNoAddress" %}
-    <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+    {% include "components/contact-us-link.njk" %}
   {% endif %}
-
 {% endblock %}

--- a/src/views/ipv/page/page-face-to-face-handoff.njk
+++ b/src/views/ipv/page/page-face-to-face-handoff.njk
@@ -6,7 +6,6 @@
 {% set googleTagManagerPageId = "pageF2fHandoff" %}
 
 {% block content %}
-
   {{ govukPanel({
     titleText: 'pages.pageF2fHandoff.panelText' | translate,
     classes:"di-f2f-panel govuk-!-margin-bottom-7"
@@ -42,6 +41,6 @@
       <li>{{ listItem }}</li>
     {% endfor %}
   </ul>
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
 
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/page-ipv-identity-document-start.njk
+++ b/src/views/ipv/page/page-ipv-identity-document-start.njk
@@ -84,9 +84,9 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/page-ipv-identity-postoffice-start.njk
+++ b/src/views/ipv/page/page-ipv-identity-postoffice-start.njk
@@ -11,8 +11,7 @@
 {% set errorHref = "#identityPostofficeStartPageOptionsForm" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
-      xmlns="http://www.w3.org/1999/html">{{ 'pages.pageIpvIdentityPostofficeStart.header' | translate }}</h1>
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageIpvIdentityPostofficeStart.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.pageIpvIdentityPostofficeStart.content.paragraph2' | translate }}</p>
 
@@ -70,8 +69,9 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/page-ipv-pending.njk
+++ b/src/views/ipv/page/page-ipv-pending.njk
@@ -26,5 +26,5 @@
     {% endfor %}
   </ul>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/page-multiple-doc-check.njk
+++ b/src/views/ipv/page/page-multiple-doc-check.njk
@@ -71,8 +71,9 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/page-update-name.njk
+++ b/src/views/ipv/page/page-update-name.njk
@@ -12,7 +12,6 @@
 {% set errorHref = "#pageUpdateNameOptionsForm" %}
 
 {% block content %}
-
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pageUpdateName.header' | translate }}</h1>
   <p class="govuk-body">{{ 'pages.pageUpdateName.content.paragraph1' | translate }}</p>
   <p class="govuk-body govuk-!-margin-bottom-2">{{ 'pages.pageUpdateName.content.paragraph2' | translate }}</p>
@@ -83,11 +82,9 @@
       summaryText: 'pages.pageUpdateName.content.cannotUseInformation.summary' | translate,
       text: 'pages.pageUpdateName.content.cannotUseInformation.text' | translate( { url: contactUsUrl } ) | safe
     }) }}
-
-
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
-
 {% endblock %}

--- a/src/views/ipv/page/prove-identity-another-type-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-another-type-photo-id.njk
@@ -7,7 +7,7 @@
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.proveIdentityAnotherTypePhotoId.content.formErrorMessage.errorSummaryTitleText' | translate %}
 {% set errorText = 'pages.proveIdentityAnotherTypePhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
-{% set errorHref = "#proveIdentityAnotherTypePhotoId" %}
+{% set errorHref = "#proveIdentityAnotherTypePhotoIdForm" %}
 
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityAnotherTypePhotoId.header' | translate }}</h1>
@@ -53,6 +53,7 @@
       id: "submitButton",
       text: 'general.buttons.next' | translate
     }) }}
-    <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
   </form>
+
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/prove-identity-no-other-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-other-photo-id.njk
@@ -7,7 +7,7 @@
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorSummaryTitleText' | translate %}
 {% set errorText = 'pages.proveIdentityNoOtherPhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
-{% set errorHref = "#proveIdentityNoOtherPhotoId" %}
+{% set errorHref = "#proveIdentityNoOtherPhotoIdForm" %}
 
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.proveIdentityNoOtherPhotoId.header' | translate }}</h1>
@@ -45,6 +45,7 @@
       id: "submitButton",
       text: 'general.buttons.next' | translate
     }) }}
-    <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
   </form>
+
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/prove-identity-no-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-photo-id.njk
@@ -62,8 +62,9 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-another-way.njk
+++ b/src/views/ipv/page/pyi-another-way.njk
@@ -11,5 +11,5 @@
 
   {% include 'shared/journey-next-form.njk' %}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-attempt-recovery.njk
+++ b/src/views/ipv/page/pyi-attempt-recovery.njk
@@ -9,7 +9,7 @@
   <h2 class="govuk-heading-m">{{'pages.pyiAttemptRecovery.content.subHeading' | translate }}</h2>
   <p class="govuk-body">{{'pages.pyiAttemptRecovery.content.paragraph2' | translate }}</p>
 
-  <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST">
+  <form id="attemptRecoveryForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="attempt-recovery">
     {{ govukButton({

--- a/src/views/ipv/page/pyi-attempt-recovery.njk
+++ b/src/views/ipv/page/pyi-attempt-recovery.njk
@@ -12,10 +12,11 @@
   <form id="attemptRecoveryForm" action="/ipv/page/pyi-attempt-recovery" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="attempt-recovery">
-    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-confirm-delete-details.njk
+++ b/src/views/ipv/page/pyi-confirm-delete-details.njk
@@ -38,10 +38,11 @@
       {% set errorMessageObject = { 'text': 'pages.pyiConfirmDeleteDetails.content.formErrorMessage.errorMessage' | translate } %}
       {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
     {% endif %}
-      
+
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-continue-with-driving-licence.njk
+++ b/src/views/ipv/page/pyi-continue-with-driving-licence.njk
@@ -50,10 +50,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-continue-with-passport.njk
+++ b/src/views/ipv/page/pyi-continue-with-passport.njk
@@ -51,10 +51,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-cri-escape-no-f2f.njk
+++ b/src/views/ipv/page/pyi-cri-escape-no-f2f.njk
@@ -54,15 +54,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
-
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-cri-escape.njk
+++ b/src/views/ipv/page/pyi-cri-escape.njk
@@ -55,14 +55,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-driving-licence-no-match-another-way.njk
+++ b/src/views/ipv/page/pyi-driving-licence-no-match-another-way.njk
@@ -44,14 +44,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-driving-licence-no-match.njk
+++ b/src/views/ipv/page/pyi-driving-licence-no-match.njk
@@ -10,5 +10,5 @@
 
   {% include 'shared/journey-next-form.njk' %}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-escape.njk
+++ b/src/views/ipv/page/pyi-escape.njk
@@ -41,15 +41,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
-
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-f2f-technical.njk
+++ b/src/views/ipv/page/pyi-f2f-technical.njk
@@ -42,14 +42,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-new-details.njk
+++ b/src/views/ipv/page/pyi-new-details.njk
@@ -67,8 +67,9 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/pyi-no-match.njk
+++ b/src/views/ipv/page/pyi-no-match.njk
@@ -15,5 +15,5 @@
 
   {% include 'shared/journey-next-form.njk' %}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-passport-no-match-another-way.njk
+++ b/src/views/ipv/page/pyi-passport-no-match-another-way.njk
@@ -43,14 +43,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-passport-no-match.njk
+++ b/src/views/ipv/page/pyi-passport-no-match.njk
@@ -10,5 +10,5 @@
 
   {% include 'shared/journey-next-form.njk' %}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">{{ 'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-post-office.njk
+++ b/src/views/ipv/page/pyi-post-office.njk
@@ -66,9 +66,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-suggest-other-options-no-f2f.njk
+++ b/src/views/ipv/page/pyi-suggest-other-options-no-f2f.njk
@@ -54,14 +54,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-suggest-other-options.njk
+++ b/src/views/ipv/page/pyi-suggest-other-options.njk
@@ -56,15 +56,11 @@
     {% endif %}
 
     {{ govukRadios(radiosConfig) }}
-    <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body">
-    <a target="_blank" rel="noopener noreferrer" href="{{ contactUsUrl }}" class="govuk-link">
-      {{ 'general.shared.contactLinkText' | translate }}
-    </a>
-  </p>
-
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-technical.njk
+++ b/src/views/ipv/page/pyi-technical.njk
@@ -20,5 +20,5 @@
     {% include 'shared/journey-next-form.njk' %}
   {% endif %}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-timeout-recoverable.njk
+++ b/src/views/ipv/page/pyi-timeout-recoverable.njk
@@ -22,10 +22,11 @@
   <form id="timeoutRecoverableForm" action="/ipv/page/pyi-timeout-recoverable" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="build-client-oauth-response">
-    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
-      {{'general.buttons.next' | translate }}
-    </button>
+    {{ govukButton({
+      id: "submitButton",
+      text: 'general.buttons.next' | translate
+    }) }}
   </form>
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-timeout-unrecoverable.njk
+++ b/src/views/ipv/page/pyi-timeout-unrecoverable.njk
@@ -19,5 +19,5 @@
     "href": 'general.shared.govUKHomepageButtonHref' | translate
   }) }}
 
-  <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{contactUsUrl}}" class="govuk-link">{{'general.shared.contactLinkText' | translate }}</a></p>
+  {% include "components/contact-us-link.njk" %}
 {% endblock %}

--- a/src/views/ipv/page/pyi-triage-mobile-confirm.njk
+++ b/src/views/ipv/page/pyi-triage-mobile-confirm.njk
@@ -7,7 +7,7 @@
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.pyiTriageMobileConfirm.content.formErrorMessage.errorSummaryTitleText' | translate %}
 {% set errorText = 'pages.pyiTriageMobileConfirm.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
-{% set errorHref = "#pyiTriageMobileConfirm" %}
+{% set errorHref = "#pyiTriageMobileConfirmForm" %}
 
 {% block content %}
   <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.pyiTriageMobileConfirm.header' | translate }}</h1>

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -45,8 +45,9 @@
       {% endif %}
 
       {{ govukRadios(radiosConfig) }}
-      <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-      {{ 'general.buttons.next' | translate }}
-      </button>
+      {{ govukButton({
+          id: "submitButton",
+          text: 'general.buttons.next' | translate
+        }) }}
   </form>
 {% endblock %}

--- a/src/views/ipv/page/update-details.njk
+++ b/src/views/ipv/page/update-details.njk
@@ -105,8 +105,9 @@
               {% set checkboxConfig = checkboxConfig | setAttribute('errorMessage', errorMessageObject) %}
             {% endif %}
             {{ govukCheckboxes(checkboxConfig) }}
-            <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-                {{ 'general.buttons.next' | translate }}
-            </button>
+            {{ govukButton({
+              id: "submitButton",
+              text: 'general.buttons.next' | translate
+            }) }}
     </form>
 {% endblock %}

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -57,8 +57,9 @@
         {% endif %}
 
         {{ govukRadios(radiosConfig) }}
-        <button name="submitButton" class="govuk-button" data-module="govuk-button" id="submitButton">
-        {{ 'general.buttons.next' | translate }}
-        </button>
+        {{ govukButton({
+          id: "submitButton",
+          text: 'general.buttons.next' | translate
+        }) }}
     </form>
 {% endblock %}

--- a/src/views/shared/journey-next-form.njk
+++ b/src/views/shared/journey-next-form.njk
@@ -3,11 +3,15 @@
 <form id="nextForm" action="/ipv/page/{{pageId}}" method="POST">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="journey" value="next">
-    <button name="submitButton" class="govuk-button button" data-module="govuk-button" id="submitButton">
-      {% if customButtonLabel %}
-      {{ customButtonLabel }}
-      {% else %}
-      {{'general.buttons.next' | translate }}
-      {% endif %}
-    </button>
+    {% if customButtonLabel %}
+        {{ govukButton({
+            id: "submitButton",
+            text: customButtonLabel
+        }) }}
+    {% else %}
+        {{ govukButton({
+            id: "submitButton",
+            text:'general.buttons.next' | translate
+        }) }}
+    {% endif %}
 </form>


### PR DESCRIPTION
## Proposed changes

### What changed

- Add views README
- Create common contact-us-link.njk
- Standardise pages
- Remove renderAttemptRecoveryPage

### Why did it change

- To make pages easier to understand and more consistent

### Issue tracking

- [PYIC-5598](https://govukverify.atlassian.net/browse/PYIC-5598)

[PYIC-5598]: https://govukverify.atlassian.net/browse/PYIC-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ