### PR TITLE
PYIC-7612: configure healthcheck for ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 ENV PORT 8080
+
+HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
+  CMD curl -f http://localhost:8080/healthcheck || exit 1
+
 EXPOSE 8080
 
 ENTRYPOINT ["tini", "--"]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -857,7 +857,7 @@ Resources:
           HealthCheck:
             Command:
               - "CMD-SHELL"
-              - "curl -f <http://localhost:8080/healthcheck> || exit 1"
+              - "curl -f http://localhost:8080/healthcheck || exit 1"
             Interval: 5
             Retries: 10
             Timeout: 2

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -854,6 +854,13 @@ Resources:
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
+          HealthCheck:
+            Command:
+              - "CMD-SHELL"
+              - "curl -f <http://localhost:8080/healthcheck> || exit 1"
+            Interval: 5
+            Retries: 10
+            Timeout: 2
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,7 +87,7 @@ app.use(
 );
 
 app.get("/healthcheck", (req, res) => {
-  logger.info("Healthcheck returning 200 OK.");
+  logger.debug("Healthcheck returning 200 OK.");
   res.status(200).send("OK");
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Configured a healthcheck in TaskDefinition for ECS
Adds a healthcheck to the DockerFile with matching config

| logs in /aws/ecs/core-front-theab-CoreFront-ECS | <img width="438" alt="Screenshot 2024-11-12 at 11 21 44" src="https://github.com/user-attachments/assets/a81cf1da-854b-4bab-ad52-8e5021185f08"> |
|-|-|

### Why did it change
FE scaling doesn't work unless healthchecks are properly configured

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7612](https://govukverify.atlassian.net/browse/PYIC-7612)


[PYIC-7612]: https://govukverify.atlassian.net/browse/PYIC-7612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ