### PR TITLE
PYIC-8547: Send current page when processing callback journey event

### DIFF
--- a/src/app/mobile-app/middleware.test.ts
+++ b/src/app/mobile-app/middleware.test.ts
@@ -22,7 +22,7 @@ describe("mobile app middleware", () => {
       postMobileAppCallback: sinon.fake(),
     };
     const ipvMiddlewareStub = {
-      handleBackendResponse: sinon.fake(),
+      processAction: sinon.fake(),
     };
 
     let middleware: typeof import("./middleware");
@@ -73,9 +73,9 @@ describe("mobile app middleware", () => {
         req,
         { state: req.query.state },
       );
-      expect(
-        ipvMiddlewareStub.handleBackendResponse.lastCall.lastArg.data.journey,
-      ).to.equal("journey/next");
+      expect(ipvMiddlewareStub.processAction.lastCall.args[2]).to.equal(
+        "journey/next",
+      );
       expect(res.status).to.be.calledWith(200);
     });
 

--- a/src/app/mobile-app/middleware.ts
+++ b/src/app/mobile-app/middleware.ts
@@ -1,7 +1,8 @@
 import { MobileAppCallbackRequest } from "../../services/coreBackService";
-import { handleBackendResponse } from "../ipv/middleware";
+import { processAction } from "../ipv/middleware";
 import * as CoreBackService from "../../services/coreBackService";
 import { RequestHandler } from "express";
+import ipvPages from "../../constants/ipv-pages";
 
 export const checkMobileAppDetails: RequestHandler = async (req, res) => {
   if (!req.query?.state) {
@@ -26,5 +27,11 @@ export const checkMobileAppDetails: RequestHandler = async (req, res) => {
     req.session.clientOauthSessionId = apiResponse.data.clientOAuthSessionId;
   }
 
-  return handleBackendResponse(req, res, apiResponse);
+  // postMobileAppCallback will give us a journey event to carry on with. So here we call processAction() as if the user had selected a radio button action on the PYI_TRIAGE_MOBILE_DOWNLOAD_APP page.
+  return await processAction(
+    req,
+    res,
+    apiResponse.data.journey,
+    ipvPages.PYI_TRIAGE_MOBILE_DOWNLOAD_APP,
+  );
 };

--- a/src/app/validators/postJourneyEventResponse.ts
+++ b/src/app/validators/postJourneyEventResponse.ts
@@ -15,6 +15,7 @@ export interface PageResponse {
 
 export interface JourneyResponse {
   journey: string;
+  clientOAuthSessionId?: string;
 }
 
 export interface ClientResponse {

--- a/src/services/coreBackService.ts
+++ b/src/services/coreBackService.ts
@@ -8,7 +8,10 @@ import { Request } from "express";
 import { Logger } from "pino";
 import { createAxiosInstance } from "../app/shared/axiosHelper";
 import config from "../config/config";
-import { PostJourneyEventResponse } from "../app/validators/postJourneyEventResponse";
+import {
+  JourneyResponse,
+  PostJourneyEventResponse,
+} from "../app/validators/postJourneyEventResponse";
 
 const axiosInstance = createAxiosInstance(config.API_BASE_URL);
 
@@ -123,7 +126,7 @@ export const postCriCallback = (
 export const postMobileAppCallback = (
   req: Request,
   body: MobileAppCallbackRequest,
-): Promise<AxiosResponse> => {
+): Promise<AxiosResponse<JourneyResponse>> => {
   return axiosInstance.post(
     config.API_MOBILE_APP_CALLBACK,
     body,


### PR DESCRIPTION
## Proposed changes
### What changed

Current page is sent to core-back when sending the event generated by the app callback

### Why did it change

So that core-back can notice if the app callback event is being sent from the wrong page.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8547](https://govukverify.atlassian.net/browse/PYIC-8547)



[PYIC-8547]: https://govukverify.atlassian.net/browse/PYIC-8547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ