### PR TITLE
PYIC-7165: display a delete option on sorry-could-not-confirm-details

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -128,10 +128,13 @@
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
+        "paragraph3": "TODO: You will not be able to use your GOV.UK One Login to access the service.",
         "subHeading": "Beth hoffech chi ei wneud? ",
         "formRadioButtons": {
           "contactOption": "Cysylltwch â thîm GOV.UK One Login",
           "contactOptionHint": "Efallai y bydd angen i chi ddileu'ch GOV.UK One Login. Yna gallwch greu un newydd a cheisio profi eich hunaniaeth eto gyda'ch manylion newydd.",
+          "deleteOption": "TODO: Delete your GOV.UK One Login",
+          "deleteOptionHint": "TODO: You can then create a new one and prove your identity using your new details.",
           "endOption": "Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o gael mynediad ato."
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -132,6 +132,8 @@
         "formRadioButtons": {
           "contactOption": "Contact the GOV.UK One Login team",
           "contactOptionHint": "You may need to delete your GOV.UK One Login. Then you can create a new one and try to prove your identity again with your new details.",
+          "deleteOption": "Delete your GOV.UK One Login",
+          "deleteOptionHint": "You can then create a new one and prove your identity using your new details.",
           "endOption": "Continue to the service you were trying to use to find out if there are other ways to access it"
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -128,6 +128,7 @@
       "content": {
         "paragraph1": "We could not find a match when we checked your details with another organisation.",
         "paragraph2": "To keep your information safe, we cannot tell you which of your details we were unable to match.",
+        "paragraph3": "You will not be able to use your GOV.UK One Login to access the service.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "contactOption": "Contact the GOV.UK One Login team",

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -15,6 +15,7 @@
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph2' | translate }}</p>
 
   {% if context == "deleteDetails" %}
+  <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph3' | translate }}</p>
   {%
     set radioItems = [{
         value: "delete",

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -14,7 +14,7 @@
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph2' | translate }}</p>
 
-  {% if context == "deleteDetails" %}
+  {% if context == "deleteDetailsReuse" %}
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph3' | translate }}</p>
   {%
     set radioItems = [{

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -14,6 +14,29 @@
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph2' | translate }}</p>
 
+  {% if context == "deleteDetails" %}
+  {%
+    set radioItems = [{
+        value: "delete",
+        text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.deleteOption' | translate,
+        hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.deleteOptionHint' | translate }
+    }]
+  %}
+  {% else %}
+  {%
+    set radioItems = [{
+        value: "contact",
+        text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOption' | translate,
+        hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOptionHint' | translate }
+    }]
+  %}
+  {% endif %}
+  {%
+    set radioItems = radioItems.concat({
+        value: "end",
+        text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.endOption' | translate
+    })
+  %}
   <form id="sorryCouldNotConfirmDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
       {% set radiosConfig = {
@@ -25,17 +48,7 @@
                   classes: "govuk-fieldset__legend--m"
               }
           },
-          items: [
-                  {
-                  value: "contact",
-                  text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOption' | translate,
-                  hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOptionHint' | translate }
-                  },
-                  {
-                  value: "end",
-                  text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.endOption' | translate
-                  }
-              ]
+          items: radioItems
       }
       %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
display a delete option on sorry-could-not-confirm-details page if the deleteDetails context is set
### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This change aims to provide users with clear options when they fail the continuity of identity check but still have a valid identity. By offering self-service options, users can either proceed to the service they intended to access or delete their account, improving user experience and reducing the need for call centre support.
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-7165

With context = deleteDetails
<img width="537" alt="Screenshot 2024-08-15 at 17 26 27" src="https://github.com/user-attachments/assets/0b8ad754-ab54-4f13-8ad0-c878973f0bfe">


without
<img width="550" alt="Screenshot 2024-08-15 at 17 12 42" src="https://github.com/user-attachments/assets/2c31de22-33de-445e-b8c0-5ca59dae92a9">

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

