### PR TITLE
PYIC-8644: add browser tests for testing links on pyi-triage-desktop-…

### DIFF
--- a/browser-tests/functional-tests/functional.spec.ts
+++ b/browser-tests/functional-tests/functional.spec.ts
@@ -278,4 +278,42 @@ test.describe.parallel("Functional tests", () => {
       expect(res.status()).toBe(expectedStatusCode);
     });
   });
+
+  ["Android", "Iphone"].forEach( mobileType => {
+    [
+      {
+        eventSelected: "anotherWay",
+        dropdownText: "I am sensitive to flashing colours",
+        linkText: "prove your identity another way if you think you might be sensitive to flashing colours",
+        expectedPage: "page-multiple-doc-check"
+      },
+      {
+        eventSelected: "preferNoApp",
+        dropdownText: "I’d prefer not to use the app",
+        linkText: "prove your identity another way",
+        expectedPage: "pyi-triage-buffer"
+      }
+    ].forEach(({eventSelected, dropdownText, linkText, expectedPage}) => {
+      test(`User routed correctly when selecting ${eventSelected} on ${mobileType}`, async ({page}) => {
+        // Start session
+        await page.goto(
+          getAuthoriseUrlForJourney(`strategicAppDesktopDownloadPage${mobileType}${eventSelected}`),
+        );
+
+        // Navigate to pyi-triage-desktop-download-app
+        const pageHeading = await page.getByRole("heading", {
+          name: "Use the GOV.UK One Login app to prove your identity",
+        });
+        await expect(pageHeading).toBeVisible();
+
+        // Select "prefer not to use app" dropdown
+        await page.locator('.govuk-details__summary').getByText(dropdownText).click();
+        await page.getByRole("link", { name: linkText}).click();
+
+        // Redirected to expected page
+        const url = page.url();
+        expect(url).toBe(`${domainUrl}/ipv/page/${expectedPage}`);
+      })
+    })
+  })
 });

--- a/browser-tests/functional-tests/functional.spec.ts
+++ b/browser-tests/functional-tests/functional.spec.ts
@@ -279,25 +279,30 @@ test.describe.parallel("Functional tests", () => {
     });
   });
 
-  ["Android", "Iphone"].forEach( mobileType => {
+  ["Android", "Iphone"].forEach((mobileType) => {
     [
       {
         eventSelected: "anotherWay",
         dropdownText: "I am sensitive to flashing colours",
-        linkText: "prove your identity another way if you think you might be sensitive to flashing colours",
-        expectedPage: "page-multiple-doc-check"
+        linkText:
+          "prove your identity another way if you think you might be sensitive to flashing colours",
+        expectedPage: "page-multiple-doc-check",
       },
       {
         eventSelected: "preferNoApp",
         dropdownText: "I’d prefer not to use the app",
         linkText: "prove your identity another way",
-        expectedPage: "pyi-triage-buffer"
-      }
-    ].forEach(({eventSelected, dropdownText, linkText, expectedPage}) => {
-      test(`User routed correctly when selecting ${eventSelected} on ${mobileType}`, async ({page}) => {
+        expectedPage: "pyi-triage-buffer",
+      },
+    ].forEach(({ eventSelected, dropdownText, linkText, expectedPage }) => {
+      test(`User routed correctly when selecting ${eventSelected} on ${mobileType}`, async ({
+        page,
+      }) => {
         // Start session
         await page.goto(
-          getAuthoriseUrlForJourney(`strategicAppDesktopDownloadPage${mobileType}${eventSelected}`),
+          getAuthoriseUrlForJourney(
+            `strategicAppDesktopDownloadPage${mobileType}${eventSelected}`,
+          ),
         );
 
         // Navigate to pyi-triage-desktop-download-app
@@ -307,13 +312,16 @@ test.describe.parallel("Functional tests", () => {
         await expect(pageHeading).toBeVisible();
 
         // Select "prefer not to use app" dropdown
-        await page.locator('.govuk-details__summary').getByText(dropdownText).click();
-        await page.getByRole("link", { name: linkText}).click();
+        await page
+          .locator(".govuk-details__summary")
+          .getByText(dropdownText)
+          .click();
+        await page.getByRole("link", { name: linkText }).click();
 
         // Redirected to expected page
         const url = page.url();
         expect(url).toBe(`${domainUrl}/ipv/page/${expectedPage}`);
-      })
-    })
-  })
+      });
+    });
+  });
 });

--- a/browser-tests/imposter/config/api-config.yaml
+++ b/browser-tests/imposter/config/api-config.yaml
@@ -40,7 +40,7 @@ resources:
     requestHeaders:
       content-type: "application/json"
       ipv-session-id:
-        value: "^.*(reuseJourney|fraudCheckJourney|checkVcReceipt).*$"
+        value: "^.*(reuseJourney|fraudCheckJourney|checkVcReceipt|strategicAppDesktopDownloadPage).*$"
         operator: NotMatches
     queryParams:
       currentPage:
@@ -618,4 +618,73 @@ resources:
       content: |
         {
           "page": "pyi-technical"
+        }
+
+  # Routing from pyi-triage-desktop-download-app
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "strategicAppDesktopDownloadPageAndroid"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "pyi-triage-desktop-download-app",
+          "context": "android"
+        }
+
+  - method: POST
+    path: /journey/next
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "strategicAppDesktopDownloadPageIphone"
+        operator: Contains
+    queryParams:
+      currentPage:
+        operator: NotExists
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "pyi-triage-desktop-download-app",
+          "context": "iphone"
+        }
+
+  - method: POST
+    path: /journey/preferNoApp
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "preferNoApp"
+        operator: Contains
+    queryParams:
+      currentPage: pyi-triage-desktop-download-app
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "pyi-triage-buffer"
+        }
+
+  - method: POST
+    path: /journey/anotherWay
+    requestHeaders:
+      content-type: "application/json"
+      ipv-session-id:
+        value: "anotherWay"
+        operator: Contains
+    queryParams:
+      currentPage: pyi-triage-desktop-download-app
+    response:
+      statusCode: 200
+      content: |
+        {
+          "page": "page-multiple-doc-check"
         }


### PR DESCRIPTION
…download-app

## Proposed changes
### What changed

- added browser tests for testing links on pyi-triage-desktop-download-app

### Why did it change

- improve test coverage for the link on pyi-triage-desktop-download-app to prevent the bug from re-occuring

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8644](https://govukverify.atlassian.net/browse/PYIC-8644)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8644]: https://govukverify.atlassian.net/browse/PYIC-8644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ