### PR TITLE
PYIC-7209: update kbv drop out page content

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -341,6 +341,8 @@
           ]
         },
         "subHeading3": "Beth hoffech chi ei wneud?",
+        "subHeading3Dropout": "Os oes gennych ID gyda llun",
+        "subHeading3P1Dropout": "How would you like to prove your identity?",
         "formRadioButtons": {
           "radioButtonBackToRpText": "Ewch i'r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
           "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -303,14 +303,11 @@
     },
     "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
-      "titleP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "titleDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "header": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
-      "headerP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "headerDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
         "paragraph1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
-        "paragraph1P1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
         "paragraph1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
         "subHeading": "Os nad oes gennych ID gyda llun",
         "paragraph2": "Gallwch geisio profi eich hunaniaeth gyda'r gwasanaeth rydych angen ei ddefnyddio. Efallai y byddant yn cymryd mathau eraill o ID.",
@@ -339,7 +336,7 @@
         },
         "subHeading3": "How would you like to prove your identity?",
         "formRadioButtons": {
-          "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
+          "radioButtonBackToRpText": "Go to the service you need to use and look for other ways to prove your identity",
           "radioButtonAppText": "Profi eich hunaniaeth gyda'r ap GOV.UK ID Check",
           "radioButtonAppTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio'r ap.",
           "radioButtonPoText": "Profwch eich hunaniaeth mewn Swyddfa'r Post",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -305,16 +305,13 @@
       "title": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "titleP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "titleDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
-      "titleP1Dropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "header": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "headerP1": "Mae'n ddrwg gennym, ni allwn gadarnhau eich hunaniaeth y ffordd hyn",
       "headerDropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
-      "headerP1Dropout": "Darganfyddwch ffordd arall i brofi eich hunaniaeth",
       "content": {
         "paragraph1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
         "paragraph1P1": "Mae hyn oherwydd nad ydych wedi ateb rhai o'r cwestiynau diogelwch yn gywir.",
         "paragraph1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
-        "paragraph1P1Dropout": "Nid oeddem yn gallu cwblhau eich gwiriad hunaniaeth drwy ddefnyddio eich cwestiynau diogelwch.",
         "subHeading": "Os nad oes gennych ID gyda llun",
         "paragraph2": "Gallwch geisio profi eich hunaniaeth gyda'r gwasanaeth rydych angen ei ddefnyddio. Efallai y byddant yn cymryd mathau eraill o ID.",
         "subHeading2": "Os oes gennych ID gyda llun",
@@ -340,11 +337,8 @@
             "UK biometric residence permit (BRP)"
           ]
         },
-        "subHeading3": "Beth hoffech chi ei wneud?",
-        "subHeading3Dropout": "Os oes gennych ID gyda llun",
-        "subHeading3P1Dropout": "How would you like to prove your identity?",
+        "subHeading3": "How would you like to prove your identity?",
         "formRadioButtons": {
-          "radioButtonBackToRpText": "Ewch i'r gwasanaeth rydych angen ei ddefnyddio a darganfod a ydynt yn derbyn mathau eraill o ID",
           "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
           "radioButtonAppText": "Profi eich hunaniaeth gyda'r ap GOV.UK ID Check",
           "radioButtonAppTextHint": "Dangosir i chi sut i lawrlwytho a defnyddio'r ap.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -306,16 +306,13 @@
       "title": "Sorry, we cannot confirm your identity this way",
       "titleP1": "Sorry, we cannot confirm your identity this way",
       "titleDropout": "Find another way to prove your identity",
-      "titleP1Dropout": "Find another way to prove your identity",
       "header": "Sorry, we cannot confirm your identity this way",
       "headerP1": "Sorry, we cannot confirm your identity this way",
       "headerDropout": "Find another way to prove your identity",
-      "headerP1Dropout": "Find another way to prove your identity",
       "content": {
         "paragraph1": "This is because you did not answer some of the security questions correctly.",
         "paragraph1P1": "This is because you did not answer some of the security questions correctly.",
         "paragraph1Dropout": "We were not able to complete your identity check using security questions.",
-        "paragraph1P1Dropout": "We were not able to complete your identity check using security questions.",
         "subHeading": "If you do not have photo ID",
         "paragraph2": "You can try proving your identity with the service you need to use. They may take other types of ID.",
         "subHeading2": "If you have photo ID",
@@ -341,11 +338,8 @@
             "UK biometric residence permit (BRP)"
           ]
         },
-        "subHeading3": "What would you like to do?",
-        "subHeading3Dropout": "What would you like to do?",
-        "subHeading3P1Dropout": "How would you like to prove your identity?",
+        "subHeading3": "How would you like to prove your identity?",
         "formRadioButtons": {
-          "radioButtonBackToRpText": "Go to the service you need to use and find out if they take other types of ID",
           "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
           "radioButtonAppText": "Prove your identity with the GOV.UK ID check app",
           "radioButtonAppTextHint": "You’ll be shown how to download and use the app.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -342,6 +342,8 @@
           ]
         },
         "subHeading3": "What would you like to do?",
+        "subHeading3Dropout": "What would you like to do?",
+        "subHeading3P1Dropout": "How would you like to prove your identity?",
         "formRadioButtons": {
           "radioButtonBackToRpText": "Go to the service you need to use and find out if they take other types of ID",
           "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -337,7 +337,7 @@
         },
         "subHeading3": "How would you like to prove your identity?",
         "formRadioButtons": {
-          "radioButtonBackToRpP1Text": "Go to the service you need to use and look for other ways to prove your identity",
+          "radioButtonBackToRpText": "Go to the service you need to use and look for other ways to prove your identity",
           "radioButtonAppText": "Prove your identity with the GOV.UK ID check app",
           "radioButtonAppTextHint": "You’ll be shown how to download and use the app.",
           "radioButtonPoText": "Prove your identity at a Post Office",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -304,14 +304,11 @@
 
     "noPhotoIdSecurityQuestionsFindAnotherWay": {
       "title": "Sorry, we cannot confirm your identity this way",
-      "titleP1": "Sorry, we cannot confirm your identity this way",
       "titleDropout": "Find another way to prove your identity",
       "header": "Sorry, we cannot confirm your identity this way",
-      "headerP1": "Sorry, we cannot confirm your identity this way",
       "headerDropout": "Find another way to prove your identity",
       "content": {
         "paragraph1": "This is because you did not answer some of the security questions correctly.",
-        "paragraph1P1": "This is because you did not answer some of the security questions correctly.",
         "paragraph1Dropout": "We were not able to complete your identity check using security questions.",
         "subHeading": "If you do not have photo ID",
         "paragraph2": "You can try proving your identity with the service you need to use. They may take other types of ID.",

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -62,7 +62,7 @@
         },
         {
           value: "end",
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpP1Text' | translate
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpText' | translate
         }
       ]
     %}

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -93,7 +93,7 @@
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading3' | translate,
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading3' | translateWithContext(context),
           classes: "govuk-fieldset__legend--m"
         }
       },

--- a/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/src/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -45,55 +45,34 @@
   <form id="noPhotoIdSecurityQuestionsFindAnotherWayForm" action="/ipv/page/{{ pageId }}" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    {% if context == "p1" or context == "p1Dropout" %}
-      {% set radioOptions =
-        [
-          {
-            value: "appTriage",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppText' | translate,
-            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppTextHint' | translate }
-          },
-          {
-            value: "f2f",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoText' | translate,
-            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoTextHint' | translate }
-          },
-          {
-            divider: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.separateOptionsInFormText' | translate
-          },
-          {
-            value: "end",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpP1Text' | translate
-          }
-        ]
+    {% set radioOptions =
+      [
+        {
+          value: "appTriage",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppText' | translate,
+          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppTextHint' | translate }
+        },
+        {
+          value: "f2f",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoText' | translate,
+          hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoTextHint' | translate }
+        },
+        {
+          divider: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.separateOptionsInFormText' | translate
+        },
+        {
+          value: "end",
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpP1Text' | translate
+        }
+      ]
     %}
-    {% else %}
-      {% set radioOptions =
-        [
-          {
-            value: "end",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonBackToRpText' | translate
-          },
-          {
-            value: "appTriage",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppText' | translate,
-            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonAppTextHint' | translate }
-          },
-          {
-            value: "f2f",
-            text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoText' | translate,
-            hint: { text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.formRadioButtons.radioButtonPoTextHint' | translate }
-          }
-        ]
-      %}
-    {% endif %}
 
     {% set radiosConfig = {
       idPrefix: "journey",
       name: "journey",
       fieldset: {
         legend: {
-          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading3' | translateWithContext(context),
+          text: 'pages.noPhotoIdSecurityQuestionsFindAnotherWay.content.subHeading3' | translate,
           classes: "govuk-fieldset__legend--m"
         }
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- update kbv drop out page content for p1 journey

### What changed

- Updated translation file to show updated content for p1 drop out page.

<!-- Describe the changes in detail - the "what"-->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7209](https://govukverify.atlassian.net/browse/PYIC-7209)

Drop out fail kbV

<img width="226" alt="Screenshot 2024-08-22 at 10 38 14" src="https://github.com/user-attachments/assets/9fcaa46b-650f-4d5f-a26a-c2fd9825b03a">

Dropout thin file

<img width="241" alt="Screenshot 2024-08-22 at 10 37 51" src="https://github.com/user-attachments/assets/ecb1bb69-63b6-4373-b8a8-4cba0fa354ba">



[PYIC-7209]: https://govukverify.atlassian.net/browse/PYIC-7209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ