### PR TITLE
Revert "DCP-4451 FE Container TaskDefinitions should have a minimum of 2048 cpu"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -844,9 +844,9 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub core-front-${Environment}
-      Cpu: !If [ IsPerformanceSensitive, 2048, 256 ]
+      Cpu: !If [ IsPerformanceSensitive, 1024, 256 ]
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: !If [ IsPerformanceSensitive, 4096, 512 ]
+      Memory: !If [ IsPerformanceSensitive, 2048, 512 ]
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
Our scale out policy is tuned for 1vCPU and in a recent perf test we failed to scale properly because CPU utilisation did not breach the threshold of 60%. Agreed with @huwd until we get further direction on this and/or tune our scaling policy for 2vCPU, we should revert back to 1vCPU for now.

Reverts govuk-one-login/ipv-core-front#1823