### PR TITLE
PYIC-6156: Updated handleJourneyPage/Action session validation

### DIFF
--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -323,8 +323,7 @@ async function renderAttemptRecoveryPage(req, res) {
 async function validateSessionAndPage(req, res, pageId) {
   // Check if the page is valid
   if (!isValidIpvPage(pageId)) {
-    res.status(HTTP_STATUS_CODES.NOT_FOUND);
-    return res.render(getTemplatePath("errors", "page-not-found"));
+    return render404(res);
   }
 
   // Check for clientOauthSessionId for recoverable timeout page
@@ -385,7 +384,6 @@ async function handleJourneyPage(req, res, next, pageErrorState = undefined) {
     const { pageId } = req.params;
     const { context } = req?.session || "";
 
-    // handles page id validation first
     if (!(await validateSessionAndPage(req, res, pageId))) {
       return;
     }

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -356,12 +356,8 @@ async function validateSessionAndPage(req, res, pageId) {
   }
 
   if (req.session.currentPage !== pageId) {
-    await handleUnexpectedPage(req, res, pageId);
-    return false;
+    return await handleUnexpectedPage(req, res, pageId);
   }
-
-  // Return true if validation passed
-  return true;
 }
 
 async function updateJourneyState(req, res, next) {
@@ -384,9 +380,7 @@ async function handleJourneyPage(req, res, next, pageErrorState = undefined) {
     const { pageId } = req.params;
     const { context } = req?.session || "";
 
-    if (!(await validateSessionAndPage(req, res, pageId))) {
-      return;
-    }
+    await validateSessionAndPage(req, res, pageId);
 
     const renderOptions = {
       pageId,
@@ -424,9 +418,7 @@ async function handleJourneyAction(req, res, next) {
   const pageId = req.params.pageId;
 
   try {
-    if (!(await validateSessionAndPage(req, res, pageId))) {
-      return;
-    }
+    await validateSessionAndPage(req, res, pageId);
 
     checkJourneyAction(req);
     if (req.body?.journey === "contact") {

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -49,7 +49,7 @@ describe("journey middleware", () => {
         ipAddress: "ip-address",
         featureSet: "feature-set",
       },
-      params: { pageId: "ipv-current-page" },
+      params: { pageId: "page-ipv-identity-document-start" },
       csrfToken: sinon.fake(),
       log: { info: sinon.fake(), error: sinon.fake() },
     };
@@ -299,9 +299,13 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "next" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         const callBack = sinon.stub();
@@ -367,9 +371,13 @@ describe("journey middleware", () => {
         id: "1",
         url: "/journey/next",
         body: { journey: "next" },
-        session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+        session: {
+          ipvSessionId: "ipv-session-id",
+          ipAddress: "ip-address",
+          currentPage: "page-ipv-identity-document-start",
+        },
         log: { info: sinon.fake(), error: sinon.fake() },
-        params: { pageId: "ipv-current-page" },
+        params: { pageId: "page-ipv-identity-document-start" },
       };
 
       const callBack = sinon.stub();
@@ -395,40 +403,59 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "end" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "end", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "end",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with attempt-recovery", async function () {
         req = {
           id: "1",
           body: { journey: "attempt-recovery" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "attempt-recovery", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "attempt-recovery",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with build-client-oauth-response and use ip address from header when not present in session", async function () {
         req = {
           id: "1",
           body: { journey: "build-client-oauth-response" },
-          session: { ipvSessionId: "ipv-session-id" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            currentPage: "page-ipv-identity-document-start",
+          },
           headers: { forwarded: "1.1.1.1" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -437,7 +464,7 @@ describe("journey middleware", () => {
         ).to.have.been.calledWith(
           req,
           "build-client-oauth-response",
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
       });
 
@@ -445,10 +472,14 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "build-client-oauth-response" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           headers: { forwarded: "1.1.1.1" },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -457,7 +488,7 @@ describe("journey middleware", () => {
         ).to.have.been.calledWith(
           req,
           "build-client-oauth-response",
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
       });
     },
@@ -472,7 +503,7 @@ describe("journey middleware", () => {
           ipvSessionId: null,
           ipAddress: "ip-address",
         },
-        params: { pageId: "ipv-current-page" },
+        params: { pageId: "page-ipv-identity-document-start" },
         log: { info: sinon.fake(), error: sinon.fake() },
       };
 
@@ -638,30 +669,46 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "ukPassport" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "ukPassport", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "ukPassport",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with drivingLicence", async function () {
         req = {
           id: "1",
           body: { journey: "drivingLicence" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "drivingLicence", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "drivingLicence",
+          "page-ipv-identity-document-start",
+        );
       });
     },
   );
@@ -673,15 +720,23 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "end" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "end", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "end",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should call saveAndRedirect given 'contact' event", async function () {
@@ -692,9 +747,10 @@ describe("journey middleware", () => {
             ipvSessionId: "ipv-session-id",
             ipAddress: "ip-address",
             save: sinon.fake.yields(null),
+            currentPage: "page-ipv-identity-document-start",
           },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -709,9 +765,10 @@ describe("journey middleware", () => {
             ipvSessionId: "ipv-session-id",
             ipAddress: "ip-address",
             save: sinon.fake.yields(null),
+            currentPage: "page-ipv-identity-document-start",
           },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
@@ -727,56 +784,45 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "next" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
-          log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
-        };
-
-        await middleware.handleJourneyAction(req, res, next);
-        expect(
-          CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "next", "ipv-current-page");
-      });
-
-      it("should postJourneyEvent with bankAccount", async function () {
-        req = {
-          id: "1",
-          body: { journey: "bankAccount" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
-          log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
-        };
-
-        await middleware.handleJourneyAction(req, res, next);
-        expect(
-          CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "bankAccount", "ipv-current-page");
-      });
-    },
-  );
-
-  context(
-    "handleJourneyAction: handling missing ipvSessionId before calling the backend",
-    () => {
-      it("should render the technical unrecoverable page", async function () {
-        req = {
-          id: "1",
           session: {
-            currentPage: "page-ipv-identity-document-start",
-            ipvSessionId: null,
+            ipvSessionId: "ipv-session-id",
             ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
           },
           log: { info: sinon.fake(), error: sinon.fake() },
           params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
-        expect(res.status).to.have.been.calledWith(401);
-        expect(res.render).to.have.been.calledWith(
-          "ipv/page/pyi-technical.njk",
-          {
-            context: "unrecoverable",
+        expect(
+          CoreBackServiceStub.postJourneyEvent.firstCall,
+        ).to.have.been.calledWith(
+          req,
+          "next",
+          "page-ipv-identity-document-start",
+        );
+      });
+
+      it("should postJourneyEvent with bankAccount", async function () {
+        req = {
+          id: "1",
+          body: { journey: "bankAccount" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
           },
+          log: { info: sinon.fake(), error: sinon.fake() },
+          params: { pageId: "page-ipv-identity-document-start" },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(
+          CoreBackServiceStub.postJourneyEvent.firstCall,
+        ).to.have.been.calledWith(
+          req,
+          "bankAccount",
+          "page-ipv-identity-document-start",
         );
       });
     },
@@ -789,35 +835,51 @@ describe("journey middleware", () => {
         req = {
           id: "1",
           body: { journey: "f2f" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(
           req,
           res,
           next,
-          "ipv-current-page",
+          "page-ipv-identity-document-start",
         );
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "f2f", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "f2f",
+          "page-ipv-identity-document-start",
+        );
       });
 
       it("should postJourneyEvent with dcmaw", async function () {
         req = {
           id: "1",
           body: { journey: "dcmaw" },
-          session: { ipvSessionId: "ipv-session-id", ipAddress: "ip-address" },
+          session: {
+            ipvSessionId: "ipv-session-id",
+            ipAddress: "ip-address",
+            currentPage: "page-ipv-identity-document-start",
+          },
           log: { info: sinon.fake(), error: sinon.fake() },
-          params: { pageId: "ipv-current-page" },
+          params: { pageId: "page-ipv-identity-document-start" },
         };
 
         await middleware.handleJourneyAction(req, res, next);
         expect(
           CoreBackServiceStub.postJourneyEvent.firstCall,
-        ).to.have.been.calledWith(req, "dcmaw", "ipv-current-page");
+        ).to.have.been.calledWith(
+          req,
+          "dcmaw",
+          "page-ipv-identity-document-start",
+        );
       });
     },
   );
@@ -858,6 +920,7 @@ describe("journey middleware", () => {
           session: {
             currentPage: "pyi-suggest-other-options",
             ipvSessionId: null,
+            clientOauthSessionId: null,
             ipAddress: "ip-address",
           },
           params: { pageId: "pyi-suggest-other-options" },

--- a/src/app/ipv/middleware.test.js
+++ b/src/app/ipv/middleware.test.js
@@ -939,6 +939,76 @@ describe("journey middleware", () => {
     },
   );
 
+  context(
+    "handleJourneyAction: should render timeout-recoverable page if present clientOauthSessionId",
+    () => {
+      it("should render the timeout-recoverable page", async function () {
+        req = {
+          id: "1",
+          session: {
+            currentPage: "pyi-timeout-recoverable",
+            ipvSessionId: null,
+            clientOauthSessionId: "client-oauth-session-id",
+            ipAddress: "ip-address",
+          },
+          params: { pageId: "pyi-timeout-recoverable" },
+          log: { info: sinon.fake(), error: sinon.fake() },
+        };
+
+        await middleware.handleJourneyAction(req, res, next);
+        expect(res.render).to.have.been.calledWith(
+          "ipv/page/pyi-timeout-recoverable.njk",
+        );
+      });
+    },
+  );
+
+  context("updateJourneyState: handling invalid pageId", () => {
+    it("should render 404 page when pageId is invalid", async function () {
+      req = {
+        params: { pageId: "invalid-page-id", action: "next" },
+        session: {
+          ipvSessionId: "ipv-session-id",
+          ipAddress: "ip-address",
+        },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+      res = {
+        render: sinon.fake(),
+        status: sinon.stub().returnsThis(),
+      };
+      next = sinon.fake();
+
+      await middleware.updateJourneyState(req, res, next);
+
+      expect(res.render).to.have.been.calledWith("errors/page-not-found.njk");
+      expect(res.status).to.have.been.calledWith(404);
+    });
+  });
+
+  context("updateJourneyState: handling missing action", () => {
+    it("should render 404 page when action is not provided", async function () {
+      req = {
+        params: { pageId: "pyi-suggest-other-options", action: null },
+        session: {
+          ipvSessionId: "ipv-session-id",
+          ipAddress: "ip-address",
+        },
+        log: { info: sinon.fake(), error: sinon.fake() },
+      };
+      res = {
+        render: sinon.fake(),
+        status: sinon.stub().returnsThis(),
+      };
+      next = sinon.fake();
+
+      await middleware.updateJourneyState(req, res, next);
+
+      expect(res.render).to.have.been.calledWith("errors/page-not-found.njk");
+      expect(res.status).to.have.been.calledWith(404);
+    });
+  });
+
   context("validateFeatureSet", () => {
     beforeEach(() => {
       req = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Seperate the session validation and page logic into a new funcition. This is now used in both the GET (handleJourneyPage) and POST (handleJourneyAction) handlers.
- Remove duplicated test
- Use correct page template ID's in test cases now that the POST (handleJourneyAction) function also checks if page is valid
- Add session.currentPage to test cases as the POST (handleJourneyAction) function also checks if session.currentPage is valid

### Why did it change

The GET validation is not the same as for POST. So people can/ can't get onto a page with different conditionality to whether they can post to it

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6156](https://govukverify.atlassian.net/browse/PYIC-6156)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6156]: https://govukverify.atlassian.net/browse/PYIC-6156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ