### PR TITLE
BAU: add missing Welsh content for confirm-details page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -791,7 +791,8 @@
           "checkbox4": "Dyddiad geni"
         },
         "errorCheckBoxMessage": "Dewiswch ba fanylion rydych angen eu diweddaru",
-        "warningText": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol."
+        "warningTextContent": "Efallai na fyddwch yn gallu defnyddio'ch GOV.UK One Login os nad yw'ch manylion yn gyfredol.",
+        "warningTextFallback": "Rhybudd"
       }
     },
     "pyiDetailsDeleted": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
updates/adds missing warning text to confirm-details page

### Why did it change
The Welsh page for confirm-details was showing the english translations bc the translation var was not up to date with the english version

| The problem | Fixed |
|-|-|
| <img width="670" alt="Screenshot 2024-09-11 at 09 13 07" src="https://github.com/user-attachments/assets/2a9aa6aa-ffc4-42bb-ad8f-815dc55e4af4"> | <img width="588" alt="Screenshot 2024-09-11 at 09 13 30" src="https://github.com/user-attachments/assets/56da8bba-b7e3-45c2-84ef-7b52d5a2adeb"> |

