### PR TITLE
PYIC-8226: Add runbook URL to alarm descriptions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -177,6 +177,9 @@ Mappings:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
       s3: "pl-7ca54015"
+  Constants:
+    Urls:
+      pagerDutyRunbook: "https://team-manual.account.gov.uk/teams/IPV-Core-team/Supporting-IPV-Core/pager-duty-runbooks/"
 
 Resources:
 
@@ -1490,6 +1493,9 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: FrontLoadBalancer5xxAlarm
+      AlarmDescription: !Sub
+        - 'The Elastic Load Balancer (ELB) in front of core-front has returned 2 or more 500 errors in a 5 minute period, for 2 periods in a row. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap [ Constants, Urls, pagerDutyRunbook]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue sns-topics-AlarmTopic
@@ -1524,6 +1530,9 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: FrontTargetGroup5xxAlarm
+      AlarmDescription: !Sub
+        - 'The targets of the ELB in front of core-front have returned a 500 error more than 50 times in a 5 minute period, for 2 periods in a row. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap [ Constants, Urls, pagerDutyRunbook]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue sns-topics-AlarmTopic
@@ -1601,9 +1610,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FrontRestApiGateway5XXErrorAlarm"
-      AlarmDescription: >
-        Trigger the alarm if errors exceed 10% with a minimum of 50
-        invocations, in 2 out of the last 5 minutes
+      AlarmDescription: !Sub
+        - 'Trigger the alarm if errors exceed 10% with a minimum of 50 invocations, in 2 out of the last 5 minutes. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap [ Constants, Urls, pagerDutyRunbook]
       ActionsEnabled: true
       OKActions:
         - !ImportValue sns-topics-AlarmTopic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add runbook URL to alarm description

### Why did it change

So people responding to the alarm can easily find the runbook

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8226](https://govukverify.atlassian.net/browse/PYIC-8226)


[PYIC-8226]: https://govukverify.atlassian.net/browse/PYIC-8226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ