### PR TITLE
Revert "PYIC-8624 Apply FMS tags to FE APIGW up to staging"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1216,11 +1216,6 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-      Tags:
-        - Key: !If [IsDevOrBuildOrStaging, "FMSRegionalPolicy", "aTempTag"]
-          Value: false
-        - Key: !If [IsDevOrBuildOrStaging, "CustomPolicy", "anotherTempTag"]
-          Value: true
 
   RestApiGwDeployment202502241200:
     DependsOn:


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-front#2273

The FE API GW is already in the separate CloudFront CloakingOrigin ACL so these tags do not need applying