### PR TITLE
BAU Avoid blocking crypto

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -32,6 +32,7 @@ const {
 const { pageNotFoundHandler } = require("./handlers/page-not-found-handler");
 const {
   securityHeadersHandler,
+  cspHandler,
 } = require("./handlers/security-headers-handler");
 
 const APP_VIEWS = [
@@ -63,7 +64,6 @@ app.use(function (req, res, next) {
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(setLocals);
 app.use(securityHeadersHandler);
 
 app.use("/public", express.static(path.join(__dirname, "../dist/public")));
@@ -74,6 +74,8 @@ app.use(
   ),
 );
 
+app.use(setLocals);
+app.use(cspHandler);
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
 i18next

--- a/src/handlers/security-headers-handler.js
+++ b/src/handlers/security-headers-handler.js
@@ -2,16 +2,21 @@ module.exports = {
   securityHeadersHandler: (req, res, next) => {
     res.set({
       "Strict-Transport-Security": "max-age=31536000",
-      // Adapted from https://csp.withgoogle.com/docs/strict-csp.html
-      "Content-Security-Policy":
-        "object-src 'none'; " +
-        `script-src 'nonce-${res.locals.cspNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
-        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",
     });
     res.removeHeader("X-Powered-By");
+    next();
+  },
+  cspHandler: (req, res, next) => {
+    res.set({
+      // Adapted from https://csp.withgoogle.com/docs/strict-csp.html
+      "Content-Security-Policy":
+        "object-src 'none'; " +
+        `script-src 'nonce-${res.locals.cspNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
+    });
     next();
   },
 };

--- a/src/handlers/security-headers-handler.test.js
+++ b/src/handlers/security-headers-handler.test.js
@@ -3,6 +3,7 @@ const sinon = require("sinon");
 
 const {
   securityHeadersHandler,
+  cspHandler,
 } = require("../../src/handlers/security-headers-handler");
 
 describe("Security headers handler", () => {
@@ -30,18 +31,11 @@ describe("Security headers handler", () => {
   });
 
   it("should add security headers to response", () => {
-    const testNonce = "test-nonce";
-
-    res.locals.cspNonce = testNonce;
     securityHeadersHandler(req, res, next);
 
     expect(res.set).to.have.been.calledOnce;
     expect(res.set).to.have.been.calledWith({
       "Strict-Transport-Security": "max-age=31536000",
-      "Content-Security-Policy":
-        "object-src 'none'; " +
-        `script-src 'nonce-${testNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
-        "base-uri 'none'",
       "X-Frame-Options": "DENY",
       "X-XSS-Protection": "0",
       "X-Content-Type-Options": "nosniff",
@@ -53,6 +47,22 @@ describe("Security headers handler", () => {
     securityHeadersHandler(req, res, next);
     expect(res.removeHeader).to.have.been.calledOnce;
     expect(res.removeHeader).to.have.been.calledWith("X-Powered-By");
+    expect(next).to.have.been.calledOnce;
+  });
+
+  it("should add csp header to response", () => {
+    const testNonce = "test-nonce";
+
+    res.locals.cspNonce = testNonce;
+    cspHandler(req, res, next);
+
+    expect(res.set).to.have.been.calledOnce;
+    expect(res.set).to.have.been.calledWith({
+      "Content-Security-Policy":
+        "object-src 'none'; " +
+        `script-src 'nonce-${testNonce}' 'unsafe-inline' 'strict-dynamic' https:; ` +
+        "base-uri 'none'",
+    });
     expect(next).to.have.been.calledOnce;
   });
 });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -24,6 +24,7 @@ module.exports = {
   ENABLE_PREVIEW: process.env.ENABLE_PREVIEW === "development",
   EXTERNAL_WEBSITE_HOST: process.env.EXTERNAL_WEBSITE_HOST,
   PORT: process.env.PORT || 4501,
+  SESSION_COOKIE_NAME: "ipv_core_service_session",
   SESSION_SECRET: process.env.SESSION_SECRET,
   SESSION_TABLE_NAME: process.env.SESSION_TABLE_NAME,
   GTM_ID: process.env.GTM_ID,

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -13,10 +13,10 @@ const {
 const { generateNonce } = require("./strings");
 
 module.exports = {
-  setLocals: function (req, res, next) {
+  setLocals: async function (req, res, next) {
     res.locals.uaContainerId = GTM_ID;
     res.locals.ga4ContainerId = GTM_ID_GA4;
-    res.locals.cspNonce = generateNonce();
+    res.locals.cspNonce = await generateNonce();
     res.locals.isGa4Disabled = GA4_DISABLED;
     res.locals.isUaDisabled = UA_DISABLED;
     res.locals.dynatraceRumUrl = DT_RUM_URL;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,5 +1,4 @@
 const pino = require("pino");
-const { randomUUID } = require("node:crypto");
 const pinoHttp = require("pino-http");
 
 const logger = pino({
@@ -35,7 +34,8 @@ const loggerMiddleware = pinoHttp({
     if (req.id) return req.id;
     let id = req.get("x-request-id");
     if (id) return id;
-    id = randomUUID();
+    // Not securely random, but this is just used for request correlation
+    id = Math.random().toString(36).slice(2);
     res.header("x-request-id", id);
     return id;
   },

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,6 +1,10 @@
+const { promisify } = require("util");
 const { randomBytes } = require("crypto");
+
+const asyncRandomBytes = promisify(randomBytes);
+
 module.exports = {
-  generateNonce: function generateNonce() {
-    return randomBytes(16).toString("hex");
+  generateNonce: async function generateNonce() {
+    return (await asyncRandomBytes(16)).toString("hex");
   },
 };


### PR DESCRIPTION
## Proposed changes

### What changed

- Change nonce generation to use async randomBytes
- Change request id generation to use non-blocking Math.random
- Change session id generation to use async uid (where possible)

### Why did it change

Blocking operations cause a significant degradation in performance when under high load. Making these operations async means the work will be offloaded to the nodejs threadpool and allow other operations to continue.

In the perf environment, when under load:
- Without this change: healthchecks degrade as the task came under load and end up frequently timing out
- After this change: healthchecks consistently return quickly (mostly <10ms and all <50ms)

### Issue tracking

- [IPS-954](https://govukverify.atlassian.net/browse/IPS-954)


[IPS-954]: https://govukverify.atlassian.net/browse/IPS-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ