### PR TITLE
PYIC-7160: update-name-date-birth page to allow account deletion

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -688,16 +688,25 @@
     },
     "updateNameDateBirth": {
       "title": "Diweddaru eich enw llawn neu ddyddiad geni",
+      "titleReuse": "TODO PYIC-7195: You cannot update your full name or date of birth",
       "header": "Diweddaru eich enw llawn neu ddyddiad geni",
+      "headerReuse": "TODO PYIC-7195: You cannot update your full name or date of birth",
       "content": {
         "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
+        "paragraph1Reuse": "TODO PYIC-7195: This is to help protect you from identity fraud.",
+        "paragraph2": "TODO PYIC-7195: You can still use the service if your details are out of date.",
+        "paragraph3": "TODO PYIC-7195: To use a different full name or date of birth, you'll need to delete your GOV.UK One Login and create a new one.",
         "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
         "warningTextFallback": "Rhybudd",
         "radioButtonHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw llawn neu ddyddiad geni",
+          "yesReuse": "TODO PYIC-7195: Continue to the service without updating your details",
+          "yesHintReuse": "TODO PYIC-7195: Your proof of identity is valid even if your details have changed.",
           "no": "Ewch yn ôl i wirio eich manylion eto",
-          "noHint": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf."
+          "noReuse": "TODO PYIC-7195: Delete your GOV.UK One Login",
+          "noHint": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf.",
+          "noHintReuse": "TODO PYIC-7195: Then create a new one and prove your identity with your new details."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -757,16 +757,25 @@
     },
     "updateNameDateBirth": {
       "title": "Update your full name or date of birth",
+      "titleReuse": "You cannot update your full name or date of birth",
       "header": "Update your full name or date of birth",
+      "headerReuse": "You cannot update your full name or date of birth",
       "content": {
         "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
+        "paragraph1Reuse": "This is to help protect you from identity fraud.",
+        "paragraph2": "You can still use the service if your details are out of date.",
+        "paragraph3": "To use a different full name or date of birth, you'll need to delete your GOV.UK One Login and create a new one.",
         "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
         "warningTextFallback": "Warning",
         "radioButtonHeading": "What would you like to do?",
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your full name or date of birth",
+          "yesReuse": "Continue to the service without updating your details",
+          "yesHintReuse": "Your proof of identity is valid even if your details have changed.",
           "no": "Go back and check your details again",
-          "noHint": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name."
+          "noReuse": "Delete your GOV.UK One Login",
+          "noHint": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name.",
+          "noHintReuse": "Then create a new one and prove your identity with your new details."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -12,6 +12,11 @@
 {% set errorText = 'pages.updateNameDateBirth.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
 {% set errorHref = "#updateNameDateBirthActionForm" %}
 
+{% if context === 'reuse' %}
+{% set showBack = true %}
+{% set hrefBack = "/ipv/journey/update-name-date-birth/back" %}
+{% endif %}
+
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
         xmlns="http://www.w3.org/1999/html">{{ 'pages.updateNameDateBirth.header' | translateWithContextOrFallback(context) }}</h1>

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -47,9 +47,23 @@
                             text: 'pages.updateNameDateBirth.content.formRadioButtons.yesHint' | translateWithContextOrFallback(context)
                         }
         } if context === 'reuse' else {
-                        value: "contact",
-                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context)
+                        value: "continue",
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContext(context)
         })%}
+
+        {% set yesButtonConfig = {
+            reuse: {
+                value: "contact",
+                text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context),
+                hint: {
+                    text: 'pages.updateNameDateBirth.content.formRadioButtons.yesHint' | translateWithContextOrFallback(context)
+                }
+            },
+            default: {
+                value: "continue",
+                text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContext(context)
+            }
+        } %}
 
         {% set radiosConfig = {
             idPrefix: "journey",
@@ -61,7 +75,7 @@
                 }
             },
             items: [
-                    yesButtonConfig,
+                    yesButtonConfig[context],
                     {
                         value: "end",
                         text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translateWithContextOrFallback(context),

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -50,7 +50,7 @@
             },
             withoutHint: {
                 value: "contact",
-                text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContext(context)
+                text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translate
             }
         } %}
 

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -40,27 +40,16 @@
 
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-        {% set yesButtonConfig = ({
-                        value: "contact",
-                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context),
-                        hint: {
-                            text: 'pages.updateNameDateBirth.content.formRadioButtons.yesHint' | translateWithContextOrFallback(context)
-                        }
-        } if context === 'reuse' else {
-                        value: "continue",
-                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContext(context)
-        })%}
-
         {% set yesButtonConfig = {
-            reuse: {
-                value: "contact",
+            withHint: {
+                value: "continue",
                 text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context),
                 hint: {
                     text: 'pages.updateNameDateBirth.content.formRadioButtons.yesHint' | translateWithContextOrFallback(context)
                 }
             },
-            default: {
-                value: "continue",
+            withoutHint: {
+                value: "contact",
                 text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContext(context)
             }
         } %}
@@ -75,7 +64,7 @@
                 }
             },
             items: [
-                    yesButtonConfig[context],
+                    yesButtonConfig["withHint"] if context === "reuse" else yesButtonConfig["withoutHint"],
                     {
                         value: "end",
                         text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translateWithContextOrFallback(context),

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -14,9 +14,13 @@
 
 {% block content %}
     <h1 class="govuk-heading-l" id="header" data-page="{{ googleTagManagerPageId }}"
-        xmlns="http://www.w3.org/1999/html">{{ 'pages.updateNameDateBirth.header' | translate }}</h1>
+        xmlns="http://www.w3.org/1999/html">{{ 'pages.updateNameDateBirth.header' | translateWithContextOrFallback(context) }}</h1>
 
-    <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph1' | translateWithContextOrFallback(context) }}</p>
+
+    {% if context === 'reuse' %}
+        <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph2' | translate }}</p>
+    {% endif %}
 
     {% if context === "repeatFraudCheck" %}
     {{ govukWarningText({
@@ -25,8 +29,23 @@
         }) }}
     {% endif %}
 
+    {% if context === 'reuse' %}
+        <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph3' | translate }}</p>
+    {% endif %}
+
     <form id="updateNameDateBirthActionForm" action="/ipv/page/{{ pageId }}" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        {% set yesButtonConfig = ({
+                        value: "contact",
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context),
+                        hint: {
+                            text: 'pages.updateNameDateBirth.content.formRadioButtons.yesHint' | translateWithContextOrFallback(context)
+                        }
+        } if context === 'reuse' else {
+                        value: "contact",
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translateWithContextOrFallback(context)
+        })%}
+
         {% set radiosConfig = {
             idPrefix: "journey",
             name: "journey",
@@ -37,15 +56,12 @@
                 }
             },
             items: [
-                    {
-                        value: "contact",
-                        text: 'pages.updateNameDateBirth.content.formRadioButtons.yes' | translate
-                    },
+                    yesButtonConfig,
                     {
                         value: "end",
-                        text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translate,
+                        text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translateWithContextOrFallback(context),
                         hint: {
-                            text: 'pages.updateNameDateBirth.content.formRadioButtons.noHint' | translate
+                            text: 'pages.updateNameDateBirth.content.formRadioButtons.noHint' | translateWithContextOrFallback(context)
                         }
                     }
                 ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- updates the `update-name-date-birth` page to match new UCD designs for fast follow when on a reuse journey

| Old screen | Old screen (context `repeatFraudCheck`) | New screen (on reuse journey - use `reuse` context) |
| - | - | - |
| <img width="658" alt="Screenshot 2024-08-15 at 14 10 07" src="https://github.com/user-attachments/assets/e1e8a1d1-94f1-418d-93d5-a14097176b33"> |  <img width="652" alt="Screenshot 2024-08-15 at 14 14 05" src="https://github.com/user-attachments/assets/2b48cf06-6df2-427d-9d85-3daf9011170f"> | <img width="666" alt="Screenshot 2024-08-15 at 14 13 44" src="https://github.com/user-attachments/assets/ec531640-31a8-42b3-9f71-9a7867a426f5"> |



### Why did it change
We want to reduce the number of people contacting the call centre for help by allowing users to delete their account themselves.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7160](https://govukverify.atlassian.net/browse/PYIC-7160)

Core-back PR: https://github.com/govuk-one-login/ipv-core-back/pull/2304


[PYIC-7160]: https://govukverify.atlassian.net/browse/PYIC-7160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ