### PR TITLE
PYIC-8674: Add backoff on unexpected polling errors

### DIFF
--- a/assets/javascript/app/dcmaw-async.js
+++ b/assets/javascript/app/dcmaw-async.js
@@ -14,11 +14,14 @@ function generatePollApiFunction(url) {
         throw new Error(`Unexpected status: ${data.status}`);
       })
       .catch((error) => {
-        if (error.name !== "AbortError") {
-          console.error("Unexpected error in pollFunction, backing off: ", error);
-          return 3; // Backoff
+        if (error.name === "AbortError") {
+          // If the error is an AbortError then the user is navigating away from the page (probably a refresh) so we
+          // don't want to trigger success or failure methods.
+          return 2; // Pending
         }
-        return 1; // Failure
+
+        console.error("Unexpected error in pollFunction, backing off: ", error);
+        return 3; // Backoff
       });
   }
 }

--- a/assets/javascript/app/dcmaw-async.js
+++ b/assets/javascript/app/dcmaw-async.js
@@ -14,7 +14,8 @@ function generatePollApiFunction(url) {
       })
       .catch((error) => {
         if (error.name !== "AbortError") {
-          console.error("Error in pollFunction:", error);
+          console.error("Unexpected error in pollFunction, backing off: ", error);
+          return 3; // Backoff
         }
         return 1; // Failure
       });

--- a/assets/javascript/app/dcmaw-async.js
+++ b/assets/javascript/app/dcmaw-async.js
@@ -6,11 +6,12 @@ function generatePollApiFunction(url) {
       .then((data) => {
         if (data.status === "COMPLETED") {
           return 0; // Success
-        } else if (data.status === "ERROR") {
-          return 1; // Failure
-        } else {
+        } else if (data.status === "PROCESSING") {
           return 2; // Pending
+        } else if (data.status === "ERROR") {
+          return 3; // Backoff
         }
+        throw new Error(`Unexpected status: ${data.status}`);
       })
       .catch((error) => {
         if (error.name !== "AbortError") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-language-toggle": "2.2.1",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
-        "@govuk-one-login/frontend-ui": "3.0.0",
+        "@govuk-one-login/frontend-ui": "3.1.0",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.12.2",
         "body-parser": "2.2.0",
@@ -1339,9 +1339,9 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-3.0.0.tgz",
-      "integrity": "sha512-aBCjDoSE2lD08RXZMUbPwSoDacOiqDZSi9krMoPeSoJLdUM10aA57nzDkX2TfgYKRwBCXWGhiQiiGUAde/K3Nw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-3.1.0.tgz",
+      "integrity": "sha512-v6d18NXjs4xgrjCQDPo+Ydb04lH/lyRHyHoI44OQPyKkX4gjb6+20oOyTHYeSlelKEk9p3sw2PHyTV5voysrGg==",
       "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-language-toggle": "2.2.1",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
-    "@govuk-one-login/frontend-ui": "3.0.0",
+    "@govuk-one-login/frontend-ui": "3.1.0",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.12.2",
     "body-parser": "2.2.0",

--- a/views/ipv/page/check-mobile-app-result.njk
+++ b/views/ipv/page/check-mobile-app-result.njk
@@ -14,6 +14,7 @@
           data-ms-between-requests="{{msBetweenRequests}}"
           data-ms-before-informing-of-long-wait="{{msBeforeInformingOfLongWait}}"
           data-ms-before-abort="{{msBeforeAbort}}"
+          data-max-backoff-tries="3"
           data-aria-alert-completion-text="{{ 'pages.checkMobileAppResult.content.spinner.ariaButtonEnabledMessage' | translate }}">
       <div id="no-js-content" class="govuk-form-group">
         <p class="govuk-body">{{ 'pages.checkMobileAppResult.content.htmlOnlyVersion.paragraph' | translate }}</p>

--- a/views/ipv/page/pyi-triage-desktop-download-app.njk
+++ b/views/ipv/page/pyi-triage-desktop-download-app.njk
@@ -111,6 +111,7 @@
             data-ms-between-requests="{{msBetweenRequests}}"
             data-ms-before-informing-of-long-wait="{{msBeforeInformingOfLongWait}}"
             data-ms-before-abort="{{msBeforeAbort}}"
+            data-max-backoff-tries="3"
             data-aria-alert-completion-text="{{ 'pages.pyiTriageDesktopDownload.content.spinner.ariaBuariaButtonEnabledMessagettonEnabledMessage' | translate }}">
         <div id="no-js-content">
           {# If JS is disabled don't show anything. #}


### PR DESCRIPTION
DO NOT MERGE UNTIL QA TESTED IN DEV

## Proposed changes
### What changed

Add backoff on unexpected spinner polling errors

### Why did it change

So we don't instantly fail the process if a user loses connectivity or our end point is rate limited

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8674](https://govukverify.atlassian.net/browse/PYIC-8674)

(Frontend changes here: https://github.com/govuk-one-login/govuk-one-login-frontend/pull/283)

[PYIC-8674]: https://govukverify.atlassian.net/browse/PYIC-8674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ