### PR TITLE
BAU: add log for displayed banner

### DIFF
--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -88,7 +88,9 @@ const notificationBannerHandler: RequestHandler = async (req, res, next) => {
           "general.govuk.notificationBanner.title",
         );
 
-        logger.info(`Banner enabled for "${req.path}" (context: "${req.session.context}")`)
+        logger.info(
+          `Banner enabled for "${req.path}" (context: "${req.session.context}")`,
+        );
       }
     });
     next();

--- a/src/handlers/notification-banner-handler.ts
+++ b/src/handlers/notification-banner-handler.ts
@@ -87,6 +87,8 @@ const notificationBannerHandler: RequestHandler = async (req, res, next) => {
         res.locals.bannerTitleText = translate(
           "general.govuk.notificationBanner.title",
         );
+
+        logger.info(`Banner enabled for "${req.path}" (context: "${req.session.context}")`)
       }
     });
     next();


### PR DESCRIPTION
This is so we can check that the banner was enabled by looking at the logs.

## Proposed changes
### What changed

- add log when banner is enabled for a specific page

### Why did it change

- There isn't a way of checking that the banner was enabled for a certain page unless you go on the site during the time it was configured to be enabled. This would let us check if the banner was enabled by via the logs which will help us assess impact

