### PR TITLE
BAU Use npm ci in GHA workflows

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -43,7 +43,7 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run lint
         run: npm run lint
       - name: Run test and write coverage


### PR DESCRIPTION
## Proposed changes
### What changed

Use `npm ci` in pre-merge GHA workflow

### Why did it change

It's best practice to use `npm ci` over `npm install` in CI/CD (see https://docs.npmjs.com/cli/v10/commands/npm-ci#description)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
