### PR TITLE
PYIC-8624: add FMS tags to core-front load balancers in lower envs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -49,7 +49,12 @@ Conditions:
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
   IsDev02: !Equals [ !Ref AWS::AccountId, "175872367215"]
   IsBuild: !Equals [ !Ref AWS::AccountId, "457601271792"]
+  IsStaging: !Equals [ !Ref AWS::AccountId, "335257547869"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
+  IsDevOrBuildOrStaging: !Or
+    - !Condition IsDevelopment
+    - !Condition IsBuild
+    - !Condition IsStaging
   IsProduction: !Equals [ !Ref Environment, production ]
   IsSubscriptionEnviroment: !Or
     - !Equals [ !Ref Environment, staging ]
@@ -522,6 +527,11 @@ Resources:
           - Key: deletion_protection.enabled
             Value: true
           - !Ref AWS::NoValue
+      Tags:
+        - Key: !If [IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag"]
+          Value: false
+        - Key: !If [IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag"]
+          Value: true
     DependsOn: CoreFrontAccessLogsBucketPolicy
 
   PrivateLoadBalancerListenerTargetGroupECS:
@@ -1384,6 +1394,10 @@ Resources:
           Value: identity
         - Key: Source
           Value: alphagov/di-ipv-core-front/deploy/template.yaml
+        - Key: !If [ IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag" ]
+          Value: false
+        - Key: !If [ IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag" ]
+          Value: true
     Metadata:
       checkov:
         skip:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -528,11 +528,16 @@ Resources:
             Value: true
           - !Ref AWS::NoValue
       Tags:
-        - Key: !If [IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag"]
-          Value: false
-        - Key: !If [IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag"]
-          Value: true
-    DependsOn: CoreFrontAccessLogsBucketPolicy
+        - !If
+          - IsDevOrBuildOrStaging
+          - Key: FMSRegionalPolicy
+            Value: false
+          - !Ref AWS::NoValue
+        - !If
+          - IsDevOrBuildOrStaging
+          - Key: CustomPolicy
+            Value: true
+          - !Ref AWS::NoValue
 
   PrivateLoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1394,9 +1394,9 @@ Resources:
           Value: identity
         - Key: Source
           Value: alphagov/di-ipv-core-front/deploy/template.yaml
-        - Key: !If [ IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag" ]
+        - Key: FMSRegionalPolicy
           Value: false
-        - Key: !If [ IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag" ]
+        - Key: CustomPolicy
           Value: true
     Metadata:
       checkov:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -528,16 +528,11 @@ Resources:
             Value: true
           - !Ref AWS::NoValue
       Tags:
-        - !If
-          - IsDevOrBuildOrStaging
-          - Key: FMSRegionalPolicy
-            Value: false
-          - !Ref AWS::NoValue
-        - !If
-          - IsDevOrBuildOrStaging
-          - Key: CustomPolicy
-            Value: true
-          - !Ref AWS::NoValue
+        - Key: !If [IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag"]
+          Value: false
+        - Key: !If [IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag"]
+          Value: true
+    DependsOn: CoreFrontAccessLogsBucketPolicy
 
   PrivateLoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"


### PR DESCRIPTION
## Proposed changes
### What changed

- add FMS tags to core-front load balancers in lower envs

### Why did it change

- As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8624](https://govukverify.atlassian.net/browse/PYIC-8624)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8624]: https://govukverify.atlassian.net/browse/PYIC-8624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ