### PR TITLE
PYIC-7215: add error message for nino no photo id journey

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -961,7 +961,9 @@
         "formErrorMessage": {
           "errorSummaryTitleText": "Mae problem",
           "errorSummaryDescriptionText": "Dewiswch beth hoffech chi ei wneud",
-          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud"
+          "errorRadioMessage": "Dewiswch beth hoffech chi ei wneud",
+          "errorSummaryDescriptionTextNino": "Select yes if you have a National Insurance number",
+          "errorRadioMessageNino": "Select yes if you have a National Insurance number"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1011,7 +1011,9 @@
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",
           "errorSummaryDescriptionText": "Select yes if you have a UK bank or building society account in your name",
-          "errorRadioMessage": "Select yes if you have a UK bank or building society account in your name"
+          "errorRadioMessage": "Select yes if you have a UK bank or building society account in your name",
+          "errorSummaryDescriptionTextNino": "Select yes if you have a National Insurance number",
+          "errorRadioMessageNino": "Select yes if you have a National Insurance number"
         }
       }
     },

--- a/src/views/ipv/page/prove-identity-no-photo-id.njk
+++ b/src/views/ipv/page/prove-identity-no-photo-id.njk
@@ -6,7 +6,7 @@
 
 {% set errorState = pageErrorState %}
 {% set errorTitle = 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorSummaryTitleText' | translate %}
-{% set errorText = 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translate %}
+{% set errorText = 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorSummaryDescriptionText' | translateWithContext(context) %}
 {% set errorHref = "#proveIdentityNoPhotoIdOptionsForm" %}
 
 {% block content %}
@@ -57,7 +57,7 @@
     } %}
 
     {% if errorState %}
-      {% set errorMessageObject = { 'text': 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorRadioMessage' | translate } %}
+      {% set errorMessageObject = { 'text': 'pages.proveIdentityNoPhotoId.content.formErrorMessage.errorRadioMessage' | translateWithContext(context) } %}
       {% set radiosConfig = radiosConfig | setAttribute('errorMessage', errorMessageObject) %}
     {% endif %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- add error message for nino no photo id journey

### What changed

- Error message with context for no photo id journey.

<!-- Describe the changes in detail - the "what"-->

![Screenshot 2024-08-15 at 14 55 12](https://github.com/user-attachments/assets/44df07ec-1e2d-46a9-b05c-7c7af4ac319f)


existing page

![Screenshot 2024-08-15 at 14 56 35](https://github.com/user-attachments/assets/5faaa1b9-a0c8-453a-a438-7335ac6c1048)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7215](https://govukverify.atlassian.net/browse/PYIC-7215)


[PYIC-7215]: https://govukverify.atlassian.net/browse/PYIC-7215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ