### PR TITLE
Pyic 6736 strategic app journey map

### DIFF
--- a/browser-tests/Dockerfile
+++ b/browser-tests/Dockerfile
@@ -11,5 +11,6 @@ COPY ./browser-tests/functional-tests ./functional-tests
 COPY ./browser-tests/snapshot-tests ./snapshot-tests
 COPY ./browser-tests/playwright.config.js ./
 COPY ../src/views/ipv/page ../src/views/ipv/page
+COPY ../test ../test
 
 CMD ["npm run test"]

--- a/browser-tests/functional-tests/functional.spec.js
+++ b/browser-tests/functional-tests/functional.spec.js
@@ -5,7 +5,7 @@ const domainUrl = process.env.WEBSITE_HOST;
 test.describe.parallel("Functional tests", () => {
   test("Handover from orchestration", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("examplePageNavigation"));
+    await page.goto(getAuthoriseUrlForJourney("testPageNavigation"));
 
     // Check that we are on the start page
     const url = page.url();
@@ -14,7 +14,7 @@ test.describe.parallel("Functional tests", () => {
 
   test("Page navigation", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("examplePageNavigation"));
+    await page.goto(getAuthoriseUrlForJourney("testPageNavigation"));
 
     // Go to the F2F start page
     await page.click("input[type='radio'][value='end']");
@@ -27,7 +27,7 @@ test.describe.parallel("Functional tests", () => {
 
   test("Welsh language toggle", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("exampleWelshLanguage"));
+    await page.goto(getAuthoriseUrlForJourney("testWelshLanguage"));
 
     // Click the language toggle
     await page.click('[hreflang="cy"]');
@@ -41,7 +41,7 @@ test.describe.parallel("Functional tests", () => {
 
   test("Context is used to display page", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("exampleContext"));
+    await page.goto(getAuthoriseUrlForJourney("testContext"));
 
     // Go to the DCMAW CRI
     await page.click("input[type='radio'][value='appTriage']");
@@ -54,7 +54,7 @@ test.describe.parallel("Functional tests", () => {
 
   test("Visiting a CRI", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("exampleCri"));
+    await page.goto(getAuthoriseUrlForJourney("testCri"));
 
     // Go to the DCMAW CRI
     await page.click("input[type='radio'][value='appTriage']");

--- a/browser-tests/functional-tests/functional.spec.js
+++ b/browser-tests/functional-tests/functional.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require("@playwright/test");
+const TEST_CONSTANTS = require("../../test/constants");
 
 const domainUrl = process.env.WEBSITE_HOST;
 
@@ -65,6 +66,42 @@ test.describe.parallel("Functional tests", () => {
     expect(url).toBe(`${domainUrl}/ipv/page/page-multiple-doc-check`);
   });
 })
+
+test.describe("iPhone tests", () => {
+  test.use({ userAgent: TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE });
+
+  test("Handling identify-device", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testIdentifyDeviceIphone"));
+
+    // Have core-back return an identify-device page response
+    // Core front should convert that page to an appTriageIphone event which core back will then respond to with
+    // a prove-identity-another-type-photo-id page response
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
+
+    const url = page.url();
+    expect(url).toBe(`${domainUrl}/ipv/page/prove-identity-another-type-photo-id`);
+  });
+});
+
+test.describe("Android tests", () => {
+  test.use({ userAgent: TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID });
+
+  test("Handling identify-device", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testIdentifyDeviceAndroid"));
+
+    // Have core-back return an identify-device page response
+    // Core front should convert that page to an appTriageIphone event which core back will then respond to with
+    // a prove-identity-another-type-photo-id page response
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
+
+    const url = page.url();
+    expect(url).toBe(`${domainUrl}/ipv/page/prove-identity-another-type-photo-id`);
+  });
+});
 
 // Put the journey into the 'state' parameter of the request so that imposter sends it back as the IpvSessionId
 // See the readme and/or `imposter/config/api-config.yaml` for more information

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -52,7 +52,7 @@ resources:
     path: /journey/end
     requestHeaders:
       content-type: "application/json"
-      ipv-session-id: "examplePageNavigation"
+      ipv-session-id: "testPageNavigation"
     queryParams:
       currentPage: "page-ipv-identity-document-start"
     response:
@@ -68,7 +68,7 @@ resources:
     path: /journey/appTriage
     requestHeaders:
       content-type: "application/json"
-      ipv-session-id: "exampleContext"
+      ipv-session-id: "testContext"
     queryParams:
       currentPage: "page-ipv-identity-document-start"
     response:
@@ -87,7 +87,7 @@ resources:
     path: /journey/appTriage
     requestHeaders:
       content-type: "application/json"
-      ipv-session-id: "exampleCri"
+      ipv-session-id: "testCri"
     queryParams:
       currentPage: "page-ipv-identity-document-start"
     response:
@@ -95,7 +95,7 @@ resources:
       content: |
         {
           "cri": {
-            "redirectUrl": "http://localhost:4601/credential-issuer/callback/fakeDcmaw?state=exampleCri&code=dummyAuthCode",
+            "redirectUrl": "http://localhost:4601/credential-issuer/callback/fakeDcmaw?state=testCri&code=dummyAuthCode",
             "id": "fakeDcmaw"
           }
         }
@@ -113,7 +113,7 @@ resources:
       - jsonPath: $.redirectUri
         value: "http://localhost:4601/credential-issuer/callback/fakeDcmaw"
       - jsonPath: $.state
-        value: "exampleCri"
+        value: "testCri"
     response:
       statusCode: 200
       content: |

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -124,7 +124,7 @@ resources:
   # Journeys for identify-device test
   # We just want to test the handling of identify-device so this journey does not match what core-back actually does
   - method: POST
-    path: /journey/appTriageIphone
+    path: /journey/appTriage
     requestHeaders:
       content-type: "application/json"
       ipv-session-id: "testIdentifyDeviceIphone"
@@ -152,7 +152,7 @@ resources:
         }
 
   - method: POST
-    path: /journey/appTriageAndroid
+    path: /journey/appTriage
     requestHeaders:
       content-type: "application/json"
       ipv-session-id: "testIdentifyDeviceAndroid"

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -120,3 +120,61 @@ resources:
         {
           "page": "page-multiple-doc-check"
         }
+
+  # Journeys for identify-device test
+  # We just want to test the handling of identify-device so this journey does not match what core-back actually does
+  - method: POST
+    path: /journey/appTriageIphone
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id: "testIdentifyDeviceIphone"
+    queryParams:
+      currentPage: "page-ipv-identity-document-start"
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "identify-device"
+        }
+
+  - method: POST
+    path: /journey/appTriageIphone
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id: "testIdentifyDeviceIphone"
+    queryParams:
+      currentPage: "identify-device"
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "prove-identity-another-type-photo-id"
+        }
+
+  - method: POST
+    path: /journey/appTriageAndroid
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id: "testIdentifyDeviceAndroid"
+    queryParams:
+      currentPage: "page-ipv-identity-document-start"
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "identify-device"
+        }
+
+  - method: POST
+    path: /journey/appTriageAndroid
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id: "testIdentifyDeviceAndroid"
+    queryParams:
+      currentPage: "identify-device"
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "prove-identity-another-type-photo-id"
+        }

--- a/browser-tests/readme.md
+++ b/browser-tests/readme.md
@@ -17,17 +17,17 @@ Each test can have its own journey configured in `imposter/config/api-config.yam
 ### Running Playwright tests in IntelliJ
 - Install the IntelliJ Test Automation plugin
 - Build the docker containers `docker compose build`
-- Run the imposter and core-front containers `docker compose up browser-tests-core-front`
+- Run the imposter and core-front containers `docker compose up browser-tests-core-back-imposter browser-tests-core-front`
 - Optionally disable headless mode in `playwright.config.js` so you can see what happening
 - Set up environment variables as in the `browser-tests-tests` container setup
 - Click on the arrow next to the test in IntelliJ
 
 ### Debugging core front during tests
 - Build the docker containers `docker compose build`
-- Run the imposter and core-front containers in one terminal `docker compose up browser-tests-core-front`
+- Run the imposter and core-front containers in one terminal `docker compose up browser-tests-core-back-imposter browser-tests-core-front`
 - Set up environment variables as in the `browser-tests-tests` container setup
 - Attach IntelliJ to core front on localhost port 5101
-- Run the tests in another terminal `docker compose up browser-tests-tests`
+- Run the tests in Playwright's UI from another terminal `WEBSITE_HOST="http://localhost:4601" npx playwright test --ui`
 
 ## Snapshot tests
 These tests just call the dev template display URL with different languages and contexts and compare screenshots of the

--- a/src/app/ipv/middleware.js
+++ b/src/app/ipv/middleware.js
@@ -42,7 +42,10 @@ const {
 } = require("../../lib/paths");
 const PAGES = require("../../constants/ipv-pages");
 const { parseContextAsPhoneType } = require("../shared/contextHelper");
-const { sniffPhoneType, detectAppTriageEvent} = require("../shared/deviceSniffingHelper");
+const {
+  sniffPhoneType,
+  detectAppTriageEvent,
+} = require("../shared/deviceSniffingHelper");
 const ERROR_PAGES = require("../../constants/error-pages");
 
 const directoryPath = path.join(__dirname, "/../../views/ipv/page");
@@ -156,8 +159,7 @@ async function handleBackendResponse(req, res, backendResponse) {
     if (backendResponse.page === PAGES.IDENTIFY_DEVICE) {
       const event = detectAppTriageEvent(req);
       return await handleJourneyResponse(req, res, event, backendResponse.page);
-    }
-    else {
+    } else {
       return res.redirect(getIpvPagePath(req.session.currentPage));
     }
   }

--- a/src/app/ipv/router.js
+++ b/src/app/ipv/router.js
@@ -6,8 +6,8 @@ const router = express.Router();
 const {
   renderAttemptRecoveryPage,
   updateJourneyState,
-  handleJourneyPage,
-  handleJourneyAction,
+  handleJourneyPageRequest,
+  handleJourneyActionRequest,
   renderFeatureSetPage,
   staticPageMiddleware,
   validateFeatureSet,
@@ -43,7 +43,7 @@ router.get(
   staticPageMiddleware(PAGE_IPV_IDENTITY_DOCUMENT_TYPES),
 );
 
-router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
+router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPageRequest);
 
 // Special case to handle determination of COI journey type based on the checkboxes selected
 router.post(
@@ -53,7 +53,7 @@ router.post(
   setRequestPageId(UPDATE_DETAILS),
   formHandleUpdateDetailsCheckBox,
   checkFormRadioButtonSelected,
-  handleJourneyAction,
+  handleJourneyActionRequest,
 );
 
 // Special case to handle determination of COI journey type based on the checkboxes selected and determine the error type
@@ -64,7 +64,7 @@ router.post(
   setRequestPageId(CONFIRM_DETAILS),
   formHandleCoiDetailsCheck,
   checkFormRadioButtonSelected,
-  handleJourneyAction,
+  handleJourneyActionRequest,
 );
 
 router.post(
@@ -72,7 +72,7 @@ router.post(
   parseForm,
   csrfProtection,
   checkFormRadioButtonSelected,
-  handleJourneyAction,
+  handleJourneyActionRequest,
 );
 
 router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -4,7 +4,7 @@ const { LOG_COMMUNICATION_TYPE_REQUEST } = require("../shared/loggerConstants");
 const coreBackService = require("../../services/coreBackService");
 const {
   checkForIpvAndOauthSessionId,
-  handleJourneyResponse,
+  processAction,
 } = require("../ipv/middleware");
 
 async function setIpvSessionId(req, res, next) {
@@ -47,7 +47,7 @@ async function setIpvSessionId(req, res, next) {
 async function handleOAuthJourneyAction(req, res, next) {
   try {
     checkForIpvAndOauthSessionId(req, res);
-    await handleJourneyResponse(req, res, "next");
+    await processAction(req, res, "next");
   } catch (error) {
     transformError(error, "error invoking handleOAuthJourneyAction");
     return next(error);

--- a/src/app/shared/deviceSniffingHelper.js
+++ b/src/app/shared/deviceSniffingHelper.js
@@ -1,27 +1,24 @@
 const UAParser = require("ua-parser-js");
 const PHONE_TYPES = require("../../constants/phone-types");
 const OS_TYPES = require("../../constants/os-types");
+const EVENTS = require("../../constants/events");
 
-function getJourneyOnSniffing(req) {
-  const parser = new UAParser(req.headers["user-agent"]);
-  let journeyEvent = req.body.journey;
+// The AppTriage event is special in that we want to send a more specialised version if we can detect the current
+// device type as being an Android phone or iPhone.
+function detectAppTriageEvent(req) {
+  const detectedPhone = sniffPhoneType(req);
 
-  if (parser.getDevice()["type"] === "mobile") {
-    journeyEvent += "Smartphone";
-    switch (parser.getOS()["name"]) {
-      case OS_TYPES.IOS:
-        journeyEvent += "Iphone";
-        break;
-      case OS_TYPES.ANDROID:
-        journeyEvent += "Android";
-        break;
-    }
+  switch (detectedPhone) {
+    case PHONE_TYPES.ANDROID:
+      return EVENTS.APP_TRIAGE_ANDROID;
+    case PHONE_TYPES.IPHONE:
+      return EVENTS.APP_TRIAGE_IPHONE;
+    default:
+      return EVENTS.APP_TRIAGE;
   }
-
-  return journeyEvent;
 }
 
-function sniffPhoneType(req, fallback) {
+function sniffPhoneType(req, fallback = null) {
   const parser = new UAParser(req.headers["user-agent"]);
 
   switch (parser.getOS()["name"]) {
@@ -35,6 +32,6 @@ function sniffPhoneType(req, fallback) {
 }
 
 module.exports = {
-  getJourneyOnSniffing,
+  detectAppTriageEvent,
   sniffPhoneType,
 };

--- a/src/app/shared/deviceSniffingHelper.test.js
+++ b/src/app/shared/deviceSniffingHelper.test.js
@@ -1,14 +1,16 @@
 const { expect } = require("chai");
 const PHONE_TYPES = require("../../constants/phone-types");
 const {
-  getJourneyOnSniffing,
+  detectAppTriageEvent,
   sniffPhoneType,
 } = require("./deviceSniffingHelper");
+const EVENTS = require("../../constants/events");
+const TEST_CONSTANTS = require("../../../test/constants");
 
 describe("User Agent Functions", () => {
   let req;
 
-  describe("getJourneyOnSniffing", () => {
+  describe("detectAppTriageEvent", () => {
     beforeEach(() => {
       req = {
         body: {
@@ -17,34 +19,34 @@ describe("User Agent Functions", () => {
       };
     });
 
-    it("should append 'Smartphone' to journey for mobile devices", () => {
+    it("should return APP_TRIAGE for unrecognised devices", () => {
       req.headers = {
-        // Windows Phone
         "user-agent":
-          "Mozilla/5.0 (Windows Phone 10.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0) like Gecko",
+          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
       };
-      const journeyEvent = getJourneyOnSniffing(req);
-      expect(journeyEvent).to.equal("appTriageSmartphone");
+      const journeyEvent = detectAppTriageEvent(req);
+      expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE);
     });
 
-    it("should append 'Iphone' for iOS devices", () => {
+    it("should return APP_TRIAGE_IPHONE for iOS devices", () => {
       req.headers = {
         "user-agent":
-          "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
       };
-      const journeyEvent = getJourneyOnSniffing(req);
-      expect(journeyEvent).to.equal("appTriageSmartphoneIphone");
+      const journeyEvent = detectAppTriageEvent(req);
+      expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE_IPHONE);
     });
 
-    it("should append 'Android' for Android devices", () => {
+    it("should return APP_TRIAGE_ANDROID for Android devices", () => {
       req.headers = {
         "user-agent":
-          "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
       };
-      const journeyEvent = getJourneyOnSniffing(req);
-      expect(journeyEvent).to.equal("appTriageSmartphoneAndroid");
+      const journeyEvent = detectAppTriageEvent(req);
+      expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE_ANDROID);
     });
   });
+
 
   describe("sniffPhoneType", () => {
     beforeEach(() => {
@@ -54,7 +56,7 @@ describe("User Agent Functions", () => {
     it("should return IPHONE for iOS user agents", () => {
       req.headers = {
         "user-agent":
-          "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.IPHONE);
@@ -63,16 +65,16 @@ describe("User Agent Functions", () => {
     it("should return ANDROID for Android user agents", () => {
       req.headers = {
         "user-agent":
-          "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.ANDROID);
     });
 
-    it("should return specifiedPhoneType when OS is not iOS or Android", () => {
+    it("should return fallback when OS is not iOS or Android", () => {
       req.headers = {
         "user-agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal("fallback");

--- a/src/app/shared/deviceSniffingHelper.test.js
+++ b/src/app/shared/deviceSniffingHelper.test.js
@@ -21,8 +21,7 @@ describe("User Agent Functions", () => {
 
     it("should return APP_TRIAGE for unrecognised devices", () => {
       req.headers = {
-        "user-agent":
-          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
       };
       const journeyEvent = detectAppTriageEvent(req);
       expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE);
@@ -30,8 +29,7 @@ describe("User Agent Functions", () => {
 
     it("should return APP_TRIAGE_IPHONE for iOS devices", () => {
       req.headers = {
-        "user-agent":
-          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
       };
       const journeyEvent = detectAppTriageEvent(req);
       expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE_IPHONE);
@@ -39,14 +37,12 @@ describe("User Agent Functions", () => {
 
     it("should return APP_TRIAGE_ANDROID for Android devices", () => {
       req.headers = {
-        "user-agent":
-          TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
       };
       const journeyEvent = detectAppTriageEvent(req);
       expect(journeyEvent).to.equal(EVENTS.APP_TRIAGE_ANDROID);
     });
   });
-
 
   describe("sniffPhoneType", () => {
     beforeEach(() => {
@@ -55,8 +51,7 @@ describe("User Agent Functions", () => {
 
     it("should return IPHONE for iOS user agents", () => {
       req.headers = {
-        "user-agent":
-        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_IPHONE,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.IPHONE);
@@ -64,8 +59,7 @@ describe("User Agent Functions", () => {
 
     it("should return ANDROID for Android user agents", () => {
       req.headers = {
-        "user-agent":
-        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_ANDROID,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal(PHONE_TYPES.ANDROID);
@@ -73,8 +67,7 @@ describe("User Agent Functions", () => {
 
     it("should return fallback when OS is not iOS or Android", () => {
       req.headers = {
-        "user-agent":
-        TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
+        "user-agent": TEST_CONSTANTS.HTTP_HEADER_USER_AGENT_NO_PHONE,
       };
       const result = sniffPhoneType(req, "fallback");
       expect(result).to.equal("fallback");

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze({
+  APP_TRIAGE: "appTriage",
+  APP_TRIAGE_ANDROID: "appTriageAndroid",
+  APP_TRIAGE_IPHONE: "appTriageIphone",
+});

--- a/src/constants/ipv-pages.js
+++ b/src/constants/ipv-pages.js
@@ -1,5 +1,6 @@
 module.exports = Object.freeze({
   CONFIRM_DETAILS: "confirm-your-details",
+  IDENTIFY_DEVICE: "identify-device",
   NO_PHOTO_ID_EXIT_FIND_ANOTHER_WAY: "no-photo-id-exit-find-another-way",
   NO_PHOTO_ID_SECURITY_QUESTIONS_FIND_ANOTHER_WAY:
     "no-photo-id-security-questions-find-another-way",

--- a/src/views/README.md
+++ b/src/views/README.md
@@ -139,7 +139,7 @@ Breaking this example down:
 
 2. GET requests at `/page/:pageId` will be automatically handled with:
    ```javascript
-   router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPage);
+   router.get(getPagePath(":pageId"), csrfProtection, handleJourneyPageRequest);
    ```
 3. POST requests, with:
     ```javascript
@@ -148,7 +148,7 @@ Breaking this example down:
         parseForm,
         csrfProtection,
         formRadioButtonChecked,
-        handleJourneyAction,
+        handleJourneyActionRequest,
     );
     ```
 

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,5 +1,8 @@
 module.exports = Object.freeze({
-  HTTP_HEADER_USER_AGENT_NO_PHONE: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
-  HTTP_HEADER_USER_AGENT_ANDROID: "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
-  HTTP_HEADER_USER_AGENT_IPHONE: "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+  HTTP_HEADER_USER_AGENT_NO_PHONE:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+  HTTP_HEADER_USER_AGENT_ANDROID:
+    "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+  HTTP_HEADER_USER_AGENT_IPHONE:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
 });

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze({
+  HTTP_HEADER_USER_AGENT_NO_PHONE: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+  HTTP_HEADER_USER_AGENT_ANDROID: "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+  HTTP_HEADER_USER_AGENT_IPHONE: "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1",
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adding ability to handle `identify-device` page response from core-back

### Why did it change

We will need this feature to deal with CoI journeys when using the strategic app.

Overall these changes will need to be released in 4 sections, starting with this one, then alternating core back and front.
I've run the end to end tests with this and the current head of core-back to check that it doesn't break anything.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6736](https://govukverify.atlassian.net/browse/PYIC-6736)


[PYIC-6736]: https://govukverify.atlassian.net/browse/PYIC-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ