### PR TITLE
PYIC-7160: add routing to delete account page when pressing continue

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -83,6 +83,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: ""
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.build.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.dev.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -102,6 +103,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: ""
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.build.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.dev.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -124,6 +126,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: ""
       contactUrl: "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.build.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.build.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -143,6 +146,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/f728f1a83dd1b716_complete.js"
       contactUrl: "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.staging.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.staging.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -162,6 +166,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/952c24127da85c63_complete.js"
       contactUrl: "https://home.integration.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.integration.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.integration.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -181,6 +186,7 @@ Mappings:
       uaDisabled: false
       dtRumUrl: "" # https://js-cdn.dynatrace.com/jstag/17177a07246/bf04188tda/fa56a4b3a9bbea0_complete.js
       contactUrl: "https://home.account.gov.uk/contact-gov-uk-one-login"
+      deleteAccountUrl: "https://home.account.gov.uk/enter-password?type=deleteAccount"
       logoutUrl: "https://oidc.account.gov.uk/logout"
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -812,6 +818,11 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - contactUrl
+            - Name: DELETE_ACCOUNT_URL
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - deleteAccountUrl
             - Name: TEMPLATE_CACHING
               Value: !FindInMap
                 - EnvironmentConfiguration

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -429,7 +429,11 @@ module.exports = {
       }
 
       if (req.body?.journey === "deleteAccount") {
-        return await saveSessionAndRedirect(req, res, res.locals.deleteAccountUrl);
+        return await saveSessionAndRedirect(
+          req,
+          res,
+          res.locals.deleteAccountUrl,
+        );
       }
 
       await handleJourneyResponse(req, res, req.body.journey, currentPageId);

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -428,6 +428,10 @@ module.exports = {
         return await saveSessionAndRedirect(req, res, res.locals.contactUsUrl);
       }
 
+      if (req.body?.journey === "deleteAccount") {
+        return await saveSessionAndRedirect(req, res, res.locals.deleteAccountUrl);
+      }
+
       await handleJourneyResponse(req, res, req.body.journey, currentPageId);
     } catch (error) {
       transformError(error, `error handling POST request on ${currentPageId}`);

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -41,7 +41,7 @@ describe("journey middleware", () => {
       send: sinon.fake(),
       render: sinon.fake(),
       log: { info: sinon.fake(), error: sinon.fake() },
-      locals: { contactUsUrl: "contactUrl" },
+      locals: { contactUsUrl: "contactUrl", deleteAccountUrl: "deleteAccount" },
     };
     req = {
       session: {
@@ -698,6 +698,23 @@ describe("journey middleware", () => {
 
         await middleware.handleJourneyAction(req, res, next);
         expect(res.redirect).to.have.been.calledWith("contactUrl");
+      });
+
+      it("should call saveAndRedirect given 'deleteAccount' event", async function () {
+        req = {
+          id: "1",
+          body: { journey: "deleteAccount" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            save: sinon.fake.yields(null),
+          },
+          log: { info: sinon.fake(), error: sinon.fake() },
+          params: { pageId: "ipv-current-page" },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(res.redirect).to.have.been.calledWith("deleteAccount");
       });
     },
   );

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -40,4 +40,5 @@ module.exports = {
   SERVICE_DOMAIN: process.env.SERVICE_DOMAIN || "localhost",
   LANGUAGE_TOGGLE_ENABLED: process.env.LANGUAGE_TOGGLE === "true",
   LOGOUT_URL: process.env.LOGOUT_URL || "https://oidc.account.gov.uk/logout",
+  DELETE_ACCOUNT_URL: process.env.DELETE_ACCOUNT_URL || "https://home.build.account.gov.uk/enter-password?type=deleteAccount"
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -40,5 +40,7 @@ module.exports = {
   SERVICE_DOMAIN: process.env.SERVICE_DOMAIN || "localhost",
   LANGUAGE_TOGGLE_ENABLED: process.env.LANGUAGE_TOGGLE === "true",
   LOGOUT_URL: process.env.LOGOUT_URL || "https://oidc.account.gov.uk/logout",
-  DELETE_ACCOUNT_URL: process.env.DELETE_ACCOUNT_URL || "https://home.build.account.gov.uk/enter-password?type=deleteAccount"
+  DELETE_ACCOUNT_URL:
+    process.env.DELETE_ACCOUNT_URL ||
+    "https://home.build.account.gov.uk/enter-password?type=deleteAccount",
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -8,18 +8,15 @@ const {
   GA4_DISABLED,
   DT_RUM_URL,
   LOGOUT_URL,
-  DELETE_ACCOUNT_URL
+  DELETE_ACCOUNT_URL,
 } = require("./config");
 const { generateNonce } = require("./strings");
 
-const generateUrlFromString = (url, req) => {
-  const url = new URL(CONTACT_URL);
-  contactUsUrl.searchParams.set(
-    "fromUrl",
-    `${SERVICE_URL}${req.originalUrl}`,
-  );
+const generateUrlFromString = (stringURl, req) => {
+  const url = new URL(stringURl);
+  url.searchParams.set("fromUrl", `${SERVICE_URL}${req.originalUrl}`);
   return url;
-}
+};
 
 module.exports = {
   setLocals: function (req, res, next) {
@@ -33,7 +30,8 @@ module.exports = {
     res.locals.logoutUrl = LOGOUT_URL;
 
     res.locals.contactUsUrl = generateUrlFromString(CONTACT_URL).href;
-    res.locals.deleteAccountUrl = generateUrlFromString(DELETE_ACCOUNT_URL).href;
+    res.locals.deleteAccountUrl =
+      generateUrlFromString(DELETE_ACCOUNT_URL).href;
 
     // Patch the status code setter to make it available in locals as well
     const setStatusCode = res.status;

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -12,12 +12,6 @@ const {
 } = require("./config");
 const { generateNonce } = require("./strings");
 
-const generateUrlFromString = (stringURl, req) => {
-  const url = new URL(stringURl);
-  url.searchParams.set("fromUrl", `${SERVICE_URL}${req.originalUrl}`);
-  return url;
-};
-
 module.exports = {
   setLocals: function (req, res, next) {
     res.locals.uaContainerId = GTM_ID;
@@ -29,9 +23,14 @@ module.exports = {
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.logoutUrl = LOGOUT_URL;
 
-    res.locals.contactUsUrl = generateUrlFromString(CONTACT_URL).href;
-    res.locals.deleteAccountUrl =
-      generateUrlFromString(DELETE_ACCOUNT_URL).href;
+    const contactUsUrl = new URL(CONTACT_URL);
+    contactUsUrl.searchParams.set(
+      "fromUrl",
+      `${SERVICE_URL}${req.originalUrl}`,
+    );
+    res.locals.contactUsUrl = contactUsUrl.href;
+
+    res.locals.deleteAccountUrl = DELETE_ACCOUNT_URL;
 
     // Patch the status code setter to make it available in locals as well
     const setStatusCode = res.status;

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -8,8 +8,18 @@ const {
   GA4_DISABLED,
   DT_RUM_URL,
   LOGOUT_URL,
+  DELETE_ACCOUNT_URL
 } = require("./config");
 const { generateNonce } = require("./strings");
+
+const generateUrlFromString = (url, req) => {
+  const url = new URL(CONTACT_URL);
+  contactUsUrl.searchParams.set(
+    "fromUrl",
+    `${SERVICE_URL}${req.originalUrl}`,
+  );
+  return url;
+}
 
 module.exports = {
   setLocals: function (req, res, next) {
@@ -22,12 +32,8 @@ module.exports = {
     res.locals.analyticsCookieDomain = GTM_ANALYTICS_COOKIE_DOMAIN;
     res.locals.logoutUrl = LOGOUT_URL;
 
-    const contactUsUrl = new URL(CONTACT_URL);
-    contactUsUrl.searchParams.set(
-      "fromUrl",
-      `${SERVICE_URL}${req.originalUrl}`,
-    );
-    res.locals.contactUsUrl = contactUsUrl.href;
+    res.locals.contactUsUrl = generateUrlFromString(CONTACT_URL).href;
+    res.locals.deleteAccountUrl = generateUrlFromString(DELETE_ACCOUNT_URL).href;
 
     // Patch the status code setter to make it available in locals as well
     const setStatusCode = res.status;

--- a/src/views/ipv/page/delete-handover.njk
+++ b/src/views/ipv/page/delete-handover.njk
@@ -1,4 +1,5 @@
 {% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% set pageTitleKey = 'pages.deleteHandover.title' %}
 {% set googleTagManagerPageId = "deleteHandover" %}
 {% set isPageDynamic = false %}
@@ -9,5 +10,12 @@
   <p class="govuk-body">{{ 'pages.deleteHandover.content.paragraph1Html' | translate | safe }}</p>
   <p class="govuk-body">{{ 'pages.deleteHandover.content.paragraph2' | translate  }}</p>
 
-  {% include 'shared/journey-next-form.njk' %}
+  <form id="deleteAccountForm" action="/ipv/page/{{pageId}}" method="POST">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <input type="hidden" name="journey" value="deleteAccount">
+    {{ govukButton({
+        id: "submitButton",
+        text:'general.buttons.next' | translate
+    }) }}
+  </form>
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds redirect to delete account when pressing continue on `delete-handover` page

### Why did it change
User can delete their account themselves to reduce the number of users contacting the call centre for help.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7160](https://govukverify.atlassian.net/browse/PYIC-7160)


[PYIC-7160]: https://govukverify.atlassian.net/browse/PYIC-7160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ