### PR TITLE
PYIC-8265: update min ios version

### DIFF
--- a/browser-tests/functional-tests/device.spec.ts
+++ b/browser-tests/functional-tests/device.spec.ts
@@ -4,9 +4,9 @@ import { getAuthoriseUrlForJourney } from "./helpers";
 const HTTP_HEADER_USER_AGENT_ANDROID =
   "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36";
 const HTTP_HEADER_USER_AGENT_IPHONE_VALID_VERSION =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
   const HTTP_HEADER_USER_AGENT_IPHONE_INVALID_VERSION =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1";
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1";
 
 const domainUrl = process.env.WEBSITE_HOST;
 

--- a/src/app/shared/deviceSniffingHelper.test.ts
+++ b/src/app/shared/deviceSniffingHelper.test.ts
@@ -77,12 +77,12 @@ describe("User Agent Functions", () => {
       {
         scenario: "iOS user agents",
         userAgent: HTTP_HEADER_USER_AGENT_IPHONE_INVALID_VERSION,
-        expectedOs: { name: PHONE_TYPES.IPHONE, version: 10.3 },
+        expectedOs: { name: PHONE_TYPES.IPHONE, version: 14.3 },
       },
       {
         scenario: "iOS user agents",
         userAgent: HTTP_HEADER_USER_AGENT_IPHONE_VALID_VERSION,
-        expectedOs: { name: PHONE_TYPES.IPHONE, version: 14.3 },
+        expectedOs: { name: PHONE_TYPES.IPHONE, version: 15.1 },
       },
       {
         scenario: "Android user agents",

--- a/src/constants/device-constants.ts
+++ b/src/constants/device-constants.ts
@@ -8,4 +8,4 @@ export const OS_TYPES = Object.freeze({
   ANDROID: "Android",
 });
 
-export const MINIMUM_IOS_VERSION = 14;
+export const MINIMUM_IOS_VERSION = 15;

--- a/src/test-utils/constants.ts
+++ b/src/test-utils/constants.ts
@@ -5,8 +5,8 @@ export const HTTP_HEADER_USER_AGENT_ANDROID =
 export const HTTP_HEADER_USER_AGENT_ANDROID_NO_VERSION =
   "Mozilla/5.0 (Linux; Android; Nexus 5X Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36";
 export const HTTP_HEADER_USER_AGENT_IPHONE_INVALID_VERSION =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1";
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1";
 export const HTTP_HEADER_USER_AGENT_IPHONE_VALID_VERSION =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
 export const HTTP_HEADER_USER_AGENT_IPHONE_NO_VERSION =
   "Mozilla/5.0 (iPhone; CPU iPhone OS X like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update minimum ios version required from 14 to 15.

### Why did it change
Minimum ios version has increased form 14 to 15 as only a small percentage of users are on ios14 and maintaining support for it posed some security concerns highlighted [here](https://govukverify.atlassian.net/browse/DFDT-147).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8265](https://govukverify.atlassian.net/browse/PYIC-8265)



[PYIC-8265]: https://govukverify.atlassian.net/browse/PYIC-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ