### PR TITLE
PYIC-8088: Reduce noisy error logging

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -102,6 +102,7 @@ export const handleBackendResponse = async (
   backendResponse: AxiosResponse<PostJourneyEventResponse>,
 ): Promise<void> => {
   const data = backendResponse.data;
+
   if (isJourneyResponse(data)) {
     return await processAction(req, res, data.journey);
   }

--- a/src/app/shared/axiosHelper.test.ts
+++ b/src/app/shared/axiosHelper.test.ts
@@ -6,6 +6,7 @@ import API_URLS from "../../config/config";
 
 const testLogger = {
   info: sinon.fake(),
+  warn: sinon.fake(),
   error: sinon.fake(),
 };
 
@@ -165,9 +166,9 @@ describe("axiosHelper", () => {
       await expect(axiosErrorLogger(error)).to.be.rejectedWith(error);
 
       // Assert
-      expect(testLogger.error).has.been.calledWith({
+      expect(testLogger.warn).has.been.calledWith({
         message: {
-          description: "API request failed",
+          description: "API returned error response",
           endpoint: "GET /test-path",
           data: { page: "testPage" },
           cri: "testCri",
@@ -201,9 +202,9 @@ describe("axiosHelper", () => {
       await expect(axiosErrorLogger(error)).to.be.rejectedWith(error);
 
       // Assert
-      expect(testLogger.error).has.been.calledWith({
+      expect(testLogger.warn).has.been.calledWith({
         message: {
-          description: "API request failed",
+          description: "API returned error response",
           endpoint: "GET /test-path",
           data: undefined,
           cri: "testCri",

--- a/src/app/shared/axiosHelper.ts
+++ b/src/app/shared/axiosHelper.ts
@@ -129,9 +129,9 @@ export const axiosErrorLogger = async (error: unknown): Promise<void> => {
   if (axios.isAxiosError(error) && error.config?.logger) {
     const logger = error.config.logger;
     if (error.response) {
-      logger.error({
+      logger.warn({
         message: {
-          ...buildRequestLog(error.response, "API request failed"),
+          ...buildRequestLog(error.response, "API returned error response"),
           errorMessage: error.message,
           errorStatus: error.response.status,
         },

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -108,6 +108,5 @@ export const loggerMiddleware: RequestHandler = pinoHttp({
     responseTime: "timeTaken",
   },
   // Define a custom logger level
-  customLogLevel: (req, res, err) =>
-    res.statusCode >= 400 || err ? "error" : "info",
+  customLogLevel: () => "info",
 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Reduce noisy error logging
- Additional-to-ticket: make the custom logging middleware always log to INFO, since errors caught by other handlers

### Why did it change

- Making it clearer to see when genuine issues occur

### Issue tracking

- [PYIC-8088](https://govukverify.atlassian.net/browse/PYIC-8088)

[PYIC-8088]: https://govukverify.atlassian.net/browse/PYIC-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ