### PR TITLE
PYIC-6245: Use clientOAuthSessionId returned from core-back.

### DIFF
--- a/src/app/mobile-app/middleware.test.ts
+++ b/src/app/mobile-app/middleware.test.ts
@@ -81,6 +81,7 @@ describe("mobile app middleware", () => {
 
     it("should add clientOAuthSessionId to the session if core-back provides a value", async () => {
       // Arrange
+      req.session.ipvSessionId = undefined;
       axiosResponse.status = 200;
       axiosResponse.data = {
         journey: "journey/next",

--- a/src/app/mobile-app/middleware.ts
+++ b/src/app/mobile-app/middleware.ts
@@ -19,6 +19,7 @@ export const checkMobileAppDetails: RequestHandler = async (req, res) => {
 
   // If we don't have a clientOAuthSessionId in our session then we're dealing with a cross browser callback and core back will give us a clientOAuthSessionId to use instead.
   if (
+    !req.session.ipvSessionId &&
     !req.session.clientOauthSessionId &&
     apiResponse.data.clientOAuthSessionId
   ) {

--- a/src/app/mobile-app/middleware.ts
+++ b/src/app/mobile-app/middleware.ts
@@ -17,5 +17,13 @@ export const checkMobileAppDetails: RequestHandler = async (req, res) => {
     res.status(apiResponse.status);
   }
 
+  // If we don't have a clientOAuthSessionId in our session then we're dealing with a cross browser callback and core back will give us a clientOAuthSessionId to use instead.
+  if (
+    !req.session.clientOauthSessionId &&
+    apiResponse.data.clientOAuthSessionId
+  ) {
+    req.session.clientOauthSessionId = apiResponse.data.clientOAuthSessionId;
+  }
+
   return handleBackendResponse(req, res, apiResponse?.data);
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handling of clientOAuthSessionId for cross-browser callbacks

### Why did it change

As part of the new strategic app routing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6245](https://govukverify.atlassian.net/browse/PYIC-6245)


[PYIC-6245]: https://govukverify.atlassian.net/browse/PYIC-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ