### PR TITLE
Pyic 8471 Add timestamp stored in sessionStorage and initTime

### DIFF
--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -28,7 +28,7 @@ class Spinner {
   };
 
   updateAccordingToTimeElapsed = () => {
-    const elapsedMilliseconds = this.initTime - new Date().getTime();
+    const elapsedMilliseconds = new Date().getTime() - this.initTime;
     if (elapsedMilliseconds >= this.config.msBeforeAbort) {
       this.reflectError();
     } else if (elapsedMilliseconds >= this.config.msBeforeInformingOfLongWait) {

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -41,16 +41,6 @@ class Spinner {
     if (this.domRequirementsMet) {
       this.spinnerState = "pending";
       this.button.setAttribute("disabled", true);
-
-      let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
-      if(spinnerInitTime === null) {
-        spinnerInitTime = Date.now();
-        sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
-      } else {
-        spinnerInitTime = parseInt(spinnerInitTime, 10);
-      }
-      this.initTime = spinnerInitTime;
-      this.updateAccordingToTimeElapsed();
     }
   };
 
@@ -186,7 +176,20 @@ class Spinner {
     this.container.replaceChildren(this.spinnerContainer, this.ariaLiveContainer);
   };
 
+  initTimer = () => {
+    let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
+    if(spinnerInitTime === null) {
+      spinnerInitTime = Date.now();
+      sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
+    } else {
+      spinnerInitTime = parseInt(spinnerInitTime, 10);
+    }
+    this.initTime = spinnerInitTime;
+    this.updateAccordingToTimeElapsed();
+  }
+
   init = () => {
+    this.initTimer()
     this.initialiseContainers();
     this.updateDom();
     this.requestAppVcReceiptStatus();

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -101,18 +101,12 @@ class Spinner {
     ];
 
     const paragraphs = (stateContent.text ?? "").split("\n");
-    paragraphs.forEach((t) =>
-      elements.push({
-        nodeName: "p",
-        text: t,
-        classes: [
-          "centre",
-          "spinner-state-text",
-          "govuk-body",
-          "govuk-!-font-weight-bold",
-        ],
-      }),
-    );
+    paragraphs.forEach(t => elements.push(
+    {
+      nodeName: "p",
+      text: t,
+      classes: ["centre", "spinner-state-text", "govuk-body", "govuk-!-font-weight-bold"],
+    }));
 
     return elements;
   };
@@ -136,13 +130,13 @@ class Spinner {
   };
 
   updateDom = () => {
-    const spinnerStateChanged =
-      this.displayedSpinnerState !== this.spinnerState;
+    const spinnerStateChanged = this.displayedSpinnerState !== this.spinnerState;
     if (spinnerStateChanged) {
-      const elements = this.createSpinnerVirtualDomElements(
-        this.spinnerState,
-      ).map(this.convertToElement);
-      this.spinnerContainer.replaceChildren(...elements);
+      const elements = this
+        .createSpinnerVirtualDomElements(this.spinnerState)
+        .map(this.convertToElement);
+      this.spinnerContainer
+        .replaceChildren(...elements);
       this.displayedSpinnerState = this.spinnerState;
     }
 
@@ -187,12 +181,9 @@ class Spinner {
   initialiseContainers = () => {
     this.spinnerContainer = document.createElement("div");
     this.ariaLiveContainer = document.createElement("div");
-    this.ariaLiveContainer.setAttribute("aria-live", "assertive");
+    this.ariaLiveContainer.setAttribute("aria-live","assertive");
     this.ariaLiveContainer.classList.add("govuk-visually-hidden");
-    this.container.replaceChildren(
-      this.spinnerContainer,
-      this.ariaLiveContainer,
-    );
+    this.container.replaceChildren(this.spinnerContainer, this.ariaLiveContainer);
   };
 
   init = () => {
@@ -200,7 +191,6 @@ class Spinner {
     this.updateDom();
     this.requestAppVcReceiptStatus();
   };
-
 
   constructor(domContainer) {
     this.container = domContainer;

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -16,10 +16,12 @@ class Spinner {
   };
 
   reflectCompletion = () => {
+    sessionStorage.removeItem('spinnerInitTime');
     this.spinnerState = "complete";
   };
 
   reflectError = () => {
+    sessionStorage.removeItem('spinnerInitTime');
     window.location.href = "/ipv/page/pyi-technical";
   };
 
@@ -40,7 +42,15 @@ class Spinner {
     if (this.domRequirementsMet) {
       this.spinnerState = "pending";
       this.button.setAttribute("disabled", true);
-      this.initTime = new Date().getTime();
+
+      let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
+      if(spinnerInitTime === null) {
+        spinnerInitTime = new Date().getTime();
+        sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
+      } else {
+        spinnerInitTime = parseInt(spinnerInitTime, 10);
+      }
+      this.initTime = spinnerInitTime;
     }
   };
 

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -14,6 +14,7 @@ class Spinner {
     msBeforeInformingOfLongWait: 5000,
     msBeforeAbort: 25000,
     msBetweenRequests: 1000,
+    msBetweenDomUpdate: 2000,
   };
 
   reflectCompletion = () => {

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -29,7 +29,7 @@ class Spinner {
   };
 
   updateAccordingToTimeElapsed = () => {
-    const elapsedMilliseconds = new Date().getTime() - this.initTime;
+    const elapsedMilliseconds = Date.now() - this.initTime;
     if (elapsedMilliseconds >= this.config.msBeforeAbort) {
       this.reflectError();
     } else if (elapsedMilliseconds >= this.config.msBeforeInformingOfLongWait) {
@@ -44,12 +44,13 @@ class Spinner {
 
       let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
       if(spinnerInitTime === null) {
-        spinnerInitTime = new Date().getTime();
+        spinnerInitTime = Date.now();
         sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
       } else {
         spinnerInitTime = parseInt(spinnerInitTime, 10);
       }
       this.initTime = spinnerInitTime;
+      this.updateAccordingToTimeElapsed();
     }
   };
 
@@ -163,6 +164,11 @@ class Spinner {
       } else if (data.status === "PROCESSING") {
         this.updateAccordingToTimeElapsed();
         setTimeout(async () => {
+          if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
+            this.reflectError();
+            this.updateDom();
+            return;
+          }
           await this.requestAppVcReceiptStatus();
         }, this.config.msBetweenRequests);
       } else {
@@ -194,6 +200,7 @@ class Spinner {
     this.updateDom();
     this.requestAppVcReceiptStatus();
   };
+
 
   constructor(domContainer) {
     this.container = domContainer;

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -181,6 +181,9 @@ class Spinner {
           this.reflectError();
         }
       })
+      .finally(() => {
+        this.updateDom();
+      })
   };
 
   // For the Aria alert to work reliably we need to create its container once and then update the contents
@@ -215,8 +218,7 @@ class Spinner {
     this.initTimer()
     this.initialiseContainers();
     this.updateDom();
-    this.requestAppVcReceiptStatus()
-      .then(() => this.updateDom);
+    this.requestAppVcReceiptStatus();
   };
 
   constructor(domContainer) {

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -5,7 +5,6 @@ class Spinner {
   content;
   domRequirementsMet;
   spinnerState;
-  timers = {};
   initTime;
   button;
   config = {

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -168,7 +168,6 @@ class Spinner {
         } else if (data.status === "PROCESSING") {
           setTimeout(async () => {
             if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
-              this.reflectError();
               return;
             }
             await this.requestAppVcReceiptStatus();

--- a/assets/javascript/spinner/init.js
+++ b/assets/javascript/spinner/init.js
@@ -152,8 +152,8 @@ class Spinner {
       } else if (data.status === "ERROR") {
         this.reflectError();
       } else if (data.status === "PROCESSING") {
+        this.updateAccordingToTimeElapsed();
         setTimeout(async () => {
-          this.updateAccordingToTimeElapsed();
           await this.requestAppVcReceiptStatus();
         }, this.config.msBetweenRequests);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
         "@govuk-one-login/frontend-ui": "1.3.7",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
-        "@govuk-one-login/spinner": "2.0.1",
+        "@govuk-one-login/spinner": "2.1.0",
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cfenv": "1.2.4",
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/@govuk-one-login/spinner": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/spinner/-/spinner-2.0.1.tgz",
-      "integrity": "sha512-qJSpUjuejjgeUXuPqhvV9rgram1F5ilK3RFpdCi3iwHL2TL8GH+HF1fqskzUEuOcRLijzb2ZmdiSGsS9WdvVRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-md8eTMou00Er1FONX736LnSFXxv6LkD7UyFteJfK84SVc4wv3twlt1zBPXwD2yjzsmusaK49IdfDm2dC3KwH1w==",
       "license": "ISC"
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
         "@govuk-one-login/frontend-ui": "1.3.7",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
-        "@govuk-one-login/spinner": "2.1.0",
+        "@govuk-one-login/spinner": "2.1.1",
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cfenv": "1.2.4",
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/@govuk-one-login/spinner": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/spinner/-/spinner-2.1.0.tgz",
-      "integrity": "sha512-md8eTMou00Er1FONX736LnSFXxv6LkD7UyFteJfK84SVc4wv3twlt1zBPXwD2yjzsmusaK49IdfDm2dC3KwH1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/spinner/-/spinner-2.1.1.tgz",
+      "integrity": "sha512-hfS4u4cT93VUc8STXk4gBTKFlaZfgaWGzjMR/UBVkJS+QqH9r9DyDhZujaNKGc3PKk626yA46xD9OiUYbDm0Tw==",
       "license": "ISC"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
     "@govuk-one-login/frontend-ui": "1.3.7",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
-    "@govuk-one-login/spinner": "2.0.1",
+    "@govuk-one-login/spinner": "2.1.0",
     "axios": "1.10.0",
     "body-parser": "2.2.0",
     "cfenv": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
     "@govuk-one-login/frontend-ui": "1.3.7",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
-    "@govuk-one-login/spinner": "2.1.0",
+    "@govuk-one-login/spinner": "2.1.1",
     "axios": "1.10.0",
     "body-parser": "2.2.0",
     "cfenv": "1.2.4",


### PR DESCRIPTION
## Proposed changes
### What changed

- Spinner component 
    - Removed longWait and abortTime setTimeouts.
    - Added logic that update state according to time elapsed
    - Introduced initTime stored in sessionStorage.
    - Add abortController to cancel fetch on page unload.
    - Added updateDomTimer interval.

### Why did it change

Spinner still uses setTimeout for polling and setInterval for DOM update to avoid usage of loops. Each of those call first check time elapsed from the initialisation time. This make it resistant against power saving and sleep modes.   

It also prevent spinner from updating to abort or long wait state even if spinner already end in completed state.

"During the v2 app switch-ons in prod it’s been noticed that in some cases the MAM/DAD spinner polling for DCMAW VC receipt appears not to timeout within the configured window and/or stops but then resumes some time later. Because the EVCS access token has an expiry of 1 hour, eventually the polling calls to EVCS fail with 401s.

It’s possible that this is being caused by browser throttling (background tab, device sleep, power saving) because of users leaving the tab open running and abandoning their journeys."



### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8471](https://govukverify.atlassian.net/browse/PYIC-8471)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8471]: https://govukverify.atlassian.net/browse/PYIC-8471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ