### PR TITLE
BAU: Fix overload-protection logging

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -80,7 +80,9 @@ const protectConfig: ProtectionConfig = {
   maxHeapUsedBytes: 0,
   maxRssBytes: 0,
   errorPropagationMode: false,
-  logging: "error",
+  logging: (msg) => {
+    logger.error(msg);
+  },
 };
 const overloadProtection = protect("express", protectConfig);
 app.use(overloadProtection);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix overload-protection logging

### Why did it change

I noticed that there we no logs being generated when overload-protection kicked in.
Specifying the logging config as a string value requires that req.log exists. We haven't assigned that yet in the middleware stack, at the point overload protection is run. So we got no logs.

We can instead set the config for logging to a function which is responsible for the logging.

![Screenshot 2024-12-19 at 15 01 34](https://github.com/user-attachments/assets/d5357599-7445-43d4-a8bc-87595d1f80d1)
