### PR TITLE
fix(948): adding data-nav to buttons

### DIFF
--- a/views/components/journey-next-form.njk
+++ b/views/components/journey-next-form.njk
@@ -6,7 +6,8 @@
     <input type="hidden" name="journey" value="next">
       {{ govukButton({
           id: "submitButton",
-          text: buttonLabel
+          text: buttonLabel,
+          attributes: {"data-nav": true,"data-link": "/undefined"}
       }) }}
 </form>
 {% endmacro %}


### PR DESCRIPTION
## Proposed changes
### What changed

added datanav to buttons to ensure they fire GA4 events on click
-

### Why did it change

analytics team were not receiving data about these buttons
-

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [DFC-948](https://govukverify.atlassian.net/browse/DFC-948)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[DFC-948]: https://govukverify.atlassian.net/browse/DFC-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ