### PR TITLE
PYIC-5565: Update iOS app staging download URL

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -88,6 +88,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::738810260032:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
       iosAppId: "DEV_IOS_APP_ID"
       androidAppId: "DEV_ANDROID_APP_ID"
       androidFingerprint: "DEV_ANDROID_FINGERPRINT"
@@ -108,6 +110,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::738810260032:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
       iosAppId: "DEV_IOS_APP_ID"
       androidAppId: "DEV_ANDROID_APP_ID"
       androidFingerprint: "DEV_ANDROID_FINGERPRINT"
@@ -128,6 +132,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::429671060046:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
       iosAppId: "N8W395F695.uk.gov.onelogin.build"
       androidAppId: "uk.gov.onelogin.build"
       androidFingerprint: "6E:AA:2A:A0:11:4B:62:EB:34:5E:BA:9D:44:13:85:DC:35:8B:10:60:B3:2B:4B:41:50:9F:E8:B7:FB:3A:DA:B0"
@@ -148,6 +154,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::444977453444:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://testflight.apple.com/v1/app/6737052003"
       iosAppId: "N8W395F695.uk.gov.onelogin.staging"
       androidAppId: "uk.gov.onelogin.staging"
       androidFingerprint: "72:77:50:A0:9D:B7:38:46:DD:19:33:A9:4D:59:58:AB:7D:A9:95:CC:5F:A9:77:E5:8C:74:BF:F4:42:EA:43:18"
@@ -168,6 +176,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       spotAccountArn: arn:aws:iam::298945768017:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
       iosAppId: "N8W395F695.uk.gov.onelogin.integration"
       androidAppId: "uk.gov.onelogin.integration"
       androidFingerprint: "25:87:35:1C:E8:5E:D7:72:47:16:82:2D:44:F5:E0:54:C9:7C:2B:82:A3:6A:6C:04:DF:89:17:50:8A:0B:75:AF"
@@ -188,6 +198,8 @@ Mappings:
       templateCaching: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       spotAccountArn: arn:aws:iam::101836073728:root
+      appStoreUrlAndroid: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
+      appStoreUrlApple: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
       iosAppId: "N8W395F695.uk.gov.onelogin"
       androidAppId: "uk.gov.onelogin"
       androidFingerprint: "CC:8D:C5:6D:15:4A:F4:E7:97:B0:1A:68:88:CF:B7:B5:C7:EE:F0:8D:E5:94:D0:BD:BD:24:35:B7:CE:7B:B7:74"
@@ -734,10 +746,6 @@ Resources:
                 - APIGatewayId:
                     Fn::ImportValue: !Sub IPVCorePrivateAPIGatewayID-${Environment}
                   Environment: !Ref Environment
-            - Name: APP_STORE_URL_ANDROID
-              Value: "https://play.google.com/store/apps/details?id=uk.gov.documentchecking"
-            - Name: APP_STORE_URL_APPLE
-              Value: "https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566"
             - Name: SESSION_TABLE_NAME
               Value: !Sub
                 - "core-front-sessions-${Environment}"
@@ -839,6 +847,16 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - logoutUrl
+            - Name: APP_STORE_URL_ANDROID
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - appStoreUrlAndroid
+            - Name: APP_STORE_URL_APPLE
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - appStoreUrlApple
             - Name: IOS_APP_ID
               Value: !FindInMap
                 - EnvironmentConfiguration


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Made the app store URLs configurable per environment and updated the staging URL

### Why did it change

We now have the staging URL to use

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5565](https://govukverify.atlassian.net/browse/PYIC-5565)


[PYIC-5565]: https://govukverify.atlassian.net/browse/PYIC-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ