### PR TITLE
PYIC-8032: Log unexpected responses from core-back

### DIFF
--- a/src/app/credential-issuer/middleware.test.ts
+++ b/src/app/credential-issuer/middleware.test.ts
@@ -125,7 +125,7 @@ describe("credential issuer middleware", () => {
 
         // Assert
         expect(
-          ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.journey,
+          ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.data.journey,
         ).to.equal("journey/next");
       });
 

--- a/src/app/credential-issuer/middleware.ts
+++ b/src/app/credential-issuer/middleware.ts
@@ -44,7 +44,7 @@ export const sendParamsToAPI: RequestHandler = async (req, res) => {
   }
 
   const apiResponse = await postCriCallback(req, body);
-  return handleBackendResponse(req, res, apiResponse.data);
+  return handleBackendResponse(req, res, apiResponse);
 };
 
 // Temporary - this will replace the above method once all CRI's have been migrated across to use the new endpoint
@@ -72,5 +72,5 @@ export const sendParamsToAPIV2: RequestHandler = async (req, res) => {
   }
 
   const apiResponse = await postCriCallback(req, body);
-  return handleBackendResponse(req, res, apiResponse.data);
+  return handleBackendResponse(req, res, apiResponse);
 };

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -146,7 +146,7 @@ export const handleBackendResponse = async (
   }
 
   throw new TechnicalError(
-    `Unrecognised response type received from core-back: ${sanitiseResponseData(backendResponse)}`,
+    `Unrecognised response type received from core-back: ${JSON.stringify(sanitiseResponseData(backendResponse))}`,
   );
 };
 

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -87,7 +87,7 @@ export const processAction = async (
   action: string,
   currentPageId = "",
 ): Promise<void> => {
-  const backendResponse = (await journeyApi(action, req, currentPageId)).data;
+  const backendResponse = await journeyApi(action, req, currentPageId);
 
   return await handleBackendResponse(req, res, backendResponse);
 };

--- a/src/app/mobile-app/middleware.test.ts
+++ b/src/app/mobile-app/middleware.test.ts
@@ -74,7 +74,7 @@ describe("mobile app middleware", () => {
         { state: req.query.state },
       );
       expect(
-        ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.journey,
+        ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.data.journey,
       ).to.equal("journey/next");
       expect(res.status).to.be.calledWith(200);
     });

--- a/src/app/mobile-app/middleware.ts
+++ b/src/app/mobile-app/middleware.ts
@@ -26,5 +26,5 @@ export const checkMobileAppDetails: RequestHandler = async (req, res) => {
     req.session.clientOauthSessionId = apiResponse.data.clientOAuthSessionId;
   }
 
-  return handleBackendResponse(req, res, apiResponse?.data);
+  return handleBackendResponse(req, res, apiResponse);
 };

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -52,16 +52,18 @@ const extractCredentialIssuerId = (
 };
 
 // Sanitise response data based on endpoint allow list
-const sanitiseResponseData = (response: AxiosResponse): object | undefined => {
+export const sanitiseResponseData = (
+  response: AxiosResponse,
+): object | undefined => {
+  // Only allow data logging for endpoints explicitly in the allow list
+  const endpoint = response.config?.url ?? "";
+  if (!isEndpointAllowedForDataLogging(endpoint)) {
+    return undefined;
+  }
+
   try {
     if (typeof response.data === "object") {
       const body = { ...response.data };
-
-      const endpoint = response.config?.url ?? "";
-      // Only allow data logging for endpoints explicitly in the allow list
-      if (!isEndpointAllowedForDataLogging(endpoint)) {
-        return undefined;
-      }
 
       // Sanitize redirect URLs for allowed endpoints
       if (body.cri?.redirectUrl) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Log sanitised data objects from backend response

### Why did it change

- To be able to see the error response objects returned from process-journey-event as part of the logs for an unexpected journey event

### Issue tracking

- [PYIC-8032](https://govukverify.atlassian.net/browse/PYIC-8032)

[PYIC-8032]: https://govukverify.atlassian.net/browse/PYIC-8032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ