### PR TITLE
DCP-4451 FE Container TaskDefinitions should have a minimum of 2048 cpu

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -837,9 +837,9 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub core-front-${Environment}
-      Cpu: !If [ IsPerformanceSensitive, 1024, 256 ]
+      Cpu: !If [ IsPerformanceSensitive, 2048, 256 ]
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: !If [ IsPerformanceSensitive, 2048, 512 ]
+      Memory: !If [ IsPerformanceSensitive, 4096, 512 ]
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
## Proposed changes

### What changed

FE Container TaskDefinitions should have a minimum of 2048 cpu

### Why did it change

Mitigate performance issues with event loop with additional cpu

### Issue tracking
[DCP-4451](https://govukverify.atlassian.net/browse/DCP-4451)



[DCP-4451]: https://govukverify.atlassian.net/browse/DCP-4451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ