### PR TITLE
PYIC-8279 Enable device intelligence cookie in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -129,7 +129,7 @@ Mappings:
       tg500ErrorWindow: 300
       lambdaInvokeCompareWindow: 300
       languageToggle: true
-      useDeviceIntelligence: false
+      useDeviceIntelligence: true
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/f728f1a83dd1b716_complete.js"


### PR DESCRIPTION
## Proposed changes

### What changed

Enable device intelligence cookie in staging

### Why did it change

Ready to test the cloudfront function update in staging

### Issue tracking
- [PYIC-8279](https://govukverify.atlassian.net/browse/PYIC-8279)

[PYIC-8279]: https://govukverify.atlassian.net/browse/PYIC-8279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ