### PR TITLE
PYIC-7228 Set Node keep-alive timeout and target deregistration delay higher than ELB timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -494,8 +494,10 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       TargetGroupAttributes:
+        # AWS suggests setting this higher than the idle timeout of the load balancer (default 60s) to prevent possible 504 errors
+        # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: 65
 
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -171,7 +171,7 @@ app.use(journeyEventErrorHandler);
 app.use(serverErrorHandler);
 app.use(pageNotFoundHandler);
 
-app
+const server = app
   .listen(PORT, () => {
     logger.info(`Server listening on port ${PORT}`);
     app.emit("appStarted");
@@ -179,5 +179,10 @@ app
   .on("error", (error) => {
     logger.error(`Unable to start server because of ${error.message}`);
   });
+
+// AWS recommends the keep-alive duration of the target is longer than the idle timeout value of the load balancer (default 60s)
+// to prevent possible 502 errors where the target connection has already been closed
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues
+server.keepAliveTimeout = 65000;
 
 module.exports = app;


### PR DESCRIPTION
## Proposed changes

### What changed

Set node keepAliveTimeout and target deregistration delay higher than ELB timeout

### Why did it change

We get a handful of 502s a day and a 504 every few days - this seems to be a known issue when running a load balancer in front of a Node.js application and the recommendation is to ensure the server's keep-alive timeout and the target's deregistration delay is set higher than the idle timeout of the load balancer.

AWS references this in its own docs for troubleshooting 5xx errors from load balancers: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues

> [Possible causes of 502 errors] The target closed the connection with a TCP RST or a TCP FIN while the load balancer had an outstanding request to the target. Check whether the keep-alive duration of the target is shorter than the idle timeout value of the load balancer.

> [Possible causes of 504 errors] The load balancer established a connection to the target but the target did not respond before the idle timeout period elapsed.

See also blog posts https://abakonski.com/resolving-502-and-504-errors-in-elastic/, https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/ and https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/

### Issue tracking
- [PYIC-7228](https://govukverify.atlassian.net/browse/PYIC-7228)


[PYIC-7228]: https://govukverify.atlassian.net/browse/PYIC-7228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ