### PR TITLE
PYIC-7552: enable outage banner for production

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -187,7 +187,7 @@ Mappings:
       nodeOldSpaceLimit: "1792"
       nodeEnv: "production"
       languageToggle: true
-      outageBanner: false
+      outageBanner: true
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf04188tda/fa56a4b3a9bbea0_complete.js"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- enable display outage banner for production

### What changed

- Enabled outageBanner flag for production


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7552](https://govukverify.atlassian.net/browse/PYIC-7552)


[PYIC-7552]: https://govukverify.atlassian.net/browse/PYIC-7552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ