### PR TITLE
Revert "BAU: Bump reviewdog/action-actionlint from 1.67.0 to 1.68.0"

### DIFF
--- a/.github/workflows/link-workflows.yaml
+++ b/.github/workflows/link-workflows.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@f00ad0691526c10be4021a91b2510f0a769b14d0 # v1.68.0
+        uses: reviewdog/action-actionlint@95395aac8c053577d0bc67eb7b74936c660c6f66 # v1.67.0
         with:
           reporter: github-pr-check
           fail_level: error


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-front#2294