### PR TITLE
PYIC-7614: move healthcheck endpoint further up app.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -86,6 +86,13 @@ app.use(
   express.static(path.resolve("node_modules/govuk-frontend/govuk/assets")),
 );
 
+const healthcheckRouter = express.Router();
+healthcheckRouter.get("/", (req, res) => {
+  logger.info('Healthcheck returning 200 OK.');
+  res.status(200).send("OK");
+})
+app.use("/healthcheck", healthcheckRouter);
+
 app.use(setLocals);
 app.use(cspHandler);
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
@@ -189,10 +196,6 @@ router.use("/ipv", ipvRouter);
 if (config.ENABLE_PREVIEW) {
   router.use("/dev", devRouter);
 }
-
-router.get("/healthcheck", (req, res) => {
-  res.status(200).send("OK");
-});
 
 app.use(router);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,12 +86,10 @@ app.use(
   express.static(path.resolve("node_modules/govuk-frontend/govuk/assets")),
 );
 
-const healthcheckRouter = express.Router();
-healthcheckRouter.get("/", (req, res) => {
+app.get("/healthcheck", (req, res) => {
   logger.info("Healthcheck returning 200 OK.");
   res.status(200).send("OK");
 });
-app.use("/healthcheck", healthcheckRouter);
 
 app.use(setLocals);
 app.use(cspHandler);

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,9 +88,9 @@ app.use(
 
 const healthcheckRouter = express.Router();
 healthcheckRouter.get("/", (req, res) => {
-  logger.info('Healthcheck returning 200 OK.');
+  logger.info("Healthcheck returning 200 OK.");
   res.status(200).send("OK");
-})
+});
 app.use("/healthcheck", healthcheckRouter);
 
 app.use(setLocals);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Moved `healthcheck` endpoint further up app.ts file

### Why did it change
Moving it further up the file prevents running unnecessary code when hitting the healthcheck endpoint

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7614](https://govukverify.atlassian.net/browse/PYIC-7614)


[PYIC-7614]: https://govukverify.atlassian.net/browse/PYIC-7614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ