### PR TITLE
PYIC-8547: Successful callbacks must come from the mobile download page

### DIFF
--- a/src/app/mobile-app/middleware.ts
+++ b/src/app/mobile-app/middleware.ts
@@ -1,7 +1,8 @@
 import { MobileAppCallbackRequest } from "../../services/coreBackService";
-import { handleBackendResponse } from "../ipv/middleware";
+import { processAction } from "../ipv/middleware";
 import * as CoreBackService from "../../services/coreBackService";
 import { RequestHandler } from "express";
+import ipvPages from "../../constants/ipv-pages";
 
 export const checkMobileAppDetails: RequestHandler = async (req, res) => {
   if (!req.query?.state) {
@@ -26,5 +27,11 @@ export const checkMobileAppDetails: RequestHandler = async (req, res) => {
     req.session.clientOauthSessionId = apiResponse.data.clientOAuthSessionId;
   }
 
-  return handleBackendResponse(req, res, apiResponse);
+  // Successful callbacks must originate from the mobile download page to cause a state transition.
+  return await processAction(
+    req,
+    res,
+    apiResponse.data.journey,
+    ipvPages.PYI_TRIAGE_MOBILE_DOWNLOAD_APP,
+  );
 };


### PR DESCRIPTION
## Proposed changes
### What changed

- Enforce: Successful callbacks must come from the mobile download page to cause a state transition.

### Why did it change

- Unintended functionality we should control.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8547](https://govukverify.atlassian.net/browse/PYIC-8547)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8547]: https://govukverify.atlassian.net/browse/PYIC-8547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ