### PR TITLE
PYIC-7869: Spike - render service-unavailable page on 503

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -76,10 +76,10 @@ const protectConfig: ProtectionConfig = {
   production: process.env.NODE_ENV === "production",
   clientRetrySecs: 1,
   sampleInterval: 5,
-  maxEventLoopDelay: 400,
+  maxEventLoopDelay: 1,
   maxHeapUsedBytes: 0,
   maxRssBytes: 0,
-  errorPropagationMode: false,
+  errorPropagationMode: true,
   logging: "error",
 };
 const overloadProtection = protect("express", protectConfig);

--- a/src/constants/error-pages.ts
+++ b/src/constants/error-pages.ts
@@ -1,6 +1,7 @@
 const ERROR_PAGES = Object.freeze({
   PAGE_NOT_FOUND: "page-not-found",
   SESSION_ENDED: "session-ended",
+  SERVICE_UNAVAILABLE: "service-unavailable",
 });
 
 export default ERROR_PAGES;

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -3,7 +3,7 @@ import { isAxiosError } from "axios";
 import { ErrorRequestHandler } from "express";
 import { isHttpError } from "http-errors";
 import PAGES from "../constants/ipv-pages";
-import { getIpvPageTemplatePath, getErrorPageTemplatePath } from "../lib/paths";
+import {getIpvPageTemplatePath, getErrorPageTemplatePath, getHtmlPath} from "../lib/paths";
 import ERROR_PAGES from "../constants/error-pages";
 import HttpError from "../errors/http-error";
 import { HANDLED_ERROR } from "../lib/logger";
@@ -29,12 +29,16 @@ const serverErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     return next(err);
   }
 
+  if (res.statusCode === 503) {
+      return res.render(getHtmlPath("errors", "service-unavailable-s3", ERROR_PAGES.SERVICE_UNAVAILABLE))
+  }
+
   const status = getErrorStatus(err);
 
   req.log?.error({
     message: {
       description: err?.constructor?.name ?? "Unknown error",
-      errorMessage: err?.message ?? "Unkown error",
+      errorMessage: err?.message ?? "Unknown error",
       errorStack: err?.stack,
     },
   });

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -16,3 +16,8 @@ export function getTemplatePath(...pathComponents: string[]): string {
   const pageId = pathComponents.splice(-1, 1);
   return path.join(...pathComponents, `${pageId}.njk`);
 }
+
+export function getHtmlPath(...pathComponents: string[]): string {
+    const pageId = pathComponents.splice(-1, 1);
+    return path.join(...pathComponents, `${pageId}.html`);
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Spike - render service-unavailable page on 503

### Why did it change

The overload protection lib doesn't seem to be configurable to specify a template or html page to return when it kicks in. We can however set it to hand control back to the framework and handle a 503 ourselves.

The downside of this is that it will require the app to do work when it's already overloaded.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7869](https://govukverify.atlassian.net/browse/PYIC-7869)


[PYIC-7869]: https://govukverify.atlassian.net/browse/PYIC-7869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ