### PR TITLE
BAU Adjust v2 app spinner polling config

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -93,6 +93,10 @@ Mappings:
       iosAppId: "DEV_IOS_APP_ID"
       androidAppId: "DEV_ANDROID_APP_ID"
       androidFingerprint: "DEV_ANDROID_FINGERPRINT"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 300000
+      dadSpinnerRequestTimeout: 300000
     "175872367215": # core-dev02
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
@@ -115,6 +119,10 @@ Mappings:
       iosAppId: "DEV_IOS_APP_ID"
       androidAppId: "DEV_ANDROID_APP_ID"
       androidFingerprint: "DEV_ANDROID_FINGERPRINT"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 300000
+      dadSpinnerRequestTimeout: 300000
     "457601271792": # Build
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
@@ -137,6 +145,10 @@ Mappings:
       iosAppId: "N8W395F695.uk.gov.onelogin.build"
       androidAppId: "uk.gov.onelogin.build"
       androidFingerprint: "6E:AA:2A:A0:11:4B:62:EB:34:5E:BA:9D:44:13:85:DC:35:8B:10:60:B3:2B:4B:41:50:9F:E8:B7:FB:3A:DA:B0"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 300000
+      dadSpinnerRequestTimeout: 300000
     "335257547869": # Staging
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
@@ -159,6 +171,10 @@ Mappings:
       iosAppId: "N8W395F695.uk.gov.onelogin.staging"
       androidAppId: "uk.gov.onelogin.staging"
       androidFingerprint: "72:77:50:A0:9D:B7:38:46:DD:19:33:A9:4D:59:58:AB:7D:A9:95:CC:5F:A9:77:E5:8C:74:BF:F4:42:EA:43:18"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 300000
+      dadSpinnerRequestTimeout: 900000
     "991138514218": # Integration
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
@@ -181,6 +197,10 @@ Mappings:
       iosAppId: "N8W395F695.uk.gov.onelogin.integration"
       androidAppId: "uk.gov.onelogin.integration"
       androidFingerprint: "25:87:35:1C:E8:5E:D7:72:47:16:82:2D:44:F5:E0:54:C9:7C:2B:82:A3:6A:6C:04:DF:89:17:50:8A:0B:75:AF"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 600000
+      dadSpinnerRequestTimeout: 1800000
     "075701497069": # Production
       lb500ErrorLimit: 2
       lb500ErrorWindow: 300
@@ -203,6 +223,10 @@ Mappings:
       iosAppId: "N8W395F695.uk.gov.onelogin"
       androidAppId: "uk.gov.onelogin"
       androidFingerprint: "CC:8D:C5:6D:15:4A:F4:E7:97:B0:1A:68:88:CF:B7:B5:C7:EE:F0:8D:E5:94:D0:BD:BD:24:35:B7:CE:7B:B7:74"
+      spinnerRequestInterval: 5000
+      spinnerRequestLongWaitInterval: 60000
+      mamSpinnerRequestTimeout: 600000
+      dadSpinnerRequestTimeout: 1800000
   SecurityGroups:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
@@ -872,6 +896,26 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - androidFingerprint
+            - Name: SPINNER_REQUEST_INTERVAL
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - spinnerRequestInterval
+            - Name: SPINNER_REQUEST_LONG_WAIT_INTERVAL
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - spinnerRequestLongWaitInterval
+            - Name: MAM_SPINNER_REQUEST_TIMEOUT
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - mamSpinnerRequestTimeout
+            - Name: DAD_SPINNER_REQUEST_TIMEOUT
+              Value: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - dadSpinnerRequestTimeout
           Secrets:
             - Name: DT_TENANT
               ValueFrom: !Join


### PR DESCRIPTION
## Proposed changes
### What changed

Set spinner polling config per env as so:
```
Dev/build
Polling interval: 5 seconds
Long wait interval: 1 minute
MAM/DAD polling timeout: 5 minutes

Staging
Polling interval: 5 seconds
Long wait interval: 1 minute
MAM polling timeout: 5 minutes
DAD polling timeout: 15 minutes

Int/prod
Polling interval: 5 seconds
Long wait interval: 1 minute
MAM polling timeout: 10 minutes
DAD polling timeout: 30 minutes
```

### Why did it change

We can afford to have lower timeouts in the lower envs and more sensible defaults in prod, to save on polling cost and noisy logging

We can tweak these values further based on data insights from prod as v2 app is rolled out
