### PR TITLE
PYIC-7964: Reinstate core-front backend response logging

### DIFF
--- a/src/app/shared/axiosHelper.test.ts
+++ b/src/app/shared/axiosHelper.test.ts
@@ -2,7 +2,7 @@ import sinon from "sinon";
 import { expect } from "chai";
 import { axiosErrorLogger, axiosResponseLogger } from "./axiosHelper";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
-import API_URLS from "../../constants/api-constants";
+import API_URLS from "../../config/config";
 
 const testLogger = {
   info: sinon.fake(),

--- a/src/app/shared/axiosHelper.test.ts
+++ b/src/app/shared/axiosHelper.test.ts
@@ -116,6 +116,34 @@ describe("axiosHelper", () => {
         },
       });
     });
+
+    it("should not log anything for proven-identity-details endpoint", async () => {
+      // Arrange
+      const response = {
+        ...testResponse,
+        config: {
+          ...testResponse.config,
+          url: "/user/proven-identity-details",
+        },
+        data: {
+          name: "John Doe",
+        },
+      };
+
+      // Act
+      await axiosResponseLogger(response);
+
+      // Assert
+      expect(testLogger.info).has.been.calledWith({
+        message: {
+          description: "API request completed",
+          endpoint: "GET /test-path",
+          data: undefined,
+          cri: "testCri",
+          duration: 200,
+        },
+      });
+    });
   });
 
   describe("errorLogger", () => {
@@ -125,7 +153,6 @@ describe("axiosHelper", () => {
         ...testResponse,
         status: 500,
       };
-
       const error = new AxiosError(
         "test error",
         "ERR",
@@ -162,7 +189,6 @@ describe("axiosHelper", () => {
 
       // Act & Assert
       await expect(axiosErrorLogger(error)).to.be.rejectedWith(error);
-
       expect(testLogger.error).has.been.calledWith({
         message: {
           description: "Error occurred making request to API",
@@ -178,7 +204,6 @@ describe("axiosHelper", () => {
 
       // Act & Assert
       await expect(axiosErrorLogger(error)).to.be.rejectedWith(error);
-
       expect(testLogger.error).has.been.calledWith({
         message: {
           description: "Something went wrong setting up an API request",

--- a/src/app/shared/axiosHelper.test.ts
+++ b/src/app/shared/axiosHelper.test.ts
@@ -46,6 +46,71 @@ describe("axiosHelper", () => {
         message: {
           description: "API request completed",
           endpoint: "GET /test-path",
+          data: {
+            page: "testPage",
+          },
+          cri: "testCri",
+          duration: 200,
+        },
+      });
+    });
+
+    it("should not log cri redirect details", async () => {
+      // Arrange
+      const response = {
+        ...testResponse,
+        data: {
+          cri: {
+            id: "testCri",
+            redirectUrl: "https://example.com/authorize?request=long_request",
+          },
+        },
+      };
+
+      // Act
+      await axiosResponseLogger(response);
+
+      // Assert
+      expect(testLogger.info).has.been.calledWith({
+        message: {
+          description: "API request completed",
+          endpoint: "GET /test-path",
+          data: {
+            cri: {
+              id: "testCri",
+              redirectUrl: "https://example.com/authorize?request=hidden",
+            },
+          },
+          cri: "testCri",
+          duration: 200,
+        },
+      });
+    });
+
+    it("should not log client redirect details", async () => {
+      // Arrange
+      const response = {
+        ...testResponse,
+        data: {
+          client: {
+            redirectUrl: "https://example.com/callback?code=secret_code",
+          },
+        },
+      };
+
+      // Act
+      await axiosResponseLogger(response);
+
+      // Assert
+      expect(testLogger.info).has.been.calledWith({
+        message: {
+          description: "API request completed",
+          endpoint: "GET /test-path",
+          data: {
+            client: {
+              redirectUrl: "https://example.com/callback?code=hidden",
+            },
+          },
           cri: "testCri",
           duration: 200,
         },
@@ -77,6 +142,7 @@ describe("axiosHelper", () => {
         message: {
           description: "API request failed",
           endpoint: "GET /test-path",
+          data: { page: "testPage" },
           cri: "testCri",
           duration: 200,
           errorMessage: "test error",

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -22,7 +22,7 @@ interface RequestLog {
   duration?: number;
 }
 
-const ALLOWED_ENDPOINTS: string[] = [
+const ALLOWED_RESPONSE_DATA_LOGGING_ENDPOINTS: string[] = [
   API_URLS.API_CRI_CALLBACK,
   API_URLS.API_MOBILE_APP_CALLBACK,
   API_URLS.API_JOURNEY_EVENT,
@@ -31,8 +31,8 @@ const ALLOWED_ENDPOINTS: string[] = [
 
 // Helper function to determine if an endpoint is in the allow list
 const isEndpointAllowedForDataLogging = (url: string): boolean => {
-  return Object.values(ALLOWED_ENDPOINTS).some((allowedUrl) =>
-    url.includes(allowedUrl),
+  return Object.values(ALLOWED_RESPONSE_DATA_LOGGING_ENDPOINTS).some(
+    (allowedUrl) => url.includes(allowedUrl),
   );
 };
 

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -4,6 +4,7 @@ import axios, {
   InternalAxiosRequestConfig,
 } from "axios";
 import https from "https";
+import { redactQueryParams } from "../../lib/logger";
 
 // Extend axios definition with logger
 declare module "axios" {
@@ -34,12 +35,39 @@ const extractCredentialIssuerId = (
   return undefined;
 };
 
+// Client/CRI redirect URLs may contain sensitive data, and we shouldn't log them
+const sanitiseResponseData = (response: AxiosResponse): object | undefined => {
+  try {
+    if (typeof response.data === "object") {
+      const body = { ...response.data };
+      if (body.cri?.redirectUrl) {
+        body.cri = {
+          ...body.cri,
+          redirectUrl: redactQueryParams(body.cri.redirectUrl),
+        };
+      }
+      if (body.client?.redirectUrl) {
+        body.client = {
+          ...body.client,
+          redirectUrl: redactQueryParams(body.client.redirectUrl),
+        };
+      }
+      return body;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (err) {
+    // Ignore
+  }
+  return undefined;
+};
+
 const buildRequestLog = (
   response: AxiosResponse,
   description: string,
 ): RequestLog => ({
   description,
   endpoint: `${response.request?.method} ${response.request?.path}`,
+  data: sanitiseResponseData(response),
   cri: extractCredentialIssuerId(response),
   duration: response.config.startTime && Date.now() - response.config.startTime,
 });

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -1,4 +1,4 @@
-import API_URLS from "../../constants/api-constants";
+import API_URLS from "../../config/config";
 import axios, {
   AxiosInstance,
   AxiosResponse,
@@ -22,9 +22,18 @@ interface RequestLog {
   duration?: number;
 }
 
+const ALLOWED_ENDPOINTS: string[] = [
+  API_URLS.API_CRI_CALLBACK,
+  API_URLS.API_MOBILE_APP_CALLBACK,
+  API_URLS.API_JOURNEY_EVENT,
+  API_URLS.API_SESSION_INITIALISE,
+];
+
 // Helper function to determine if an endpoint is in the allow list
 const isEndpointAllowedForDataLogging = (url: string): boolean => {
-  return Object.values(API_URLS).some((allowedUrl) => url.includes(allowedUrl));
+  return Object.values(ALLOWED_ENDPOINTS).some((allowedUrl) =>
+    url.includes(allowedUrl),
+  );
 };
 
 // Extract credentialIssuerId for logging

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -1,8 +1,0 @@
-const API_URLS = Object.freeze({
-  API_CRI_CALLBACK: "/cri/callback",
-  API_MOBILE_APP_CALLBACK: "/app/callback",
-  API_JOURNEY_EVENT: "/journey",
-  API_SESSION_INITIALISE: "/session/initialise",
-});
-
-export default API_URLS;

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -1,0 +1,8 @@
+const API_URLS = Object.freeze({
+  API_CRI_CALLBACK: "/cri/callback",
+  API_MOBILE_APP_CALLBACK: "/app/callback",
+  API_JOURNEY_EVENT: "/journey",
+  API_SESSION_INITIALISE: "/session/initialise",
+});
+
+export default API_URLS;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reinstate core-front backend response logging
Exclude data logging for the proven-identity-details request only

### Why did it change

In core-front we were logging the response data we get back for all core-back requests. This is useful for debugging as it includes for example CRI ids, redirect URIs and page/journey responses. Unfortunately we discovered we were inadvertently logging PII (name/dob/address) for the proven-identity-details request, and the quick incident fix was just to drop the data property for all API requested completed logs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7964](https://govukverify.atlassian.net/browse/PYIC-7964)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7964]: https://govukverify.atlassian.net/browse/PYIC-7964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ