### PR TITLE
PYIC-7163: added update details failed page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1211,6 +1211,25 @@
         "paragraph1Html": "TODO: When you continue, you'll be able to permanently delete your GOV.UK One Login. Find out <a class=\"govuk-link\" rel=\"noopener\" target=\"_blank\" href=\"https://www.gov.uk/guidance/deleting-your-govuk-one-login\">what happens when you delete your GOV.UK One Login (opens in new tab)<a>.",
         "paragraph2": "TODO: After you delete your GOV.UK One Login, go back to the service you were trying to use. You can then create a new GOV.UK One Login and prove your identity with your new details."
       }
+    },
+    "updateDetailsFailed": {
+      "title": "TODO: You were not able to update your details with the GOV.UK ID check app",
+      "header": "TODO:You were not able to update your details with the GOV.UK ID check app",
+      "content": {
+        "paragraph1": "TODO:You can still use the service if your details are out of date.",
+        "subHeading": "TODO: What would you like to do?",
+        "formRadioButtons": {
+          "continueOption": "TODO: Continue to the service without updating your details",
+          "continueOptionHint": "TODO: Your proof of identity is valid even if your details have changed.",
+          "deleteOption": "TODO: Delete your GOV.UK One Login",
+          "deleteOptionHint": "YTODO: ou can then create a new one and prove your identity using your new details."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "TODO: There is a problem",
+          "errorSummaryDescriptionText": "TODO: Select what you would like to do",
+          "errorRadioMessage": "TODO: Select what you would like to do"
+        }
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1213,6 +1213,25 @@
         "paragraph1Html": "When you continue, you'll be able to permanently delete your GOV.UK One Login. Find out <a class=\"govuk-link\" rel=\"noopener\" target=\"_blank\" href=\"https://www.gov.uk/guidance/deleting-your-govuk-one-login\">what happens when you delete your GOV.UK One Login (opens in new tab)<a>.",
         "paragraph2": "After you delete your GOV.UK One Login, go back to the service you were trying to use. You can then create a new GOV.UK One Login and prove your identity with your new details."
       }
+    },
+    "updateDetailsFailed": {
+      "title": "You were not able to update your details with the GOV.UK ID check app",
+      "header": "You were not able to update your details with the GOV.UK ID check app",
+      "content": {
+        "paragraph1": "You can still use the service if your details are out of date.",
+        "subHeading": "What would you like to do?",
+        "formRadioButtons": {
+          "continueOption": "Continue to the service without updating your details",
+          "continueOptionHint": "Your proof of identity is valid even if your details have changed.",
+          "deleteOption": "Delete your GOV.UK One Login",
+          "deleteOptionHint": "You can then create a new one and prove your identity using your new details."
+        },
+        "formErrorMessage": {
+          "errorSummaryTitleText": "There is a problem",
+          "errorSummaryDescriptionText": "Select what you would like to do",
+          "errorRadioMessage": "Select what you would like to do"
+        }
+      }
     }
   }
 }

--- a/src/views/ipv/page/update-details-failed.njk
+++ b/src/views/ipv/page/update-details-failed.njk
@@ -1,0 +1,53 @@
+{% extends "shared/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleKey = 'pages.updateDetailsFailed.title' %}
+{% set googleTagManagerPageId = "updateDetailsFailed" %}
+
+{% set errorState = pageErrorState %}
+{% set errorTitle = 'pages.updateDetailsFailed.content.formErrorMessage.errorSummaryTitleText' | translate %}
+{% set errorText = 'pages.updateDetailsFailed.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorHref = "#updateDetailsFailedActionForm" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}">{{ 'pages.updateDetailsFailed.header' | translate }}</h1>
+  <p class="govuk-body">{{ 'pages.updateDetailsFailed.content.paragraph1' | translate }}</p>
+
+  <form id="updateDetailsFailedActionForm" action="/ipv/page/{{ pageId }}" method="POST">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      {% set radiosConfig = {
+          idPrefix: "journey",
+          name: "journey",
+          fieldset: {
+              legend: {
+                  text: 'pages.updateDetailsFailed.content.subHeading' | translate,
+                  classes: "govuk-fieldset__legend--m"
+              }
+          },
+          items: [
+                  {
+                  value: "continue",
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.continueOption' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.continueOptionHint' | translate }
+                  },
+                  {
+                  value: "delete",
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOption' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOptionHint' | translate }
+                  }
+              ]
+      }
+      %}
+
+      {% if errorState %}
+      {% set errorMessageObject = { 'text': 'pages.updateDetailsFailed.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
+      {% endif %}
+
+      {{ govukRadios(radiosConfig) }}
+      {{ govukButton({
+          id: "submitButton",
+          text: 'general.buttons.next' | translate
+        }) }}
+  </form>
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

Adds a new page to give user options when they cannot update their details via a COI journey


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This change aims to provide users with clear information and options when they are unable to use the live/likeness application to prove their identity. By offering self-service options, users can either proceed to the service they intended to access or delete their account, improving user experience and reducing the need for call centre support.
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-7163

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

