### PR TITLE
PYIC-8675: Add /assets caching

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -105,11 +105,7 @@ app.use(
   "/assets",
   express.static(
     path.resolve("node_modules/govuk-frontend/dist/govuk/assets"),
-    {
-      cacheControl: true,
-      immutable: false,
-      maxAge: "3600s",
-    },
+    { maxAge: "3600s" },
   ),
 );
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -103,7 +103,14 @@ app.use(securityHeadersHandler);
 app.use("/public", express.static(path.resolve("dist/public")));
 app.use(
   "/assets",
-  express.static(path.resolve("node_modules/govuk-frontend/dist/govuk/assets")),
+  express.static(
+    path.resolve("node_modules/govuk-frontend/dist/govuk/assets"),
+    {
+      cacheControl: true,
+      immutable: false,
+      maxAge: "3600s",
+    }
+  ),
 );
 
 app.get("/healthcheck", (req, res) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -109,7 +109,7 @@ app.use(
       cacheControl: true,
       immutable: false,
       maxAge: "3600s",
-    }
+    },
   ),
 );
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Add /assets caching

### Why did it change

- Improve performance

### Issue tracking

- [PYIC-8675](https://govukverify.atlassian.net/browse/PYIC-8675)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8675]: https://govukverify.atlassian.net/browse/PYIC-8675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ