### PR TITLE
BAU Stop duplicate logging

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -178,13 +178,10 @@ if (ENABLE_PREVIEW) {
   router.use("/dev", require("./app/development/router"));
 }
 
-const healthcheckRouter = express.Router();
-healthcheckRouter.use(loggerMiddleware);
-healthcheckRouter.get("/healthcheck", (req, res) => {
+router.get("/healthcheck", (req, res) => {
   return res.status(200).send("OK");
 });
 
-app.use(healthcheckRouter);
 app.use(router);
 
 app.use(journeyEventErrorHandler);

--- a/src/app.js
+++ b/src/app.js
@@ -148,6 +148,7 @@ app.use((req, res, next) => {
   });
   next();
 });
+app.use(loggerMiddleware);
 
 app.use((req, res, next) => {
   res.set(
@@ -160,7 +161,6 @@ app.use((req, res, next) => {
 app.set("etag", false);
 
 const router = express.Router();
-router.use(loggerMiddleware);
 
 router.use((req, res, next) => {
   req.log = logger.child({


### PR DESCRIPTION
## Proposed changes

### What changed

Removes the standalone healthcheck router and registers the healthcheck endpoint on the main router so we get (non-duplicated) logging across all routes

### Why did it change

Earlier this month we registered the logging middleware on the healthcheck router to enable logging for the healthcheck, but as this router is ultimately registered on the `app` alongside the main router it means requests fall through 2 instances of logging middleware and we see double
