### PR TITLE
PYIC-7609: export dynatrace host id in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ COPY --chown=appuser:appgroup --from=builder /app/package-lock.json ./
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV DT_HOST_ID="CORE-FRONT-`openssl rand -base64 12`"
 ENV PORT 8080
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=$DT_HOST_ID && tini npm start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,4 @@ ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 ENV PORT 8080
 EXPOSE 8080
 
-ENTRYPOINT ["tini", "--"]
-
-CMD ["npm", "start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ COPY --chown=appuser:appgroup --from=builder /app/package-lock.json ./
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
+ENV DT_HOST_ID="CORE-FRONT-`openssl rand -base64 12`"
 ENV PORT 8080
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=$DT_HOST_ID && tini npm start"]

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -46,4 +46,4 @@ HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=$DT_HOST_ID && tini npm start"]

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -38,6 +38,7 @@ COPY --chown=appuser:appgroup --from=builder /app/views ./views
 COPY --chown=appuser:appgroup --from=builder /app/package.json ./
 COPY --chown=appuser:appgroup --from=builder /app/package-lock.json ./
 
+ENV DT_HOST_ID="CORE-FRONT-`openssl rand -base64 12`"
 ENV PORT=8080
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=10 \

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -45,6 +45,4 @@ HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
 
 EXPOSE 8080
 
-ENTRYPOINT ["tini", "--"]
-
-CMD ["npm", "start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -38,7 +38,6 @@ COPY --chown=appuser:appgroup --from=builder /app/views ./views
 COPY --chown=appuser:appgroup --from=builder /app/package.json ./
 COPY --chown=appuser:appgroup --from=builder /app/package-lock.json ./
 
-ENV DT_HOST_ID="CORE-FRONT-`openssl rand -base64 12`"
 ENV PORT=8080
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
@@ -46,4 +45,4 @@ HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=$DT_HOST_ID && tini npm start"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CORE-FRONT-$RANDOM && tini npm start"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The default DYNATRACE_HOST_ID in ECS is set to the same value across all containers, so we only get an aggregate view of performance in Dynatrace. To fix this, we export `DT_HOST_ID` with a unique value

### Why did it change
exports unique dynatrace host id in dockerfile

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7609](https://govukverify.atlassian.net/browse/PYIC-7609)


[PYIC-7609]: https://govukverify.atlassian.net/browse/PYIC-7609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ