### PR TITLE
Pyic 8558 notification banners

### DIFF
--- a/browser-tests/compose.yaml
+++ b/browser-tests/compose.yaml
@@ -28,7 +28,7 @@ services:
       MAY_2025_REBRAND_ENABLED: true
       SERVICE_URL: http://localhost:4601
 # Note that due to how snapshot tests work the pageIds here include the language so the banners only appear in one language version of the snapshot. We also can't test banner contexts in snapshot tests as the all-templates page shortcuts a lot of stuff.
-      NOTIFICATION_BANNER: '[{"pageId":"/dev/template/live-in-uk/en","bannerMessage":"<h3>Test banner</h3> <p>This is a test banner <a class=\"govuk-notification-banner__link\" href=\"#\">with a dummy link</a></p>","bannerMessageCy":"Not seen","startTime":"2024-10-25T06:14:40.162+0000","endTime":"2030-10-25T06:14:40.162+0000"}]'
+      NOTIFICATION_BANNER: '[{"pages": [ { "pageId":"/dev/template/live-in-uk/en" } ],"bannerMessage":"<h3>Test banner</h3> <p>This is a test banner <a class=\"govuk-notification-banner__link\" href=\"#\">with a dummy link</a></p>","bannerMessageCy":"Not seen","startTime":"2024-10-25T06:14:40.162+0000","endTime":"2030-10-25T06:14:40.162+0000"}]'
     ports:
       - "4601:4601"
       - "5101:9229"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -80,6 +80,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: true
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: ""
@@ -107,6 +108,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: true
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: ""
@@ -134,6 +136,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: false
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: ""
@@ -161,6 +164,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: false
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/f728f1a83dd1b716_complete.js"
@@ -188,6 +192,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: false
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/952c24127da85c63_complete.js"
@@ -215,6 +220,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
+      alwaysShowBanners: false
       ga4Disabled: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf04188tda/fa56a4b3a9bbea0_complete.js"
@@ -825,6 +831,8 @@ Resources:
               Value: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, useDeviceIntelligence ]
             - Name: MAY_2025_REBRAND_ENABLED
               Value: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, may2025RebrandEnabled ]
+            - Name: ALWAYS_SHOW_BANNERS
+              Value: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, alwaysShowBanners ]
             - Name: NODE_OPTIONS
               Value: !Join
                 - ''

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -64,4 +64,5 @@ export default {
   DAD_SPINNER_REQUEST_TIMEOUT:
     process.env.DAD_SPINNER_REQUEST_TIMEOUT || 2400000,
   MAY_2025_REBRAND_ENABLED: process.env.MAY_2025_REBRAND_ENABLED === "true",
+  ALWAYS_SHOW_BANNERS: process.env.ALWAYS_SHOW_BANNERS === "true",
 };

--- a/src/handlers/notification-banner-handler.test.ts
+++ b/src/handlers/notification-banner-handler.test.ts
@@ -75,7 +75,7 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
@@ -101,7 +101,7 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
@@ -128,7 +128,7 @@ describe("Notification banner handler", () => {
       if (paramName === "/core-front/notification-banner") {
         return JSON.stringify([
           {
-            pageId: "/some-other-page",
+            pages: [{ pageId: "/some-other-page" }],
             bannerMessage: "Test banner",
             bannerMessageCy: "Welsh Test banner",
             startTime: beforeNow,
@@ -139,7 +139,7 @@ describe("Notification banner handler", () => {
       if (paramName === "/core-front/notification-banner2") {
         return JSON.stringify([
           {
-            pageId: "/some-page",
+            pages: [{ pageId: "/some-page" }],
             bannerMessage: "Test banner 2",
             bannerMessageCy: "Welsh Test banner 2",
             startTime: beforeNow,
@@ -158,6 +158,34 @@ describe("Notification banner handler", () => {
     expect(next).to.have.been.calledOnce;
   });
 
+  it("should display banner text on all pages", async () => {
+    // Arrange
+    const req = createRequest();
+    req.i18n.language = "en";
+    const res = createResponse();
+    parameterServiceStub.getParameter = sinon.fake((paramName: string) => {
+      if (paramName === "/core-front/notification-banner") {
+        return JSON.stringify([
+          {
+            pages: [{ pageId: "/some-other-page" }, { pageId: "/some-page" }],
+            bannerMessage: "Test banner",
+            bannerMessageCy: "Welsh Test banner",
+            startTime: beforeNow,
+            endTime: afterNow,
+          },
+        ]);
+      }
+    });
+
+    // Act
+    await underTest(req, res, next);
+
+    // Assert
+    expect(res.locals.displayBanner).to.be.true;
+    expect(res.locals.bannerMessage).to.equal("Test banner");
+    expect(next).to.have.been.calledOnce;
+  });
+
   it("should use parsed local environment variable when NODE_ENV is local", async () => {
     // Arrange
     const req = createRequest();
@@ -165,7 +193,7 @@ describe("Notification banner handler", () => {
     process.env.NODE_ENV = "local";
     process.env["NOTIFICATION_BANNER"] = JSON.stringify([
       {
-        pageId: "/some-page",
+        pages: [{ pageId: "/some-page" }],
         bannerMessage: "Test banner",
         bannerMessageCy: "Welsh Test banner",
         startTime: beforeNow,
@@ -188,7 +216,7 @@ describe("Notification banner handler", () => {
     process.env.NODE_ENV = "local";
     process.env["NOTIFICATION_BANNER"] = JSON.stringify([
       {
-        pageId: "/some-other-page",
+        pages: [{ pageId: "/some-other-page" }],
         bannerMessage: "Test banner",
         bannerMessageCy: "Welsh Test banner",
         startTime: beforeNow,
@@ -197,7 +225,7 @@ describe("Notification banner handler", () => {
     ]);
     process.env["NOTIFICATION_BANNER_2"] = JSON.stringify([
       {
-        pageId: "/some-page",
+        pages: [{ pageId: "/some-page" }],
         bannerMessage: "Test banner 2",
         bannerMessageCy: "Welsh Test banner 2",
         startTime: beforeNow,
@@ -235,10 +263,10 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
-          startTime: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+          startTime: afterNow,
           endTime: afterNow,
         },
       ]),
@@ -259,11 +287,11 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
-          endTime: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+          endTime: beforeNow,
         },
       ]),
     );
@@ -283,7 +311,7 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
@@ -307,7 +335,7 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNowBst,
@@ -331,10 +359,9 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page", contexts: ["notMatchingContext"] }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
-          context: "notMatchingContext",
           startTime: beforeNow,
           endTime: afterNow,
         },
@@ -357,7 +384,7 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page" }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
@@ -382,10 +409,35 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page", contexts: ["matchingContext"] }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
-          context: "matchingContext",
+          startTime: beforeNow,
+          endTime: afterNow,
+        },
+      ]),
+    );
+
+    // Act
+    await underTest(req, res, next);
+
+    // Assert
+    expect(res.locals.displayBanner).to.be.true;
+    expect(next).to.have.been.calledOnce;
+  });
+
+  it("should display banner if config has blank and non-blank contexts and request has no context", async () => {
+    // Arrange
+    const req = createRequest();
+    const res = createResponse();
+    parameterServiceStub.getParameter = sinon.fake.resolves(
+      JSON.stringify([
+        {
+          pages: [
+            { pageId: "/some-page", contexts: ["notMatchingContext", ""] },
+          ],
+          bannerMessage: "Test banner",
+          bannerMessageCy: "Welsh Test banner",
           startTime: beforeNow,
           endTime: afterNow,
         },
@@ -408,18 +460,16 @@ describe("Notification banner handler", () => {
     parameterServiceStub.getParameter = sinon.fake.resolves(
       JSON.stringify([
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page", contexts: ["matchingContext"] }],
           bannerMessage: "Test banner",
           bannerMessageCy: "Welsh Test banner",
-          context: "matchingContext",
           startTime: beforeNow,
           endTime: afterNow,
         },
         {
-          pageId: "/some-page",
+          pages: [{ pageId: "/some-page", contexts: ["notMatchingContext"] }],
           bannerMessage: "Bad banner",
           bannerMessageCy: "Welsh Test banner",
-          context: "notMatchingContext",
           startTime: beforeNow,
           endTime: afterNow,
         },
@@ -438,7 +488,6 @@ describe("Notification banner handler", () => {
   it("should continue if the config is invalid", async () => {
     // Arrange
     const req = createRequest();
-    req.session.context = "matchingContext";
     const res = createResponse();
     parameterServiceStub.getParameter = sinon.fake.resolves("not JSON");
 

--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -2,8 +2,12 @@ import { getParameter } from "../services/parameterStoreService";
 import { logger } from "../lib/logger";
 import { RequestHandler } from "express";
 export interface BannerConfig {
-  pageId: string;
-  context?: string;
+  pages: [
+    {
+      pageId: string;
+      contexts?: string[];
+    },
+  ];
   bannerType?: string;
   bannerMessage: string;
   bannerMessageCy: string;
@@ -58,12 +62,14 @@ const notificationBannerHandler: RequestHandler = async (req, res, next) => {
       const bannerStartTime = new Date(data.startTime);
       const bannerEndTime = new Date(data.endTime);
       const currentTime = new Date();
+
       if (
-        req.path === data.pageId &&
         currentTime >= bannerStartTime &&
         currentTime <= bannerEndTime &&
-        ((!req.session.context && !data.context) ||
-          req.session.context === data.context)
+        data.pages.some(p =>
+          p.pageId === req.path &&
+          ((!req.session.context && (!p.contexts || p.contexts?.includes(""))) ||
+            (req.session.context && p.contexts && p.contexts.includes(req.session.context))))
       ) {
         res.locals.displayBanner = true;
         res.locals.bannerType = data.bannerType;

--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -1,6 +1,7 @@
 import { getParameter } from "../services/parameterStoreService";
 import { logger } from "../lib/logger";
 import { RequestHandler } from "express";
+import Config from "../config/config";
 export interface BannerConfig {
   pages: [
     {
@@ -64,12 +65,17 @@ const notificationBannerHandler: RequestHandler = async (req, res, next) => {
       const currentTime = new Date();
 
       if (
-        currentTime >= bannerStartTime &&
-        currentTime <= bannerEndTime &&
-        data.pages.some(p =>
-          p.pageId === req.path &&
-          ((!req.session.context && (!p.contexts || p.contexts?.includes(""))) ||
-            (req.session.context && p.contexts && p.contexts.includes(req.session.context))))
+        (Config.ALWAYS_SHOW_BANNERS ||
+          (currentTime >= bannerStartTime && currentTime <= bannerEndTime)) &&
+        data.pages.some(
+          (p) =>
+            p.pageId === req.path &&
+            ((!req.session.context &&
+              (!p.contexts || p.contexts?.includes(""))) ||
+              (req.session.context &&
+                p.contexts &&
+                p.contexts.includes(req.session.context))),
+        )
       ) {
         res.locals.displayBanner = true;
         res.locals.bannerType = data.bannerType;

--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -73,8 +73,7 @@ const notificationBannerHandler: RequestHandler = async (req, res, next) => {
             ((!req.session.context &&
               (!p.contexts || p.contexts?.includes(""))) ||
               (req.session.context &&
-                p.contexts &&
-                p.contexts.includes(req.session.context))),
+                p.contexts?.includes(req.session.context))),
         )
       ) {
         res.locals.displayBanner = true;


### PR DESCRIPTION
## Proposed changes
### What changed

Improved notification banner config structure

### Why did it change

To allow the same banner to easily appear on multiple pages.
Also add the option to always show banners in dev to allow review/testing

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8558](https://govukverify.atlassian.net/browse/PYIC-8558)

## Checklists

- [ x ] READMEs and documentation up-to-date

I've updated the confluence page on banners to match this new structure



[PYIC-8558]: https://govukverify.atlassian.net/browse/PYIC-8558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ