### PR TITLE
PYIC-8283: Fix device detection to route iPads to desktop flow instead of mobile app download

### DIFF
--- a/src/app/shared/deviceSniffingHelper.test.ts
+++ b/src/app/shared/deviceSniffingHelper.test.ts
@@ -9,6 +9,7 @@ import {
   HTTP_HEADER_USER_AGENT_IPHONE_VALID_VERSION,
   HTTP_HEADER_USER_AGENT_ANDROID_NO_VERSION,
   HTTP_HEADER_USER_AGENT_IPHONE_NO_VERSION,
+  HTTP_HEADER_USER_AGENT_IPAD,
 } from "../../test-utils/constants";
 import { specifyCreateRequest } from "../../test-utils/mock-express";
 
@@ -92,6 +93,11 @@ describe("User Agent Functions", () => {
       {
         scenario: "OS not iOS or Android",
         userAgent: HTTP_HEADER_USER_AGENT_NO_PHONE,
+        expectedOs: { name: "fallback" },
+      },
+      {
+        scenario: "iPad user agent",
+        userAgent: HTTP_HEADER_USER_AGENT_IPAD,
         expectedOs: { name: "fallback" },
       },
     ].forEach(({ scenario, userAgent, expectedOs }) => {

--- a/src/app/shared/deviceSniffingHelper.ts
+++ b/src/app/shared/deviceSniffingHelper.ts
@@ -41,16 +41,22 @@ export const sniffPhoneType = (
   fallback?: OsType,
 ): OsType | null => {
   const parser = new UAParser(req.headers["user-agent"]);
+  const deviceType = parser.getDevice().type;
+  const osName = parser.getOS().name;
+  const version = parser.getOS().version;
 
-  const version = parser.getOS()["version"];
-  switch (parser.getOS()["name"]) {
-    case OS_TYPES.IOS:
+  // Only treat "mobile" + OS as phone
+  if (deviceType === "mobile") {
+    if (osName === OS_TYPES.IOS) {
       return { name: PHONE_TYPES.IPHONE, version: parseVersion(version) };
-    case OS_TYPES.ANDROID:
+    }
+    if (osName === OS_TYPES.ANDROID) {
       return { name: PHONE_TYPES.ANDROID, version: parseVersion(version) };
-    default:
-      return fallback ?? null;
+    }
   }
+
+  // Everything else (tablet, desktop, unknown) → fallback → desktop flow
+  return fallback ?? null;
 };
 
 const parseVersion = (version: string | undefined): number | undefined =>

--- a/src/test-utils/constants.ts
+++ b/src/test-utils/constants.ts
@@ -10,3 +10,5 @@ export const HTTP_HEADER_USER_AGENT_IPHONE_VALID_VERSION =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
 export const HTTP_HEADER_USER_AGENT_IPHONE_NO_VERSION =
   "Mozilla/5.0 (iPhone; CPU iPhone OS X like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/14.0 Mobile/14E277 Safari/602.1";
+export const HTTP_HEADER_USER_AGENT_IPAD =
+  "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1";


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix device detection to route iPads to desktop flow Previously, iPads were incorrectly detected as iPhones due to relying solely on the OS name (iOS) without checking device type. 
This caused users to be routed to the mobile app download page instead of the select device page. 
Updated the sniffPhoneType logic to prioritise device type detection, treating only 'mobile' devices with iOS or Android as phones. 

### Why did it change

All other device types, including 'tablet' (iPads), now correctly fall back to the desktop flow. 
This restores expected behaviour after the recent OS version handling changes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8283](https://govukverify.atlassian.net/browse/PYIC-8283)

## Checklists

[PYIC-8283]: https://govukverify.atlassian.net/browse/PYIC-8283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ