### PR TITLE
BAU Remove unused variant of NPID exit page

### DIFF
--- a/views/ipv/page/no-photo-id-exit-find-another-way.njk
+++ b/views/ipv/page/no-photo-id-exit-find-another-way.njk
@@ -50,11 +50,6 @@
         }
       ] %}
 
-    {# TODO 7211: Remove the abandon context once core-back has been updated #}
-    {% if context === "abandon" %}
-      {% set radioOptions = radioOptions.slice(0, -2) %}
-    {% endif %}
-
     {% set radiosConfig = {
           idPrefix: "journey",
           name: "journey",


### PR DESCRIPTION
## Proposed changes

### What changed

Remove unused 'abandon' variant of no-photo-id exit page

### Why did it change

The old 'abandon' variant of this template is no longer used, it was replaced by no-photo-id-abandon-find-another-way when UCD agreed we could use this for both low and medium conf NPID CRI dropout

