### PR TITLE
IPS-954 Use async crypto where possible

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,13 +4,18 @@ const path = require("path");
 const session = require("express-session");
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const DynamoDBStore = require("connect-dynamodb")(session);
-const { frontendVitalSignsInit } = require("@govuk-one-login/frontend-vital-signs");
+const {
+  frontendVitalSignsInit,
+} = require("@govuk-one-login/frontend-vital-signs");
 
 // Checking for functions blocking the eventLoop
 const blocked = require("blocked-at");
-blocked((time, stack) => {
-  console.log(`Blocked for ${time}ms, operation started here:`, stack)
-}, { threshold: 20 })
+blocked(
+  (time, stack) => {
+    console.log(`Blocked for ${time}ms, operation started here:`, stack);
+  },
+  { threshold: 20 },
+);
 // Remove this check, don't merge.
 
 const {
@@ -193,12 +198,7 @@ const server = app
 frontendVitalSignsInit(server, {
   interval: 10000,
   logLevel: "info",
-  staticPaths: [
-    "/fonts",
-    "/images",
-    "/javascripts",
-    "/stylesheets",
-  ]
+  staticPaths: ["/fonts", "/images", "/javascripts", "/stylesheets"],
 });
 
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,7 @@ const {
 const { pageNotFoundHandler } = require("./handlers/page-not-found-handler");
 const {
   securityHeadersHandler,
+  cspHandler,
 } = require("./handlers/security-headers-handler");
 
 const APP_VIEWS = [
@@ -71,7 +72,6 @@ app.use(function (req, res, next) {
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(setLocals);
 app.use(securityHeadersHandler);
 
 app.use("/public", express.static(path.join(__dirname, "../dist/public")));
@@ -82,6 +82,8 @@ app.use(
   ),
 );
 
+app.use(setLocals);
+app.use(cspHandler);
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
 i18next

--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -2,16 +2,21 @@ module.exports = {
   securityHeadersHandler: (req, res, next) => {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
-      // Adapted from https://csp.withgoogle.com/docs/strict-csp.html
-      "Content-Security-Policy":
-        "object-src 'none'; " +
-        `script-src 'nonce-${res.locals.cspNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
-        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",
     });
     res.removeHeader("X-Powered-By");
+    next();
+  },
+  cspHandler: (req, res, next) => {
+    res.set({
+      // Adapted from https://csp.withgoogle.com/docs/strict-csp.html
+      "Content-Security-Policy":
+        "object-src 'none'; " +
+        `script-src 'nonce-${res.locals.cspNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
+    });
     next();
   },
 };

--- a/src/handlers/security-headers-handler.test.js
+++ b/src/handlers/security-headers-handler.test.js
@@ -3,6 +3,7 @@ const sinon = require("sinon");
 
 const {
   securityHeadersHandler,
+  cspHandler,
 } = require("../../src/handlers/security-headers-handler");
 
 describe("Security headers handler", () => {
@@ -30,18 +31,11 @@ describe("Security headers handler", () => {
   });
 
   it("should add security headers to response", () => {
-    const testNonce = "test-nonce";
-
-    res.locals.cspNonce = testNonce;
     securityHeadersHandler(req, res, next);
 
     expect(res.set).to.have.been.calledOnce;
     expect(res.set).to.have.been.calledWith({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy":
-        "object-src 'none'; " +
-        `script-src 'nonce-${testNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
-        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",
@@ -53,6 +47,22 @@ describe("Security headers handler", () => {
     securityHeadersHandler(req, res, next);
     expect(res.removeHeader).to.have.been.calledOnce;
     expect(res.removeHeader).to.have.been.calledWith("X-Powered-By");
+    expect(next).to.have.been.calledOnce;
+  });
+
+  it("should add csp header to response", () => {
+    const testNonce = "test-nonce";
+
+    res.locals.cspNonce = testNonce;
+    cspHandler(req, res, next);
+
+    expect(res.set).to.have.been.calledOnce;
+    expect(res.set).to.have.been.calledWith({
+      "Content-Security-Policy":
+        "object-src 'none'; " +
+        `script-src 'nonce-${testNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
+    });
     expect(next).to.have.been.calledOnce;
   });
 });

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -13,10 +13,10 @@ const {
 const { generateNonce } = require("./strings");
 
 module.exports = {
-  setLocals: function (req, res, next) {
+  setLocals: async function (req, res, next) {
     res.locals.uaContainerId = GTM_ID;
     res.locals.ga4ContainerId = GTM_ID_GA4;
-    res.locals.cspNonce = generateNonce();
+    res.locals.cspNonce = await generateNonce();
     res.locals.isGa4Disabled = GA4_DISABLED;
     res.locals.isUaDisabled = UA_DISABLED;
     res.locals.dynatraceRumUrl = DT_RUM_URL;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,5 +1,4 @@
 const pino = require("pino");
-const { randomUUID } = require("node:crypto");
 const pinoHttp = require("pino-http");
 
 const logger = pino({
@@ -35,7 +34,8 @@ const loggerMiddleware = pinoHttp({
     if (req.id) return req.id;
     let id = req.get("x-request-id");
     if (id) return id;
-    id = randomUUID();
+    // Not securely random, but this is just used for request correlation
+    id = Math.random().toString(36).slice(2);
     res.header("x-request-id", id);
     return id;
   },

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,6 +1,10 @@
+const { promisify } = require("util");
 const { randomBytes } = require("crypto");
+
+const asyncRandomBytes = promisify(randomBytes);
+
 module.exports = {
-  generateNonce: function generateNonce() {
-    return randomBytes(16).toString("hex");
+  generateNonce: async function generateNonce() {
+    return (await asyncRandomBytes(16)).toString("hex");
   },
 };


### PR DESCRIPTION
## Proposed changes

### What changed

- Move nonce generation after static hosting, so a nonce is not generated for static asset serving
- Make nonce generation use async crypto to avoid blocking
- Make request id generation use non-blocking (and non-secure) random

### Why did it change

Avoid blocking crypto operations, which may be causing a bottleneck in performance
