### PR TITLE
Revert "fix(1016): updated frontend-analytics version to fix status code issue"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-dynamodb": "3.896.0",
         "@aws-sdk/client-ssm": "3.896.0",
         "@govuk-one-login/data-vocab": "1.9.3",
-        "@govuk-one-login/frontend-analytics": "4.0.4",
+        "@govuk-one-login/frontend-analytics": "4.0.3",
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-language-toggle": "2.2.1",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.0",
@@ -1271,9 +1271,9 @@
       "integrity": "sha512-pOwhj9gYkCEci5qRvlXGFT1e/Li250R9+P4kRP9CliEOxTs1GoAJcDUNs60ZKOgSpL24xOQ4NE09uSn6HL5nPw=="
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.4.tgz",
-      "integrity": "sha512-vPYDiya/BioYJxQLlOEiCDUyQjKA4TdlDMgd2q+hpsiFNWJjsJub5wQHEj42y2YvRnmAPbB8osRmD3ABVySncQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.3.tgz",
+      "integrity": "sha512-r/16f7Q5Vf4cjqoLS0V791M2H5+jBEkI7NdMJjUsqlUEwzM/jx+l75jcQkRuoCQnTC2WQ9M6HzOWpNkdOrI7Hg==",
       "license": "MIT",
       "dependencies": {
         "loglevel": "^1.9.2"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@aws-sdk/client-dynamodb": "3.896.0",
     "@aws-sdk/client-ssm": "3.896.0",
     "@govuk-one-login/data-vocab": "1.9.3",
-    "@govuk-one-login/frontend-analytics": "4.0.4",
+    "@govuk-one-login/frontend-analytics": "4.0.3",
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-language-toggle": "2.2.1",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.0",


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-front#2315 as appears to have broken GA4 reporting (page view event is missing and failing a test)