### PR TITLE
PYIC-8088: Fix serverErrorHandler logging logic to use instanceof

### DIFF
--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -52,7 +52,7 @@ const serverErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
         errorStack: err?.stack,
       },
     });
-  } else if (!err instanceof AxiosError) {
+  } else if ((!err) instanceof AxiosError) {
     req.log?.error({
       message: {
         description: err?.constructor?.name ?? "Unknown error",

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -44,29 +44,22 @@ const serverErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
 
   const status = getErrorStatus(err);
 
-  switch (err?.constructor?.name) {
-    case UnauthorizedError.constructor.name: {
-      req.log?.warn({
-        message: {
-          description: UnauthorizedError.constructor.name,
-          errorMessage: err?.message ?? "Unknown error",
-          errorStack: err?.stack,
-        },
-      });
-      break;
-    }
-    case AxiosError.constructor.name: {
-      break;
-    }
-    default: {
-      req.log?.error({
-        message: {
-          description: err?.constructor?.name ?? "Unknown error",
-          errorMessage: err?.message ?? "Unknown error",
-          errorStack: err?.stack,
-        },
-      });
-    }
+  if (err instanceof UnauthorizedError) {
+    req.log?.warn({
+      message: {
+        description: UnauthorizedError.constructor.name,
+        errorMessage: err?.message ?? "Unknown error",
+        errorStack: err?.stack,
+      },
+    });
+  } else if (!err instanceof AxiosError) {
+    req.log?.error({
+      message: {
+        description: err?.constructor?.name ?? "Unknown error",
+        errorMessage: err?.message ?? "Unknown error",
+        errorStack: err?.stack,
+      },
+    });
   }
 
   res.status(status);

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -52,7 +52,7 @@ const serverErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
         errorStack: err?.stack,
       },
     });
-  } else if ((!err) instanceof AxiosError) {
+  } else if (!(err instanceof AxiosError)) {
     req.log?.error({
       message: {
         description: err?.constructor?.name ?? "Unknown error",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Fix serverErrorHandler logging logic to use instanceof

### Why did it change

- Comparing constructor names did not work

### Issue tracking

- [PYIC-8088](https://govukverify.atlassian.net/browse/PYIC-8088)

[PYIC-8088]: https://govukverify.atlassian.net/browse/PYIC-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ