### PR TITLE
BAU ignore readmes in post-merge workflow

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/README.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes
### What changed

add readmes to the post-merge workflow's paths to ignore
-

### Why did it change
eliminate some unnecessary code deployments
-

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
