### PR TITLE
PYIC-8474 Bump frontend-ui to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-language-toggle": "2.2.1",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
-        "@govuk-one-login/frontend-ui": "1.3.8",
+        "@govuk-one-login/frontend-ui": "1.3.12",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "@govuk-one-login/spinner": "2.1.1",
         "axios": "1.11.0",
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.8.tgz",
-      "integrity": "sha512-O6cTp08pYhGr4KCEZiNzOUqfNKHyCbSYRU/D4l4fNNcEzn2V24INJ81g4z7sIdGjvEFmbqm3ixuKCOtTFFPfKQ==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.12.tgz",
+      "integrity": "sha512-EKf43hi61A5IhIlaFRO2gPlOTPkHvRDBLCiBGyWwppibDUvN+tYdvlhtn1UDsYZaHRXSl6cow/1ILE/DOwH3Vg==",
       "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-language-toggle": "2.2.1",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
-    "@govuk-one-login/frontend-ui": "1.3.8",
+    "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "@govuk-one-login/spinner": "2.1.1",
     "axios": "1.11.0",


### PR DESCRIPTION
## Proposed changes
### What changed

Bump @govuk-one-login/frontend-ui to latest version

### Why did it change

Contains fix for contact link needed for branding go-live

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8474](https://govukverify.atlassian.net/browse/PYIC-8474)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8474]: https://govukverify.atlassian.net/browse/PYIC-8474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ