### PR TITLE
PYIC-7573 Update redaction method to cope with relative URLs

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -44,6 +44,7 @@ import TechnicalError from "../../errors/technical-error";
 import BadRequestError from "../../errors/bad-request-error";
 import NotFoundError from "../../errors/not-found-error";
 import UnauthorizedError from "../../errors/unauthorized-error";
+import { HANDLED_ERROR } from "../../lib/logger";
 
 const directoryPath = path.resolve("views/ipv/page");
 
@@ -361,6 +362,8 @@ export const handleJourneyPageRequest = async (
       validatePhoneType(context);
       renderOptions.appDownloadUrl = getAppStoreRedirectUrl(context);
     } else if (req.session.currentPageStatusCode !== undefined) {
+      // Set this to avoid pino-http generating a new error in the request log
+      res.err = HANDLED_ERROR;
       res.status(req.session.currentPageStatusCode);
     }
 

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -5,10 +5,7 @@ import { getIpvPageTemplatePath, getErrorPageTemplatePath } from "../lib/paths";
 import ERROR_PAGES from "../constants/error-pages";
 import { ErrorRequestHandler } from "express";
 import HttpError from "../errors/http-error";
-
-export const HANDLED_ERROR = new Error(
-  "Placeholder error for events logged in error handler",
-);
+import { HANDLED_ERROR } from "../lib/logger";
 
 const getErrorStatus = (err: unknown): number => {
   if (isAxiosError(err)) {

--- a/src/handlers/journey-event-error-handler.ts
+++ b/src/handlers/journey-event-error-handler.ts
@@ -4,6 +4,7 @@ import sanitize from "sanitize-filename";
 import { HTTP_STATUS_CODES } from "../app.constants";
 import { getIpvPageTemplatePath } from "../lib/paths";
 import { isPageResponse } from "../app/validators/postJourneyEventResponse";
+import { HANDLED_ERROR } from "../lib/logger";
 
 const journeyEventErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
   if (res.headersSent) {
@@ -23,6 +24,9 @@ const journeyEventErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     } else {
       res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
     }
+
+    // Set this to avoid pino-http generating a new error in the request log
+    res.err = HANDLED_ERROR;
 
     return res.render(getIpvPageTemplatePath(pageId), {
       pageId: pageId,

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -24,6 +24,10 @@ describe("redactQueryParams", () => {
       output:
         "http://example.com/authorize?code=hidden&safe=value&request=hidden",
     },
+    {
+      input: "/authorize?code=secret_code&safe=value&request=long_request",
+      output: "/authorize?code=hidden&safe=value&request=hidden",
+    },
   ].forEach(({ input, output }) => {
     it(`should correctly map ${input}`, () => {
       const actual = redactQueryParams(input);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,22 +1,26 @@
 import { Request, RequestHandler, Response } from "express";
 import pino, { Logger } from "pino";
 import pinoHttp from "pino-http";
-import { HANDLED_ERROR } from "../handlers/internal-server-error-handler";
 
-const sensitiveParams = ["request", "code"];
+export const HANDLED_ERROR = new Error(
+  "Placeholder errors that do not require additional logging",
+);
+
+const SENSITIVE_PARAMS = ["request", "code"];
+const BASE_PLACEHOLDER = "http://placeholder-for-redaction";
 
 export const redactQueryParams = (
   url: string | undefined,
 ): string | undefined => {
   if (url && url.includes("?")) {
     try {
-      const parsedUrl = new URL(url);
-      for (const param of sensitiveParams) {
+      const parsedUrl = new URL(url, BASE_PLACEHOLDER);
+      for (const param of SENSITIVE_PARAMS) {
         if (parsedUrl.searchParams.has(param)) {
           parsedUrl.searchParams.set(param, "hidden");
         }
       }
-      return parsedUrl.href;
+      return parsedUrl.href.replace(BASE_PLACEHOLDER, "");
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err) {
       // ignore


### PR DESCRIPTION
## Proposed changes

### What changed

- Update URL redaction to work on relative URLs
- Update other error scenarios to skip pino-http error generation

### Why did it change

- The URL redaction logic didn't work on relative URLs
- pino-http will generate a spurious error (and stack trace) for any responses with status >=500

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7573](https://govukverify.atlassian.net/browse/PYIC-7573)


[PYIC-7573]: https://govukverify.atlassian.net/browse/PYIC-7573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ