### PR TITLE
PYIC-8267: Revert banner config from Experian outage

### DIFF
--- a/src/handlers/notification-banner-handler.test.ts
+++ b/src/handlers/notification-banner-handler.test.ts
@@ -83,45 +83,6 @@ describe("Notification banner handler", () => {
     expect(next).to.have.been.calledOnce;
   });
 
-  it("should display banner text from the second config variable if present", async () => {
-    // Arrange
-    const req = createRequest();
-    req.i18n.language = "en";
-    const res = createResponse();
-    parameterServiceStub.getParameter = sinon.fake((paramName: string) => {
-      if (paramName === "/core-front/notification-banner") {
-        return JSON.stringify([
-          {
-            pageId: "/some-other-page",
-            bannerMessage: "Test banner",
-            bannerMessageCy: "Welsh Test banner",
-            startTime: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-            endTime: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
-          },
-        ]);
-      }
-      if (paramName === "/core-front/notification-banner2") {
-        return JSON.stringify([
-          {
-            pageId: "/some-page",
-            bannerMessage: "Test banner 2",
-            bannerMessageCy: "Welsh Test banner 2",
-            startTime: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-            endTime: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
-          },
-        ]);
-      }
-    });
-
-    // Act
-    await notificationBannerHandler(req, res, next);
-
-    // Assert
-    expect(res.locals.displayBanner).to.be.true;
-    expect(res.locals.bannerMessage).to.equal("Test banner 2");
-    expect(next).to.have.been.calledOnce;
-  });
-
   it("should use parsed local environment variable when NODE_ENV is local", async () => {
     // Arrange
     const req = createRequest();
@@ -142,39 +103,6 @@ describe("Notification banner handler", () => {
 
     // Assert
     expect(res.locals.displayBanner).to.be.true;
-    expect(next).to.have.been.calledOnce;
-  });
-
-  it("should use parsed local environment variable 2 when NODE_ENV is local", async () => {
-    // Arrange
-    const req = createRequest();
-    const res = createResponse();
-    process.env.NODE_ENV = "local";
-    process.env["NOTIFICATION_BANNER"] = JSON.stringify([
-      {
-        pageId: "/some-other-page",
-        bannerMessage: "Test banner",
-        bannerMessageCy: "Welsh Test banner",
-        startTime: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-        endTime: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
-      },
-    ]);
-    process.env["NOTIFICATION_BANNER_2"] = JSON.stringify([
-      {
-        pageId: "/some-page",
-        bannerMessage: "Test banner 2",
-        bannerMessageCy: "Welsh Test banner 2",
-        startTime: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-        endTime: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
-      },
-    ]);
-
-    // Act
-    await notificationBannerHandler(req, res, next);
-
-    // Assert
-    expect(res.locals.displayBanner).to.be.true;
-    expect(res.locals.bannerMessage).to.equal("Test banner 2");
     expect(next).to.have.been.calledOnce;
   });
 

--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -14,31 +14,16 @@ export interface BannerConfig {
 const notificationBannerHandler: RequestHandler = async (req, res, next) => {
   try {
     res.locals.displayBanner = false;
-    const bannerConfigs1 =
+    const bannerConfigs =
       process.env.NODE_ENV === "local"
         ? process.env["NOTIFICATION_BANNER"]
         : await getParameter("/core-front/notification-banner");
-    const bannerConfigs2 =
-      process.env.NODE_ENV === "local"
-        ? process.env["NOTIFICATION_BANNER_2"]
-        : await getParameter("/core-front/notification-banner2");
-
-    if (
-      (!bannerConfigs1 || bannerConfigs1.length === 0) &&
-      (!bannerConfigs2 || bannerConfigs2.length === 0)
-    ) {
+    const bannerConfigsParsed: BannerConfig[] = bannerConfigs
+      ? JSON.parse(bannerConfigs)
+      : [];
+    if (!bannerConfigs || bannerConfigs.length === 0) {
       return next();
     }
-
-    const bannerConfigs1Parsed: BannerConfig[] = bannerConfigs1
-      ? JSON.parse(bannerConfigs1)
-      : [];
-    const bannerConfigs2Parsed: BannerConfig[] = bannerConfigs2
-      ? JSON.parse(bannerConfigs2)
-      : [];
-
-    const bannerConfigsParsed: BannerConfig[] =
-      bannerConfigs1Parsed.concat(bannerConfigs2Parsed);
 
     bannerConfigsParsed.forEach((data: BannerConfig) => {
       const currentTime = new Date().toISOString();


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Revert banner config from Experian outage
Manually revert: https://github.com/govuk-one-login/ipv-core-front/pull/1956

### Why did it change

Experian outage is no longer 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8267](https://govukverify.atlassian.net/browse/PYIC-8267)


[PYIC-8267]: https://govukverify.atlassian.net/browse/PYIC-8267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ