### PR TITLE
IPS-1004 Updates to Core Canary Deployments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -491,26 +491,6 @@ Resources:
         - Key: deregistration_delay.timeout_seconds
           Value: 30
 
-  SecondPrivateLoadBalancerListenerTargetGroupECS:
-    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
-    Properties:
-      HealthCheckEnabled: TRUE
-      HealthCheckProtocol: HTTP
-      HealthCheckPath: /healthcheck
-      HealthCheckTimeoutSeconds: 14
-      HealthCheckIntervalSeconds: 15
-      HealthyThresholdCount: 2
-      Matcher:
-        HttpCode: 200
-      Port: 80
-      Protocol: HTTP
-      TargetType: ip
-      VpcId:
-        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
-      TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 30
-
   PrivateLoadBalancerListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
@@ -1901,7 +1881,6 @@ Resources:
         ECSClusterName: !Ref CoreFrontCluster
         ECSServiceName: !GetAtt CoreFrontService.Name
         ECSServiceTaskDefinition: !Ref ECSServiceTaskDefinition
-        GreenTargetGroupName: !GetAtt SecondPrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
         LoadBalancerListenerARN: !Ref PrivateLoadBalancerListener
         PermissionsBoundary: !If
           - UsePermissionsBoundary

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -491,7 +491,25 @@ Resources:
         - Key: deregistration_delay.timeout_seconds
           Value: 30
 
-
+  SecondPrivateLoadBalancerListenerTargetGroupECS:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckEnabled: TRUE
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /healthcheck
+      HealthCheckTimeoutSeconds: 14
+      HealthCheckIntervalSeconds: 15
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: 200
+      Port: 80
+      Protocol: HTTP
+      TargetType: ip
+      VpcId:
+        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 30
 
   PrivateLoadBalancerListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
@@ -533,18 +551,22 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 45
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref PrivateLoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt CoreFrontECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
-            - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref PrivateLoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt CoreFrontECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+              - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
       TaskDefinition: !If
         - UseCanaryDeployment
         - !Ref AWS::NoValue
@@ -1866,26 +1888,35 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: UseCanaryDeployment
     Properties:
-      TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=9vFjXAXebnhiAago1o4zhHXwEGHub7ps" # v2.0.2
+      TemplateURL: https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=5RRU1nfKQD_d08FKttr8W7pzrAsqQiUM # v2.1.1
       Parameters:
-        ECSClusterName: !Ref CoreFrontCluster
-        ECSServiceName: !GetAtt CoreFrontService.Name
-        TargetGroupName: !GetAtt PrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
-        LoadBalancerListenerARN: !Ref PrivateLoadBalancerListener
-        ECSServiceTaskDefinition: !Ref ECSServiceTaskDefinition
-        DeploymentStrategy: !Ref DeploymentStrategy
-        VpcId: !Sub ${VpcStackName}-VpcId
-        ContainerName: app
-        ContainerPort: 8080
-        CloudWatchAlarms: !Ref FrontTargetGroup5xxPercentErrors
-        PermissionsBoundary: !If
-          - UsePermissionsBoundary
-          - !Ref PermissionsBoundary
-          - none
         CodeSigningConfigArn: !If
           - UseCodeSigning
           - !Ref CodeSigningConfigArn
           - !Ref AWS::NoValue
+        CloudWatchAlarms: !Ref FrontTargetGroup5xxPercentErrors
+        ContainerName: app
+        ContainerPort: 8080
+        DeploymentStrategy: !Ref DeploymentStrategy
+        ECSClusterName: !Ref CoreFrontCluster
+        ECSServiceName: !GetAtt CoreFrontService.Name
+        ECSServiceTaskDefinition: !Ref ECSServiceTaskDefinition
+        GreenTargetGroupName: !GetAtt SecondPrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
+        LoadBalancerListenerARN: !Ref PrivateLoadBalancerListener
+        PermissionsBoundary: !If
+          - UsePermissionsBoundary
+          - Fn::ImportValue: !Sub "${AWS::StackName}-ECSCanaryPermissionsBoundaryArn"
+          - none
+        SecurityGroups: !GetAtt CoreFrontECSSecurityGroup.GroupId
+        Subnets: !Join
+          - ","
+          - - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+            - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        TargetGroupName: !GetAtt PrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
+        TGHealthCheckIntervalSeconds: 5
+        TGHealthCheckTimeoutSeconds: 2
+        TGPort: 8080
+        VpcId: !Sub ${VpcStackName}-VpcId
 
 Outputs:
   CoreFrontUrl:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1884,7 +1884,7 @@ Resources:
         LoadBalancerListenerARN: !Ref PrivateLoadBalancerListener
         PermissionsBoundary: !If
           - UsePermissionsBoundary
-          - Fn::ImportValue: !Sub "${AWS::StackName}-ECSCanaryPermissionsBoundaryArn"
+          - !Ref PermissionsBoundary
           - none
         SecurityGroups: !GetAtt CoreFrontECSSecurityGroup.GroupId
         Subnets: !Join
@@ -1892,9 +1892,9 @@ Resources:
           - - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
             - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
         TargetGroupName: !GetAtt PrivateLoadBalancerListenerTargetGroupECS.TargetGroupName
-        TGHealthCheckIntervalSeconds: 5
-        TGHealthCheckTimeoutSeconds: 2
-        TGPort: 8080
+        TGHealthCheckIntervalSeconds: 15
+        TGHealthCheckTimeoutSeconds: 14
+        TGPort: 80
         VpcId: !Sub ${VpcStackName}-VpcId
 
 Outputs:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
IPS-1004 Updates to Core Canary Deployments

Updated Nested Stack to use v2.1.1 deployment

Resources Added:
 * SecondPrivateLoadBalancerListenerTargetGroupECS

Updated ECS::Service to make LoadBalancers and NetworkConfiguration dependant on whether usCanaryDeployment is enabled or disabled.

Updated ECSBlueGreenDeploymentStack to include the following:
 * GreenTargetGroupName
 * SecurityGroups
 * Subnets
 * TGHealthCheckIntervalSeconds
 * TGHealthCheckTimeoutSeconds
 * TGPort Also template to v2.1.1 Also updated PermissionsBoundary to use the "${AWS::StackName}-ECSCanaryPermissionsBoundaryArn"


<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1004](https://govukverify.atlassian.net/browse/IPS-1004)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1004]: https://govukverify.atlassian.net/browse/IPS-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ