### PR TITLE
INC0015498 Bump max event loop delay in line with Auth FE

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -79,7 +79,7 @@ const protectConfig: ProtectionConfig = {
   production: process.env.NODE_ENV === "production",
   clientRetrySecs: 1,
   sampleInterval: 5,
-  maxEventLoopDelay: 400,
+  maxEventLoopDelay: 700,
   maxHeapUsedBytes: 0,
   maxRssBytes: 0,
   errorPropagationMode: true,


### PR DESCRIPTION
## Proposed changes
### What changed

Bump overload-protection maxEventLoopDelay from 400ms -> 700ms, benchmarking against Auth's frontend

### Why did it change

In recent days our frontend Node app has seen spikes in event loop delay above the 400ms threshold, triggering overload protection and returning `503` errors, which in turn has tripped our `FrontTargetGroup5xxAlarm`. Bumping the event loop delay threshold has trade-offs - overload protection exists to prevent the app from stalling and serving `504` timeouts via the load balancer. However ECS metrics show no signs of CPU pressure (staying below 30%) and ALB access logs show no evidence of `504`s during spikes. Agreed with @huwd it's safe for us to trial an increased threshold, benchmarking against Auth's frontend which has been running stably at 700ms for several months.

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
