### PR TITLE
PYIC-6914: Add cookies parser and language to call to backend

### DIFF
--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const csrf = require("csurf");
 const bodyParser = require("body-parser");
+const cookieParser = require("cookie-parser");
 const router = express.Router();
 
 const {
@@ -48,6 +49,7 @@ router.post(
   csrfProtection,
   formHandleUpdateDetailsCheckBox,
   formRadioButtonChecked,
+  cookieParser(),
   handleJourneyAction,
 );
 
@@ -58,6 +60,7 @@ router.post(
   csrfProtection,
   formHandleCoiDetailsCheck,
   formRadioButtonChecked,
+  cookieParser(),
   handleJourneyAction,
 );
 
@@ -66,11 +69,12 @@ router.post(
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
+  cookieParser(),
   handleJourneyAction,
 );
 
 // Enables a link in the frontend to iterate the journey state
 // This is needed because some redirects must be done with links, not forms
-router.get("/journey/:pageId/:action", updateJourneyState);
+router.get("/journey/:pageId/:action", cookieParser(), updateJourneyState);
 
 module.exports = router;

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const csrf = require("csurf");
 const bodyParser = require("body-parser");
-const cookieParser = require("cookie-parser");
 const router = express.Router();
 
 const {
@@ -49,7 +48,6 @@ router.post(
   csrfProtection,
   formHandleUpdateDetailsCheckBox,
   formRadioButtonChecked,
-  cookieParser(),
   handleJourneyAction,
 );
 
@@ -60,7 +58,6 @@ router.post(
   csrfProtection,
   formHandleCoiDetailsCheck,
   formRadioButtonChecked,
-  cookieParser(),
   handleJourneyAction,
 );
 
@@ -69,12 +66,11 @@ router.post(
   parseForm,
   csrfProtection,
   formRadioButtonChecked,
-  cookieParser(),
   handleJourneyAction,
 );
 
 // Enables a link in the frontend to iterate the journey state
 // This is needed because some redirects must be done with links, not forms
-router.get("/journey/:pageId/:action", cookieParser(), updateJourneyState);
+router.get("/journey/:pageId/:action", updateJourneyState);
 
 module.exports = router;

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -21,7 +21,7 @@ function generateAxiosConfig(url, req) {
       "content-type": "application/json",
       "x-request-id": req.id,
       "ip-address": personalDataHeaders["x-forwarded-for"] || "unknown", // Passing x-forwarded-for as ip-address because AWS appends its own incorrect IP address when using "x-forwarded-for"
-      "language": req.cookies.lng,
+      language: req.cookies.lng,
       "feature-set": req.session.featureSet,
       ...(req.session.ipvSessionId && {
         "ipv-session-id": req.session.ipvSessionId,

--- a/src/services/coreBackService.js
+++ b/src/services/coreBackService.js
@@ -21,6 +21,7 @@ function generateAxiosConfig(url, req) {
       "content-type": "application/json",
       "x-request-id": req.id,
       "ip-address": personalDataHeaders["x-forwarded-for"] || "unknown", // Passing x-forwarded-for as ip-address because AWS appends its own incorrect IP address when using "x-forwarded-for"
+      "language": req.cookies.lng,
       "feature-set": req.session.featureSet,
       ...(req.session.ipvSessionId && {
         "ipv-session-id": req.session.ipvSessionId,

--- a/src/services/coreBackService.test.js
+++ b/src/services/coreBackService.test.js
@@ -24,6 +24,9 @@ describe("CoreBackService", () => {
     },
     id: "test_request_id",
     ip: "127.0.0.1",
+    cookies: {
+      lng: "en",
+    },
   };
 
   beforeEach(() => {
@@ -57,6 +60,7 @@ describe("CoreBackService", () => {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
           "ip-address": "127.0.0.2",
+          language: "en",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -84,6 +88,7 @@ describe("CoreBackService", () => {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
           "ip-address": "127.0.0.2",
+          language: "en",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -112,6 +117,7 @@ describe("CoreBackService", () => {
           "content-type": "application/json",
           "x-request-id": "test_request_id",
           "ip-address": "127.0.0.2",
+          language: "en",
           "feature-set": "test_feature_set",
           "ipv-session-id": "test_ipv_session_id",
           "client-session-id": "test_client_session_id",
@@ -136,6 +142,7 @@ describe("CoreBackService", () => {
         "content-type": "application/json",
         "x-request-id": "test_request_id",
         "ip-address": "127.0.0.2",
+        language: "en",
         "feature-set": "test_feature_set",
         "ipv-session-id": "test_ipv_session_id",
         "client-session-id": "test_client_session_id",


### PR DESCRIPTION
## Proposed changes

### What changed

- Add cookies parser and language to call to backend

### Why did it change

- To allow us to use the lng cookie in the backend

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6914](https://govukverify.atlassian.net/browse/PYIC-6914)

### Notes

Must merge this before https://github.com/govuk-one-login/ipv-core-back/pull/2288

[PYIC-6914]: https://govukverify.atlassian.net/browse/PYIC-6914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ