### PR TITLE
PYIC-7162: update page contents to match fast follow UCD for RFC journey

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -694,6 +694,7 @@
       "content": {
         "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
         "paragraph1Reuse": "TODO PYIC-7195: This is to help protect you from identity fraud.",
+        "paragraph1RfcAccountDeletion": "TODO PYIC-7195: This is to help protect you from identity fraud.",
         "paragraph2": "TODO PYIC-7195: You can still use the service if your details are out of date.",
         "paragraph3": "TODO PYIC-7195: To use a different full name or date of birth, you'll need to delete your GOV.UK One Login and create a new one.",
         "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
@@ -702,7 +703,9 @@
         "formRadioButtons": {
           "yes": "Cysylltwch â'r tîm GOV.UK One Login i ddiweddaru eich enw llawn neu ddyddiad geni",
           "yesReuse": "TODO PYIC-7195: Continue to the service without updating your details",
+          "yesRfcAccountDeletion": "TODO PYIC-7195: Delete your GOV.UK One Login",
           "yesHintReuse": "TODO PYIC-7195: Your proof of identity is valid even if your details have changed.",
+          "yesHintRfcAccountDeletion": "TODO PYIC-7195: Then create a new one and prove your identity with your new details.",
           "no": "Ewch yn ôl i wirio eich manylion eto",
           "noReuse": "TODO PYIC-7195: Delete your GOV.UK One Login",
           "noHint": "Efallai y byddwch yn gallu diweddaru eich manylion eich hun os ydych ond angen diweddaru eich enwau cyntaf neu ganol, neu'ch enw olaf.",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -689,8 +689,10 @@
     "updateNameDateBirth": {
       "title": "Diweddaru eich enw llawn neu ddyddiad geni",
       "titleReuse": "TODO PYIC-7195: You cannot update your full name or date of birth",
+      "titleRfcAccountDeletion": "TODO PYIC-7195: You cannot update your full name or date of birth",
       "header": "Diweddaru eich enw llawn neu ddyddiad geni",
       "headerReuse": "TODO PYIC-7195: You cannot update your full name or date of birth",
+      "headerRfcAccountDeletion": "TODO PYIC-7195: You cannot update your full name or date of birth",
       "content": {
         "paragraph1": "I ddiweddaru eich enw llawn neu ddyddiad geni, mae angen i chi gysylltu â'r tîm GOV.UK One Login.",
         "paragraph1Reuse": "TODO PYIC-7195: This is to help protect you from identity fraud.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -758,8 +758,10 @@
     "updateNameDateBirth": {
       "title": "Update your full name or date of birth",
       "titleReuse": "You cannot update your full name or date of birth",
+      "titleRfcAccountDeletion": "You cannot update your full name or date of birth",
       "header": "Update your full name or date of birth",
       "headerReuse": "You cannot update your full name or date of birth",
+      "headerRfcAccountDeletion": "You cannot update your full name or date of birth",
       "content": {
         "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
         "paragraph1Reuse": "This is to help protect you from identity fraud.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -763,6 +763,7 @@
       "content": {
         "paragraph1": "To update your full name or date of birth, you need to contact the GOV.UK One Login team.",
         "paragraph1Reuse": "This is to help protect you from identity fraud.",
+        "paragraph1RfcAccountDeletion": "This is to help protect you from identity fraud.",
         "paragraph2": "You can still use the service if your details are out of date.",
         "paragraph3": "To use a different full name or date of birth, you'll need to delete your GOV.UK One Login and create a new one.",
         "warningText": "You may not be able to use your GOV.UK One Login if your details are not up to date.",
@@ -771,7 +772,9 @@
         "formRadioButtons": {
           "yes": "Contact the GOV.UK One Login team to update your full name or date of birth",
           "yesReuse": "Continue to the service without updating your details",
+          "yesRfcAccountDeletion": "Delete your GOV.UK One Login",
           "yesHintReuse": "Your proof of identity is valid even if your details have changed.",
+          "yesHintRfcAccountDeletion": "Then create a new one and prove your identity with your new details.",
           "no": "Go back and check your details again",
           "noReuse": "Delete your GOV.UK One Login",
           "noHint": "You might be able to update your details yourself if you only need to update either your first or middle names, or your last name.",

--- a/src/views/ipv/page/update-name-date-birth.njk
+++ b/src/views/ipv/page/update-name-date-birth.njk
@@ -27,14 +27,14 @@
         <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph2' | translate }}</p>
     {% endif %}
 
-    {% if context === "repeatFraudCheck" %}
+    {% if context === "repeatFraudCheck" or context === 'rfcAccountDeletion' %}
     {{ govukWarningText({
         text: 'pages.updateNameDateBirth.content.warningText' | translate,
         iconFallbackText: 'pages.updateNameDateBirth.content.warningTextFallback' | translate
         }) }}
     {% endif %}
 
-    {% if context === 'reuse' %}
+    {% if context === 'reuse' or context === 'rfcAccountDeletion' %}
         <p class="govuk-body">{{'pages.updateNameDateBirth.content.paragraph3' | translate }}</p>
     {% endif %}
 
@@ -64,7 +64,7 @@
                 }
             },
             items: [
-                    yesButtonConfig["withHint"] if context === "reuse" else yesButtonConfig["withoutHint"],
+                    yesButtonConfig["withHint"] if context === "reuse" or context === "rfcAccountDeletion" else yesButtonConfig["withoutHint"],
                     {
                         value: "end",
                         text: 'pages.updateNameDateBirth.content.formRadioButtons.no' | translateWithContextOrFallback(context),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated `update-name-date-birth` for repeat fraud check journey to match [UCD designs for fast follow](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=26170-20781&t=WIAmleMNRM2o42kN-0)

**On repeat fraud check journey:**
| Old screen | With featureSet: updateDetailsAccountDeletion |
|-| -|
 | <img width="657" alt="Screenshot 2024-08-15 at 15 50 42" src="https://github.com/user-attachments/assets/0f96efbb-ed79-4482-af6b-70e13eab2279"> |  <img width="664" alt="Screenshot 2024-08-15 at 16 00 45" src="https://github.com/user-attachments/assets/16d266c0-4590-4e4c-a349-01f739f5feb8"> |


### Why did it change
We want to reduce the number of people contacting the call centre for help by allowing users to delete their account themselves.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6172](https://govukverify.atlassian.net/browse/PYIC-6172)

Associated core-back PR: https://github.com/govuk-one-login/ipv-core-back/pull/2307


[PYIC-6172]: https://govukverify.atlassian.net/browse/PYIC-6172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ