### PR TITLE
PYIC-6156: Updated handleJourneyPage/Action session validation

### DIFF
--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -49,7 +49,7 @@ describe("journey middleware", () => {
         ipAddress: "ip-address",
         featureSet: "feature-set",
       },
-      params: { pageId: "ipv-current-page" },
+      params: { pageId: "page-ipv-identity-document-start" },
       csrfToken: sinon.fake(),
       log: { info: sinon.fake(), error: sinon.fake() },
     };
@@ -300,7 +300,7 @@ describe("journey middleware", () => {
           body: { journey: "next" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         const callBack = sinon.stub();
@@ -368,7 +368,7 @@ describe("journey middleware", () => {
         body: { journey: "next" },
         session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
         log: { info: sinon.fake(), error: sinon.fake() },
-        params: { pageId: "ipv-current-page" },
+        params: { pageId: "page-ipv-identity-document-start" },
       };
 
       const callBack = sinon.stub();
@@ -396,13 +396,17 @@ describe("journey middleware", () => {
           body: { journey: "end" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "end", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "end",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with attempt-recovery", async function () {
@@ -411,13 +415,17 @@ describe("journey middleware", () => {
           body: { journey: "attempt-recovery" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "attempt-recovery", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "attempt-recovery",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with build-client-oauth-response and use ip address from header when not present in session", async function () {
@@ -427,7 +435,7 @@ describe("journey middleware", () => {
           session: { ipvSessionId: "ipv-session-id" },
           headers: { forwarded: "1.1.1.1" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -436,7 +444,7 @@ describe("journey middleware", () => {
         ).to.have.been.calledWith(
           req,
           "build-client-oauth-response",
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
       });
 
@@ -447,7 +455,7 @@ describe("journey middleware", () => {
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           headers: { forwarded: "1.1.1.1" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -456,32 +464,11 @@ describe("journey middleware", () => {
         ).to.have.been.calledWith(
           req,
           "build-client-oauth-response",
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
       });
     },
   );
-
-  context("handling missing ipvSessionId before calling the backend", () => {
-    it("should render the technical unrecoverable page", async function () {
-      req = {
-        id: "1",
-        session: {
-          currentPage: "page-ipv-identity-document-start",
-          ipvSessionId: null,
-          ipAddress: "ip-address",
-        },
-        params: { pageId: "ipv-current-page" },
-        log: { info: sinon.fake(), error: sinon.fake() },
-      };
-
-      await middleware.handleJourneyAction(req, res, next);
-      expect(res.status).to.have.been.calledWith(401);
-      expect(res.render).to.have.been.calledWith("ipv/page/pyi-technical.njk", {
-        context: "unrecoverable",
-      });
-    });
-  });
 
   context("handling page-ipv-reuse journey route", () => {
     const pageId = "page-ipv-reuse";
@@ -639,13 +626,17 @@ describe("journey middleware", () => {
           body: { journey: "ukPassport" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "ukPassport", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "ukPassport",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with drivingLicence", async function () {
@@ -654,13 +645,17 @@ describe("journey middleware", () => {
           body: { journey: "drivingLicence" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "drivingLicence", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "drivingLicence",
+          "page-ipv-identity-document-start",
+        );
       });
     },
   );
@@ -672,15 +667,22 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "end" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "end", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "end",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should call saveAndRedirect given 'contact' event", async function () {
@@ -693,7 +695,7 @@ describe("journey middleware", () => {
             save: sinon.fake.yields(null),
           },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -711,13 +713,17 @@ describe("journey middleware", () => {
           body: { journey: "next" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "next", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "next",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with bankAccount", async function () {
@@ -726,39 +732,16 @@ describe("journey middleware", () => {
           body: { journey: "bankAccount" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "bankAccount", "ipv-current-page");
-      });
-    },
-  );
-
-  context(
-    "handleJourneyAction: handling missing ipvSessionId before calling the backend",
-    () => {
-      it("should render the technical unrecoverable page", async function () {
-        req = {
-          id: "1",
-          session: {
-            currentPage: "page-ipv-identity-document-start",
-            ipvSessionId: null,
-            ipAddress: "ip-address",
-          },
-          log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "page-ipv-identity-document-start" },
-        };
-
-        await middleware.handleJourneyAction(req, res, next);
-        expect(res.status).to.have.been.calledWith(401);
-        expect(res.render).to.have.been.calledWith(
-          "ipv/page/pyi-technical.njk",
-          {
-            context: "unrecoverable",
-          },
+        ).to.have.been.calledWith(
+          req,
+          "bankAccount",
+          "page-ipv-identity-document-start",
         );
       });
     },
@@ -773,18 +756,22 @@ describe("journey middleware", () => {
           body: { journey: "f2f" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(
           req,
           res,
           next,
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "f2f", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "f2f",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with dcmaw", async function () {
@@ -793,13 +780,17 @@ describe("journey middleware", () => {
           body: { journey: "dcmaw" },
           session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "dcmaw", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "dcmaw",
+          "page-ipv-identity-document-start",
+        );
       });
     },
   );


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The session validation logic (checking for ipvSessionId or clientOauthSessionId) is now the same in both the GET (handleJourneyPage) and POST (handleJourneyAction) handlers. 
The GET handler is updated to accommodate users with either ipvSessionId or criSessionId, ensuring users returning from the mobile app are not excluded. 
With the new validation approach, both the GET and POST handlers now check for either an ipvSessionId or a clientOauthSessionId across all pages. 
This unified validation logic removes the need to differentiate between pages using pagesUsingSessionId.

### Why did it change

The GET validation is not the same as for POST. So people can/ can't get onto a page with different conditionality to whether they can post to it

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6156](https://govukverify.atlassian.net/browse/PYIC-6156)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6156]: https://govukverify.atlassian.net/browse/PYIC-6156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ