### PR TITLE
BAU Stop logging proven-identity-details PII

### DIFF
--- a/src/app/shared/axiosHelper.test.ts
+++ b/src/app/shared/axiosHelper.test.ts
@@ -46,71 +46,6 @@ describe("axiosHelper", () => {
         message: {
           description: "API request completed",
           endpoint: "GET /test-path",
-          data: {
-            page: "testPage",
-          },
-          cri: "testCri",
-          duration: 200,
-        },
-      });
-    });
-
-    it("should not log cri redirect details", async () => {
-      // Arrange
-      const response = {
-        ...testResponse,
-        data: {
-          cri: {
-            id: "testCri",
-            redirectUrl: "https://example.com/authorize?request=long_request",
-          },
-        },
-      };
-
-      // Act
-      await axiosResponseLogger(response);
-
-      // Assert
-      expect(testLogger.info).has.been.calledWith({
-        message: {
-          description: "API request completed",
-          endpoint: "GET /test-path",
-          data: {
-            cri: {
-              id: "testCri",
-              redirectUrl: "https://example.com/authorize?request=hidden",
-            },
-          },
-          cri: "testCri",
-          duration: 200,
-        },
-      });
-    });
-
-    it("should not log client redirect details", async () => {
-      // Arrange
-      const response = {
-        ...testResponse,
-        data: {
-          client: {
-            redirectUrl: "https://example.com/callback?code=secret_code",
-          },
-        },
-      };
-
-      // Act
-      await axiosResponseLogger(response);
-
-      // Assert
-      expect(testLogger.info).has.been.calledWith({
-        message: {
-          description: "API request completed",
-          endpoint: "GET /test-path",
-          data: {
-            client: {
-              redirectUrl: "https://example.com/callback?code=hidden",
-            },
-          },
           cri: "testCri",
           duration: 200,
         },
@@ -142,7 +77,6 @@ describe("axiosHelper", () => {
         message: {
           description: "API request failed",
           endpoint: "GET /test-path",
-          data: { page: "testPage" },
           cri: "testCri",
           duration: 200,
           errorMessage: "test error",

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -4,7 +4,6 @@ import axios, {
   InternalAxiosRequestConfig,
 } from "axios";
 import https from "https";
-import { redactQueryParams } from "../../lib/logger";
 
 // Extend axios definition with logger
 declare module "axios" {
@@ -35,39 +34,12 @@ const extractCredentialIssuerId = (
   return undefined;
 };
 
-// Client/CRI redirect URLs may contain sensitive data, and we shouldn't log them
-const sanitiseResponseData = (response: AxiosResponse): object | undefined => {
-  try {
-    if (typeof response.data === "object") {
-      const body = { ...response.data };
-      if (body.cri?.redirectUrl) {
-        body.cri = {
-          ...body.cri,
-          redirectUrl: redactQueryParams(body.cri.redirectUrl),
-        };
-      }
-      if (body.client?.redirectUrl) {
-        body.client = {
-          ...body.client,
-          redirectUrl: redactQueryParams(body.client.redirectUrl),
-        };
-      }
-      return body;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
-    // Ignore
-  }
-  return undefined;
-};
-
 const buildRequestLog = (
   response: AxiosResponse,
   description: string,
 ): RequestLog => ({
   description,
   endpoint: `${response.request?.method} ${response.request?.path}`,
-  data: sanitiseResponseData(response),
   cri: extractCredentialIssuerId(response),
   duration: response.config.startTime && Date.now() - response.config.startTime,
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Stop logging response data we get from core-back requests (for now until we work out how best to obfuscate the PII)

### Why did it change

Discovered we're logging PII from the `proven-identity-details` response
