### PR TITLE
PYIC-7051: Remove text for removed context

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -238,7 +238,6 @@
         "paragraph1": "Mae hyn oherwydd nad ydych wedi ateb rhai o’r cwestiynau diogelwch yn gywir.",
         "subHeading": "Beth allwch chi ei wneud",
         "paragraph2": "Yn seiliedig ar beth rydych wedi’i ddweud wrthym, mae gennych chi lun ID y gallwch ei ddefnyddio i brofi pwy ydych chi.",
-        "paragraph2NoPhotoId": "TEMP If you have a photo ID instead you may be able to use it to prove your identity",
         "paragraph3": "Gallwch wneud hyn gyda’r ap GOV.UK ID Check os oes gennych:",
         "requirements": [
           "iPhone 7 neu uwch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -238,7 +238,6 @@
         "paragraph1": "This is because you did not answer some of the security questions correctly.",
         "subHeading": "What you can do",
         "paragraph2": "Based on what you’ve told us, you have a photo ID you can use to prove your identity.",
-        "paragraph2NoPhotoId": "TEMP If you have a photo ID instead you may be able to use it to prove your identity",
         "paragraph3": "You can do this online with the GOV.UK ID Check app if you have:",
         "requirements": [
           "an iPhone 7 or higher",

--- a/src/views/ipv/page/pyi-suggest-other-options.njk
+++ b/src/views/ipv/page/pyi-suggest-other-options.njk
@@ -15,7 +15,7 @@
   <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph1' | translate }}</p>
 
   <h2 class="govuk-heading-m">{{ 'pages.pyiSuggestOtherOptions.content.subHeading' | translate }}</h2>
-  <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph2' | translateWithContext(context) }}</p>
+  <p class="govuk-body">{{ 'pages.pyiSuggestOtherOptions.content.paragraph2' | translate }}</p>
   <p class="govuk-body govuk-!-margin-bottom-1">{{ 'pages.pyiSuggestOtherOptions.content.paragraph3' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-5">
     {% for listItem in 'pages.pyiSuggestOtherOptions.content.requirements' | translate({ returnObjects: true }) %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed `no-photo-id` context

### Why did it change

No longer used with the changes to the routing in core-back

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7051](https://govukverify.atlassian.net/browse/PYIC-7051)


[PYIC-7051]: https://govukverify.atlassian.net/browse/PYIC-7051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ