### PR TITLE
PYIC-7450: update sorry-could-not-confirm-details page for fast follo…

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -153,7 +153,7 @@
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
         "paragraph3ExistingIdentityInvalid": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad i'r gwasanaeth.",
-        "paragraph3ExistingIdentityValid": "TODO: Your details have not been updated.",
+        "paragraph3ExistingIdentityValid": "Nid yw eich manylion wedi cael eu diweddaru.",
         "subHeading": "Beth hoffech chi ei wneud? ",
         "formRadioButtons": {
           "contactOption": "Cysylltwch â thîm GOV.UK One Login",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -152,13 +152,18 @@
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
-        "paragraph3": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad i'r gwasanaeth.",
+        "paragraph3DeleteDetailsRfc": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad i'r gwasanaeth.",
+        "paragraph3DeleteDetailsReuse": "TODO: Your details have not been updated.",
         "subHeading": "Beth hoffech chi ei wneud? ",
         "formRadioButtons": {
           "contactOption": "Cysylltwch â thîm GOV.UK One Login",
           "contactOptionHint": "Efallai y bydd angen i chi ddileu'ch GOV.UK One Login. Yna gallwch greu un newydd a cheisio profi eich hunaniaeth eto gyda’ch manylion newydd.",
           "deleteOption": "Dileu eich GOV.UK One Login",
           "deleteOptionHint": "Yna gallwch greu un newydd a phrofi eich hunaniaeth gan ddefnyddio eich manylion newydd.",
+          "returnToServiceDeleteDetailsRfc": "Ewch yn ôl i'r gwasanaeth rydych yn ceisio ei ddefnyddio",
+          "returnToServiceHintDeleteDetailsRfc": "Efallai bod ffordd arall o gael mynediad i'r gwasanaeth heb ddefnyddio eich GOV.UK One Login.",
+          "returnToServiceDeleteDetailsReuse": "Parhau i'r gwasanaeth heb ddiweddaru eich manylion",
+          "returnToServiceHintDeleteDetailsReuse": "Mae eich prawf hunaniaeth yn ddilys hyd yn oed os yw'ch manylion wedi newid.",
           "endOption": "Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o gael mynediad ato."
         },
         "formErrorMessage": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1271,7 +1271,7 @@
       "header": "Nid oeddech yn gallu diweddaru eich manylion gyda’r ap GOV.UK ID check",
       "content": {
         "paragraph1": "Gallwch barhau i ddefnyddio'r gwasanaeth os yw'ch manylion allan o ddyddiad.",
-        "paragraph1RepeatFraudCheck": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad at y gwasanaeth.",
+        "paragraph1ExistingIdentityInvalid": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad at y gwasanaeth.",
         "subHeading": "Beth hoffech chi ei wneud?",
         "formRadioButtons": {
           "continue": "Parhau i'r gwasanaeth heb ddiweddaru eich manylion",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -152,18 +152,18 @@
       "content": {
         "paragraph1": "Nid oeddem yn gallu dod o hyd i unrhyw un yn cyfateb pan wnaethom wirio’ch manylion gyda sefydliad arall.",
         "paragraph2": "Er mwyn cadw eich gwybodaeth yn ddiogel, ni allwn ddweud wrthych pa un o’ch manylion nad oeddem yn gallu cyfateb.",
-        "paragraph3DeleteDetailsRfc": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad i'r gwasanaeth.",
-        "paragraph3DeleteDetailsReuse": "TODO: Your details have not been updated.",
+        "paragraph3ExistingIdentityInvalid": "Ni fyddwch yn gallu defnyddio'ch GOV.UK One Login i gael mynediad i'r gwasanaeth.",
+        "paragraph3ExistingIdentityValid": "TODO: Your details have not been updated.",
         "subHeading": "Beth hoffech chi ei wneud? ",
         "formRadioButtons": {
           "contactOption": "Cysylltwch â thîm GOV.UK One Login",
           "contactOptionHint": "Efallai y bydd angen i chi ddileu'ch GOV.UK One Login. Yna gallwch greu un newydd a cheisio profi eich hunaniaeth eto gyda’ch manylion newydd.",
           "deleteOption": "Dileu eich GOV.UK One Login",
           "deleteOptionHint": "Yna gallwch greu un newydd a phrofi eich hunaniaeth gan ddefnyddio eich manylion newydd.",
-          "returnToServiceDeleteDetailsRfc": "Ewch yn ôl i'r gwasanaeth rydych yn ceisio ei ddefnyddio",
-          "returnToServiceHintDeleteDetailsRfc": "Efallai bod ffordd arall o gael mynediad i'r gwasanaeth heb ddefnyddio eich GOV.UK One Login.",
-          "returnToServiceDeleteDetailsReuse": "Parhau i'r gwasanaeth heb ddiweddaru eich manylion",
-          "returnToServiceHintDeleteDetailsReuse": "Mae eich prawf hunaniaeth yn ddilys hyd yn oed os yw'ch manylion wedi newid.",
+          "returnToServiceExistingIdentityInvalid": "Ewch yn ôl i'r gwasanaeth rydych yn ceisio ei ddefnyddio",
+          "returnToServiceHintExistingIdentityInvalid": "Efallai bod ffordd arall o gael mynediad i'r gwasanaeth heb ddefnyddio eich GOV.UK One Login.",
+          "returnToServiceExistingIdentityValid": "Parhau i'r gwasanaeth heb ddiweddaru eich manylion",
+          "returnToServiceHintExistingIdentityValid": "Mae eich prawf hunaniaeth yn ddilys hyd yn oed os yw'ch manylion wedi newid.",
           "endOption": "Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o gael mynediad ato."
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -152,13 +152,18 @@
       "content": {
         "paragraph1": "We could not find a match when we checked your details with another organisation.",
         "paragraph2": "To keep your information safe, we cannot tell you which of your details we were unable to match.",
-        "paragraph3": "You will not be able to use your GOV.UK One Login to access the service.",
+        "paragraph3DeleteDetailsRfc": "You will not be able to use your GOV.UK One Login to access the service.",
+        "paragraph3DeleteDetailsReuse": "Your details have not been updated.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "contactOption": "Contact the GOV.UK One Login team",
           "contactOptionHint": "You may need to delete your GOV.UK One Login. Then you can create a new one and try to prove your identity again with your new details.",
           "deleteOption": "Delete your GOV.UK One Login",
           "deleteOptionHint": "You can then create a new one and prove your identity using your new details.",
+          "returnToServiceDeleteDetailsRfc": "Go back to the service you were trying to use",
+          "returnToServiceHintDeleteDetailsRfc": "There may be another way to access the service without using your GOV.UK One Login.",
+          "returnToServiceDeleteDetailsReuse": "Continue to the service without updating your details",
+          "returnToServiceHintDeleteDetailsReuse": "Your proof of identity is valid even if your details have changed.",
           "endOption": "Continue to the service you were trying to use to find out if there are other ways to access it"
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -152,18 +152,18 @@
       "content": {
         "paragraph1": "We could not find a match when we checked your details with another organisation.",
         "paragraph2": "To keep your information safe, we cannot tell you which of your details we were unable to match.",
-        "paragraph3DeleteDetailsRfc": "You will not be able to use your GOV.UK One Login to access the service.",
-        "paragraph3DeleteDetailsReuse": "Your details have not been updated.",
+        "paragraph3ExistingIdentityInvalid": "You will not be able to use your GOV.UK One Login to access the service.",
+        "paragraph3ExistingIdentityValid": "Your details have not been updated.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "contactOption": "Contact the GOV.UK One Login team",
           "contactOptionHint": "You may need to delete your GOV.UK One Login. Then you can create a new one and try to prove your identity again with your new details.",
           "deleteOption": "Delete your GOV.UK One Login",
           "deleteOptionHint": "You can then create a new one and prove your identity using your new details.",
-          "returnToServiceDeleteDetailsRfc": "Go back to the service you were trying to use",
-          "returnToServiceHintDeleteDetailsRfc": "There may be another way to access the service without using your GOV.UK One Login.",
-          "returnToServiceDeleteDetailsReuse": "Continue to the service without updating your details",
-          "returnToServiceHintDeleteDetailsReuse": "Your proof of identity is valid even if your details have changed.",
+          "returnToServiceExistingIdentityInvalid": "Go back to the service you were trying to use",
+          "returnToServiceHintExistingIdentityInvalid": "There may be another way to access the service without using your GOV.UK One Login.",
+          "returnToServiceExistingIdentityValid": "Continue to the service without updating your details",
+          "returnToServiceHintExistingIdentityValid": "Your proof of identity is valid even if your details have changed.",
           "endOption": "Continue to the service you were trying to use to find out if there are other ways to access it"
         },
         "formErrorMessage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1271,7 +1271,7 @@
       "header": "You were not able to update your details with the GOV.UK ID check app",
       "content": {
         "paragraph1": "You can still use the service if your details are out of date.",
-        "paragraph1RepeatFraudCheck": "You will not be able to use your GOV.UK One Login to access the service.",
+        "paragraph1ExistingIdentityInvalid": "You will not be able to use your GOV.UK One Login to access the service.",
         "subHeading": "What would you like to do?",
         "formRadioButtons": {
           "continue": "Continue to the service without updating your details",

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -32,9 +32,9 @@
   %}
   {% endif %}
 
-  {% if context == "deleteDetailsRfc" %}
+  {% if context == "existingIdentityInvalid" %}
     {% set radioItems = [ deleteOption, returnToServiceOption] %}
-  {% elif context == "deleteDetailsReuse" %}
+  {% elif context == "existingIdentityValid" %}
     {% set radioItems = [ returnToServiceOption, deleteOption] %}
   {% else %}
   {%

--- a/src/views/ipv/page/sorry-could-not-confirm-details.njk
+++ b/src/views/ipv/page/sorry-could-not-confirm-details.njk
@@ -14,30 +14,43 @@
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph2' | translate }}</p>
 
-  {% if context == "deleteDetailsReuse" %}
-  <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph3' | translate }}</p>
+  {% if context %}
+  <p class="govuk-body">{{ 'pages.sorryCouldNotConfirmDetails.content.paragraph3' | translateWithContext(context) }}</p>
   {%
-    set radioItems = [{
+    set deleteOption = {
         value: "delete",
         text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.deleteOption' | translate,
         hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.deleteOptionHint' | translate }
-    }]
+      }
   %}
-  {% else %}
   {%
-    set radioItems = [{
-        value: "contact",
-        text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOption' | translate,
-        hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOptionHint' | translate }
-    }]
+    set returnToServiceOption = {
+        value: "returnToRp",
+          text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.returnToService' | translateWithContext(context),
+          hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.returnToServiceHint' | translateWithContext(context) }
+      }
   %}
   {% endif %}
+
+  {% if context == "deleteDetailsRfc" %}
+    {% set radioItems = [ deleteOption, returnToServiceOption] %}
+  {% elif context == "deleteDetailsReuse" %}
+    {% set radioItems = [ returnToServiceOption, deleteOption] %}
+  {% else %}
   {%
-    set radioItems = radioItems.concat({
-        value: "end",
-        text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.endOption' | translate
-    })
+    set radioItems = [
+      {
+          value: "contact",
+          text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOption' | translate,
+          hint: { text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.contactOptionHint' | translate }
+      },
+      {
+          value: "end",
+          text: 'pages.sorryCouldNotConfirmDetails.content.formRadioButtons.endOption' | translate
+      }]
   %}
+  {% endif %}
+
   <form id="sorryCouldNotConfirmDetailsActionForm" action="/ipv/page/{{ pageId }}" method="POST">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
       {% set radiosConfig = {

--- a/src/views/ipv/page/update-details-failed.njk
+++ b/src/views/ipv/page/update-details-failed.njk
@@ -15,7 +15,7 @@
 
   <form id="updateDetailsFailedActionForm" action="/ipv/page/{{ pageId }}" method="POST">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-         {% if context == "repeatFraudCheck" %}
+         {% if context == "existingIdentityInvalid" %}
             {% set radioOptions =
               [
                    {


### PR DESCRIPTION
…w changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update `sorry-could-not-confirm-details` page to align with [UCD designs](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=9653-22423&node-type=canvas&t=nlK6xaEteoA6eLLG-0) for reuse and rfc journeys

Corresponding BE PR: https://github.com/govuk-one-login/ipv-core-back/pull/2429

| Without fast-follow changes | Repeat fraud check | Reuse
|-|-|-|
|  <img width="586" alt="Screenshot 2024-09-12 at 11 37 27" src="https://github.com/user-attachments/assets/a99f2dc9-1537-4123-a111-8ad861438047"> | <img width="574" alt="Screenshot 2024-09-12 at 11 37 19" src="https://github.com/user-attachments/assets/f5bf11e3-4d3c-46e4-bec2-8b8c3b87feb7"> |  <img width="571" alt="Screenshot 2024-09-12 at 11 36 39" src="https://github.com/user-attachments/assets/cf5fd44a-5b25-4139-a60b-2b223bb4cf7b"> |

### Why did it change
The fast follow changes allow users to delete their accounts. There are two variants of the page when fast follow is enabled, one for reuse and rfc which display different options to the user (deleting the account and continuing to the service with/without their identity depending on the journey)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7450](https://govukverify.atlassian.net/browse/PYIC-7450)


[PYIC-7450]: https://govukverify.atlassian.net/browse/PYIC-7450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ