### PR TITLE
PYIC-7189: send criId to backend when processing journey event

### DIFF
--- a/src/app/credential-issuer/middleware.test.ts
+++ b/src/app/credential-issuer/middleware.test.ts
@@ -117,17 +117,21 @@ describe("credential issuer middleware", () => {
         // Arrange
         const req = createRequest();
         const res = createResponse();
-        coreBackServiceStub.postCriCallback.resolves({
+        const apiResponse = {
           data: { journey: "journey/next" },
-        });
+        };
+        coreBackServiceStub.postCriCallback.resolves(apiResponse);
 
         // Act
         await middleware[method](req, res, next);
 
         // Assert
-        expect(
-          ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.data.journey,
-        ).to.equal("journey/next");
+        expect(ipvMiddlewareStub.handleBackendResponse).to.have.been.calledWith(
+          req,
+          res,
+          apiResponse,
+          "PassportIssuer",
+        );
       });
 
       it("should call next with error on failed core-back response", async () => {

--- a/src/app/credential-issuer/middleware.ts
+++ b/src/app/credential-issuer/middleware.ts
@@ -44,7 +44,7 @@ export const sendParamsToAPI: RequestHandler = async (req, res) => {
   }
 
   const apiResponse = await postCriCallback(req, body);
-  return handleBackendResponse(req, res, apiResponse);
+  return handleBackendResponse(req, res, apiResponse, query.id);
 };
 
 // Temporary - this will replace the above method once all CRI's have been migrated across to use the new endpoint
@@ -72,5 +72,5 @@ export const sendParamsToAPIV2: RequestHandler = async (req, res) => {
   }
 
   const apiResponse = await postCriCallback(req, body);
-  return handleBackendResponse(req, res, apiResponse);
+  return handleBackendResponse(req, res, apiResponse, criId);
 };

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -62,7 +62,7 @@ const journeyApi = async (
   action: string,
   req: Request,
   currentPageId?: string,
-  currentCriId?: string
+  currentCriId?: string,
 ): Promise<AxiosResponse<PostJourneyEventResponse>> => {
   if (action.startsWith("/")) {
     action = action.substring(1);
@@ -92,9 +92,14 @@ export const processAction = async (
   res: Response,
   action: string,
   currentPageId?: string,
-  currentCriId?: string
+  currentCriId?: string,
 ): Promise<void> => {
-  const backendResponse = await journeyApi(action, req, currentPageId, currentCriId);
+  const backendResponse = await journeyApi(
+    action,
+    req,
+    currentPageId,
+    currentCriId,
+  );
 
   return await handleBackendResponse(req, res, backendResponse);
 };
@@ -103,7 +108,7 @@ export const handleBackendResponse = async (
   req: Request,
   res: Response,
   backendResponse: AxiosResponse<PostJourneyEventResponse>,
-  criId?: string
+  criId?: string,
 ): Promise<void> => {
   const data = backendResponse.data;
 

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -61,7 +61,8 @@ const allTemplates = fs
 const journeyApi = async (
   action: string,
   req: Request,
-  currentPageId: string,
+  currentPageId?: string,
+  currentCriId?: string
 ): Promise<AxiosResponse<PostJourneyEventResponse>> => {
   if (action.startsWith("/")) {
     action = action.substring(1);
@@ -71,7 +72,7 @@ const journeyApi = async (
     action = action.substring(8);
   }
 
-  return postJourneyEvent(req, action, currentPageId);
+  return postJourneyEvent(req, action, currentPageId, currentCriId);
 };
 
 const fetchUserDetails = async (
@@ -90,9 +91,10 @@ export const processAction = async (
   req: Request,
   res: Response,
   action: string,
-  currentPageId = "",
+  currentPageId?: string,
+  currentCriId?: string
 ): Promise<void> => {
-  const backendResponse = await journeyApi(action, req, currentPageId);
+  const backendResponse = await journeyApi(action, req, currentPageId, currentCriId);
 
   return await handleBackendResponse(req, res, backendResponse);
 };
@@ -101,11 +103,12 @@ export const handleBackendResponse = async (
   req: Request,
   res: Response,
   backendResponse: AxiosResponse<PostJourneyEventResponse>,
+  criId?: string
 ): Promise<void> => {
   const data = backendResponse.data;
 
   if (isJourneyResponse(data)) {
-    return await processAction(req, res, data.journey);
+    return await processAction(req, res, data.journey, undefined, criId);
   }
 
   if (isCriResponse(data) && isValidCriResponse(data)) {

--- a/src/app/ipv/tests/handleJourneyActionRequest.test.ts
+++ b/src/app/ipv/tests/handleJourneyActionRequest.test.ts
@@ -147,6 +147,7 @@ describe("handleJourneyActionRequest", () => {
       req,
       "some-journey-event",
       req.session.currentPage,
+      undefined,
     );
   });
 

--- a/src/services/coreBackService.ts
+++ b/src/services/coreBackService.ts
@@ -73,7 +73,7 @@ export const postJourneyEvent = (
   req: Request,
   event: string,
   currentPage?: string,
-  currentCriId?: string
+  currentCriId?: string,
 ): Promise<AxiosResponse<PostJourneyEventResponse>> => {
   const encodedEvent = encodeURIComponent(event);
 
@@ -82,8 +82,8 @@ export const postJourneyEvent = (
     req,
   );
 
-  if (currentPage ||  currentCriId) {
-    requestConfig.params = {currentPage, currentCriId};
+  if (currentPage || currentCriId) {
+    requestConfig.params = { currentPage, currentCriId };
   }
 
   return axiosInstance.post(

--- a/src/services/coreBackService.ts
+++ b/src/services/coreBackService.ts
@@ -73,6 +73,7 @@ export const postJourneyEvent = (
   req: Request,
   event: string,
   currentPage?: string,
+  currentCriId?: string
 ): Promise<AxiosResponse<PostJourneyEventResponse>> => {
   const encodedEvent = encodeURIComponent(event);
 
@@ -81,8 +82,8 @@ export const postJourneyEvent = (
     req,
   );
 
-  if (currentPage) {
-    requestConfig.params = { currentPage };
+  if (currentPage ||  currentCriId) {
+    requestConfig.params = {currentPage, currentCriId};
   }
 
   return axiosInstance.post(


### PR DESCRIPTION
## Proposed changes
### What changed

- sending the CRI id along with the event to core-back when processing a journey event

### Why did it change

- so that we handle CRIs the same way we do pages if the session states do not match

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7189](https://govukverify.atlassian.net/browse/PYIC-7189)



[PYIC-7189]: https://govukverify.atlassian.net/browse/PYIC-7189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ