### PR TITLE
PYIC-7202 Enable RUM when cookies are accepted

### DIFF
--- a/src/assets/javascript/analytics/ua/init.js
+++ b/src/assets/javascript/analytics/ua/init.js
@@ -46,12 +46,17 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
     const consentGiven = window.DI.analyticsGa4.cookie.hasConsentForAnalytics();
 
     if (consentGiven) {
+      window.dtrum && window.dtrum.enable();
       window.DI.analyticsGa4.loadGtmScript(
         window.DI.analyticsGa4.uaContainerId,
       );
       initGtm();
     } else {
+      window.dtrum && window.dtrum.disable();
       window.addEventListener("cookie-consent", window.DI.analyticsUa.init);
+      window.addEventListener("cookie-consent", function () {
+        window.dtrum && window.dtrum.enable();
+      });
     }
   };
 


### PR DESCRIPTION
## Proposed changes

### What changed

RUM is off-by-default, and needs to be explicitly enabled when analytics cookies are accepted

### Why did it change

Previously RUM had no way of detecting whether consent had been granted, so stayed off

### Issue tracking

- [PYIC-7202](https://govukverify.atlassian.net/browse/PYIC-7202)


[PYIC-7202]: https://govukverify.atlassian.net/browse/PYIC-7202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ