### PR TITLE
PYIC-8731: Add comment to vpc link resource deployed in dev environment.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1373,7 +1373,8 @@ Resources:
   #
   # Rest api gateway vpc link
   #
-
+  # If deploying through secured pipeline and stack doesn't exist yet, you will need to add temporary permission to core-front deploy Iam Role to create this resource.
+  # This should only happen in shared dev environment if for some reason stack was deleted.
   ApiGatewayVpcLink:
     Condition: IsDevelopment
     DependsOn: NetworkLoadBalancerTargetGroup


### PR DESCRIPTION
## Proposed changes
### What changed

- Add comment to vpc link resource explaining how to deploy it for first time in shared dev env using secured pipeline 

### Why did it change

- Secure Pipeline doesn't have permission to create vpc link resource. It is required to deploy it for the first time.
Solution is to attach this permission manually for first time deployment period.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8731](https://govukverify.atlassian.net/browse/PYIC-8731)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8731]: https://govukverify.atlassian.net/browse/PYIC-8731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ