### PR TITLE
PYIC-7496: reuse and coi journey browser tests

### DIFF
--- a/browser-tests/functional-tests/core-back-errors.spec.js
+++ b/browser-tests/functional-tests/core-back-errors.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require("@playwright/test");
+const { getAuthoriseUrlForJourney } = require("./helpers");
+
+test.describe("Error tests", () => {
+  test("Handles an unexpected error from core-back", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testError"));
+
+    // Go to the error
+    await page.goto("/ipv/journey/page-ipv-identity-document-start/error")
+
+    // When we come back with an error
+    const textLocator = await page.getByText("Sorry, there is a problem");
+    await expect(textLocator).toBeVisible();
+  });
+
+  test("Handles an unexpected error after a CRI callback", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testCriError"));
+
+    // Go to the DCMAW CRI
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
+
+    // When we come back from DCMAW with an error
+    const textLocator = await page.getByText("Sorry, there is a problem");
+    await expect(textLocator).toBeVisible();
+  });
+});

--- a/browser-tests/functional-tests/core-back-errors.spec.js
+++ b/browser-tests/functional-tests/core-back-errors.spec.js
@@ -4,10 +4,11 @@ const { getAuthoriseUrlForJourney } = require("./helpers");
 test.describe("Error tests", () => {
   test("Handles an unexpected error from core-back", async ({ page }) => {
     // Start a session
-    await page.goto(getAuthoriseUrlForJourney("testError"));
+    await page.goto(getAuthoriseUrlForJourney("testUnexpectedError"));
 
-    // Go to the error
-    await page.goto("/ipv/journey/page-ipv-identity-document-start/error")
+    // Go to the DCMAW CRI
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
 
     // When we come back with an error
     const textLocator = await page.getByText("Sorry, there is a problem");

--- a/browser-tests/functional-tests/device.spec.file.js
+++ b/browser-tests/functional-tests/device.spec.file.js
@@ -1,0 +1,45 @@
+const { test, expect } = require("@playwright/test");
+const { getAuthoriseUrlForJourney } = require("./helpers")
+
+const HTTP_HEADER_USER_AGENT_ANDROID =
+  "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36";
+const HTTP_HEADER_USER_AGENT_IPHONE =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1";
+
+const domainUrl = process.env.WEBSITE_HOST;
+
+test.describe("iPhone tests", () => {
+  test.use({ userAgent: HTTP_HEADER_USER_AGENT_IPHONE });
+
+  test("Handling identify-device", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testIdentifyDeviceIphone"));
+
+    // Have core-back return an identify-device page response
+    // Core front should convert that page to an appTriageIphone event which core back will then respond to with
+    // a prove-identity-another-type-photo-id page response
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
+
+    const url = page.url();
+    expect(url).toBe(`${domainUrl}/ipv/page/prove-identity-another-type-photo-id`);
+  });
+});
+
+test.describe("Android tests", () => {
+  test.use({ userAgent: HTTP_HEADER_USER_AGENT_ANDROID });
+
+  test("Handling identify-device", async ({ page }) => {
+    // Start a session
+    await page.goto(getAuthoriseUrlForJourney("testIdentifyDeviceAndroid"));
+
+    // Have core-back return an identify-device page response
+    // Core front should convert that page to an appTriageIphone event which core back will then respond to with
+    // a prove-identity-another-type-photo-id page response
+    await page.click("input[type='radio'][value='appTriage']");
+    await page.click("button[id='submitButton']");
+
+    const url = page.url();
+    expect(url).toBe(`${domainUrl}/ipv/page/prove-identity-another-type-photo-id`);
+  });
+});

--- a/browser-tests/functional-tests/functional.spec.js
+++ b/browser-tests/functional-tests/functional.spec.js
@@ -134,6 +134,22 @@ test.describe.parallel("Functional tests", () => {
     const errorTextLocator = await page.getByRole('link', { name: "Select which details you need to update" });
     await expect(errorTextLocator).toBeVisible();
   })
+
+  test("The selected form options on an update details screen sends the appropriate journey", async ({page}) => {
+    // Start session with existing identity
+    await page.goto(getAuthoriseUrlForJourney("reuseJourneyKennethDecerqueira"))
+
+    await page.getByRole('heading', {name: "If your details are wrong"}).click();
+    await page.getByRole('link', {name: "update your details"}).click();
+
+    await page.click("input[value='givenNames']");
+    await page.click("input[value='address']");
+    await page.click("button[id='submitButton']");
+
+    // Check the appropriate endpoint is called and correct page is redirected to according to mock
+    const url = page.url();
+    expect(url).toBe(`${domainUrl}/ipv/page/page-update-name`);
+  })
 });
 
 test.describe("iPhone tests", () => {

--- a/browser-tests/functional-tests/helpers.js
+++ b/browser-tests/functional-tests/helpers.js
@@ -1,0 +1,7 @@
+module.exports = {
+  // Put the journey into the 'state' parameter of the request so that imposter sends it back as the IpvSessionId
+  // See the readme and/or `imposter/config/api-config.yaml` for more information
+  getAuthoriseUrlForJourney: (journey) => {
+    return "/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fexample.com&state=" + journey + "&scope=openid+phone+email4&request=FAKE_JAR&client_id=orchestrator";
+  }
+}

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -33,10 +33,15 @@ resources:
           "ipvSessionId": "${stores.request.testJourney}"
         }
 
+  # This is the first endpoint hit after /session/initialise. For new identity journeys,
+  # this should take us to the page-ipv-identity-document-start screen.
   - method: POST
     path: /journey/next
     requestHeaders:
       content-type: "application/json"
+      ipv-session-id:
+        value: "^.*(reuseJourney|fraudCheckJourney).*$"
+        operator: NotMatches
     queryParams:
       currentPage:
         operator: NotExists
@@ -212,4 +217,92 @@ resources:
       content: |
         {
           "page": "prove-identity-another-type-photo-id"
+        }
+
+  # Journeys where there is an existing identity
+  # After initialising the session, the first endpoint hit is /journey/next which we stub here
+  # to return page-ipv-reuse to mimic the reuse journey
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "reuseJourney"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "page-ipv-reuse"
+        }
+
+  # After initialising the session, the first endpoint hit is /journey/next which we stub here
+  # to return the confirm-your-details page to mimic the repeat fraud check journey
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "fraudCheckJourney"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "confirm-your-details"
+        }
+
+  - method: GET
+    path: /user/proven-identity-details
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "KennethDecerqueira"
+        operator: Contains
+    response:
+      statusCode: 200
+      content: |
+        {
+          "name": "Kenneth Decerqueira",
+          "dateOfBirth": "1965-07-08",
+          "nameParts": [
+            { "type": "GivenName", "value": "Kenneth"},
+            { "type": "FamilyName", "value": "Decerqueira"}
+          ],
+          "addresses": [
+            {
+              "addressCountry": "GB",
+              "uprn": 100120012077,
+              "buildingName": "",
+              "streetName": "HADLEY ROAD",
+              "postalCode": "BA2 5AA",
+              "buildingNumber": "8",
+              "addressLocality": "BATH",
+              "validFrom": "1000-01-01",
+              "subBuildingName": ""
+            }
+          ]
+        }
+
+
+  - method: POST
+    path: /journey/update-details
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "reuseJourney"
+        operator: Contains
+    queryParams:
+      currentPage: 'page-ipv-reuse'
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "update-details"
         }

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -137,6 +137,18 @@ resources:
           "error": "something-went-wrong"
         }
 
+  # Journey that generates an error
+  - method: POST
+    path: /journey/error
+    requestHeaders:
+      content-type: "application/json"
+    response:
+      statusCode: 500
+      content: |
+        {
+          "error": "something-went-wrong"
+        }
+
   # Journey for CRI test
   # When the user selects the DCMAW option core back sends back the CRI URL to redirect the user to. The CRI then
   # eventually sends the user back to core-front. Here we short circuit that and redirect the user straight to core

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -290,7 +290,6 @@ resources:
           ]
         }
 
-
   - method: POST
     path: /journey/update-details
     requestHeaders:
@@ -305,4 +304,21 @@ resources:
       content: |
         {
           "page": "update-details"
+        }
+
+  # Hit when core-front sends a journey request to core-back from an update details screen
+  - method: POST
+    path: /journey/given-names-and-address
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "reuseJourney"
+        operator: Contains
+    queryParams:
+      currentPage: 'update-details'
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "page-update-name"
         }

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -52,6 +52,44 @@ resources:
           "page": "page-ipv-identity-document-start"
         }
 
+  # After initialising the session, the first endpoint hit is /journey/next which we stub here
+  # to return page-ipv-reuse to mimic the reuse journey
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "reuseJourney"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "page-ipv-reuse"
+        }
+
+  # After initialising the session, the first endpoint hit is /journey/next which we stub here
+  # to return the confirm-your-details page to mimic the repeat fraud check journey
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "fraudCheckJourney"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "confirm-your-details"
+        }
+
   # Journey for page navigation test
   - method: POST
     path: /journey/end
@@ -82,6 +120,21 @@ resources:
         {
           "page": "prove-identity-another-type-photo-id",
           "context": "passport"
+        }
+
+  # Journey for unexpected error from core-back
+  - method: POST
+    path: /journey/appTriage
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id: "testUnexpectedError"
+    queryParams:
+      currentPage: "page-ipv-identity-document-start"
+    response:
+      statusCode: 500
+      content: |
+        {
+          "error": "something-went-wrong"
         }
 
   # Journey for CRI test
@@ -127,18 +180,6 @@ resources:
       content: |
         {
           "page": "page-multiple-doc-check"
-        }
-
-  # Journey that generates an error
-  - method: POST
-    path: /journey/error
-    requestHeaders:
-      content-type: "application/json"
-    response:
-      statusCode: 500
-      content: |
-        {
-          "error": "something-went-wrong"
         }
 
   # CRI callback that redirects to an error
@@ -219,45 +260,8 @@ resources:
           "page": "prove-identity-another-type-photo-id"
         }
 
-  # Journeys where there is an existing identity
-  # After initialising the session, the first endpoint hit is /journey/next which we stub here
-  # to return page-ipv-reuse to mimic the reuse journey
-  - method: POST
-    path: /journey/next
-    requestHeaders:
-      content-type: "application/json"
-      ipv-session-id:
-        value: "reuseJourney"
-        operator: Contains
-    queryParams:
-      currentPage:
-        operator: NotExists
-    response:
-      statusCode: 200
-      content: |
-        {
-          "page": "page-ipv-reuse"
-        }
-
-  # After initialising the session, the first endpoint hit is /journey/next which we stub here
-  # to return the confirm-your-details page to mimic the repeat fraud check journey
-  - method: POST
-    path: /journey/next
-    requestHeaders:
-      content-type: "application/json"
-      ipv-session-id:
-        value: "fraudCheckJourney"
-        operator: Contains
-    queryParams:
-      currentPage:
-        operator: NotExists
-    response:
-      statusCode: 200
-      content: |
-        {
-          "page": "confirm-your-details"
-        }
-
+  # On a page displaying the user's details (e.g. confirm-your-details page), core-front sends a request to the
+  # /user/proven-identity-details endpoint in core-back to get the user's details to be displayed on the page
   - method: GET
     path: /user/proven-identity-details
     requestHeaders:
@@ -290,6 +294,9 @@ resources:
           ]
         }
 
+  # This is hit when the user is on the page-ipv-reuse screen and, after expanding the "If your details are wrong" section,
+  # they click on the "update your details" link which sends a /journey/update-details event to core-back. This then redirects
+  # them to the update-details screen
   - method: POST
     path: /journey/update-details
     requestHeaders:
@@ -306,7 +313,8 @@ resources:
           "page": "update-details"
         }
 
-  # Hit when core-front sends a journey request to core-back from an update details screen
+  # Hit when core-front sends a journey request to core-back from an update details screen and the
+  # selected options to update are givenNames and address
   - method: POST
     path: /journey/given-names-and-address
     requestHeaders:

--- a/browser-tests/imposter/config/core-back-api.yaml
+++ b/browser-tests/imposter/config/core-back-api.yaml
@@ -19,7 +19,7 @@ paths:
 
   /user-identity:
     get:
-      description: "Returns a list of Verifiable Credentials representig the users identity"
+      description: "Returns a list of Verifiable Credentials representing the users identity"
       responses:
         200:
           description: "The list of Verifiable Credentials"


### PR DESCRIPTION
…tity-details as well as the update details screens

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Adds browser tests for reuse and coi journeys.
- Stubs call to `/user/proven-identity-details` endpoint

Note: snapshot tests already covered the display of the `confirm-details`, `update-details` and `page-ipv-reuse` screens so didn't add any. However, the error handling I've added as functional tests.

### Why did it change
Increase coverage of browser tests to cover the `/user/proven-identity-details` endpoint

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7496](https://govukverify.atlassian.net/browse/PYIC-7496)


[PYIC-7496]: https://govukverify.atlassian.net/browse/PYIC-7496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ