### PR TITLE
PYIC-7164: update event from update-details-failed page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1290,8 +1290,8 @@
         "formRadioButtons": {
           "continue": "TODO: Continue to the service without updating your details",
           "continueHint": "TODO: Your proof of identity is valid even if your details have changed.",
-          "returnToRp": "TODO: Go back to the service you are trying to use",
-          "returnToRpHint": "TODO: There may be another way to access the service without using your GOV.UK One Login.",
+          "returnToService": "TODO: Go back to the service you are trying to use",
+          "returnToServiceHint": "TODO: There may be another way to access the service without using your GOV.UK One Login.",
           "delete": "TODO: Delete your GOV.UK One Login",
           "deleteHint": "TODO: ou can then create a new one and prove your identity using your new details."
         },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1288,12 +1288,12 @@
         "paragraph1RepeatFraudCheck": "TODO:You will not be able to use your GOV.UK One Login to access the service.",
         "subHeading": "TODO: What would you like to do?",
         "formRadioButtons": {
-          "continueOption": "TODO: Continue to the service without updating your details",
-          "continueOptionHint": "TODO: Your proof of identity is valid even if your details have changed.",
-          "backOption": "TODO: Go back to the service you are trying to use",
-          "backOptionHint": "TODO: There may be another way to access the service without using your GOV.UK One Login.",
-          "deleteOption": "TODO: Delete your GOV.UK One Login",
-          "deleteOptionHint": "YTODO: ou can then create a new one and prove your identity using your new details."
+          "continue": "TODO: Continue to the service without updating your details",
+          "continueHint": "TODO: Your proof of identity is valid even if your details have changed.",
+          "returnToRp": "TODO: Go back to the service you are trying to use",
+          "returnToRpHint": "TODO: There may be another way to access the service without using your GOV.UK One Login.",
+          "delete": "TODO: Delete your GOV.UK One Login",
+          "deleteHint": "TODO: ou can then create a new one and prove your identity using your new details."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "TODO: There is a problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1290,12 +1290,12 @@
         "paragraph1RepeatFraudCheck": "You will not be able to use your GOV.UK One Login to access the service.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
-          "continueOption": "Continue to the service without updating your details",
-          "continueOptionHint": "Your proof of identity is valid even if your details have changed.",
-          "backOption": "Go back to the service you were trying to use",
-          "backOptionHint": "There may be another way to access the service without using your GOV.UK One Login.",
-          "deleteOption": "Delete your GOV.UK One Login",
-          "deleteOptionHint": "You can then create a new one and prove your identity using your new details."
+          "continue": "Continue to the service without updating your details",
+          "continueHint": "Your proof of identity is valid even if your details have changed.",
+          "returnToRp": "Go back to the service you were trying to use",
+          "returnToRpHint": "There may be another way to access the service without using your GOV.UK One Login.",
+          "delete": "Delete your GOV.UK One Login",
+          "deleteHint": "You can then create a new one and prove your identity using your new details."
         },
         "formErrorMessage": {
           "errorSummaryTitleText": "There is a problem",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1292,8 +1292,8 @@
         "formRadioButtons": {
           "continue": "Continue to the service without updating your details",
           "continueHint": "Your proof of identity is valid even if your details have changed.",
-          "returnToRp": "Go back to the service you were trying to use",
-          "returnToRpHint": "There may be another way to access the service without using your GOV.UK One Login.",
+          "returnToService": "Go back to the service you were trying to use",
+          "returnToServiceHint": "There may be another way to access the service without using your GOV.UK One Login.",
           "delete": "Delete your GOV.UK One Login",
           "deleteHint": "You can then create a new one and prove your identity using your new details."
         },

--- a/src/views/ipv/page/update-details-failed.njk
+++ b/src/views/ipv/page/update-details-failed.njk
@@ -20,13 +20,13 @@
               [
                    {
                    value: "delete",
-                   text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOption' | translate,
-                   hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOptionHint' | translate }
+                   text: 'pages.updateDetailsFailed.content.formRadioButtons.delete' | translate,
+                   hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteHint' | translate }
                    },
                   {
-                  value: "back",
-                  text: 'pages.updateDetailsFailed.content.formRadioButtons.backOption' | translate,
-                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.backOptionHint' | translate }
+                  value: "returnToRp",
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToRp' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToRpHint' | translate }
                   }
               ]
             %}
@@ -35,13 +35,13 @@
               [
                   {
                   value: "continue",
-                  text: 'pages.updateDetailsFailed.content.formRadioButtons.continueOption' | translate,
-                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.continueOptionHint' | translate }
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.continue' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.continueHint' | translate }
                   },
                   {
                   value: "delete",
-                  text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOption' | translate,
-                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteOptionHint' | translate }
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.delete' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteHint' | translate }
                   }
               ]
             %}

--- a/src/views/ipv/page/update-details-failed.njk
+++ b/src/views/ipv/page/update-details-failed.njk
@@ -24,9 +24,9 @@
                    hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.deleteHint' | translate }
                    },
                   {
-                  value: "returnToRp",
-                  text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToRp' | translate,
-                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToRpHint' | translate }
+                  value: "return-to-service",
+                  text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToService' | translate,
+                  hint: { text: 'pages.updateDetailsFailed.content.formRadioButtons.returnToServiceHint' | translate }
                   }
               ]
             %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- update event `back` to `returnToRp` instead to not overload the `back` event

### Why did it change
See comment [here](https://github.com/govuk-one-login/ipv-core-back/pull/2367#discussion_r1741738504)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7164](https://govukverify.atlassian.net/browse/PYIC-7164)



[PYIC-7164]: https://govukverify.atlassian.net/browse/PYIC-7164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ