### PR TITLE
DFC-692 Set GA4 global data sensitivity flag to false in int and prod

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -198,7 +198,7 @@ Mappings:
       may2025RebrandEnabled: true
       alwaysShowBanners: false
       ga4Disabled: false
-      analyticsDataSensitive: true
+      analyticsDataSensitive: false
       uaDisabled: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/952c24127da85c63_complete.js"
       contactUrl: "https://home.integration.account.gov.uk/contact-gov-uk-one-login"
@@ -228,7 +228,7 @@ Mappings:
       alwaysShowBanners: false
       ga4Disabled: false
       uaDisabled: false
-      analyticsDataSensitive: true
+      analyticsDataSensitive: false
       dtRumUrl: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf04188tda/fa56a4b3a9bbea0_complete.js"
       contactUrl: "https://home.account.gov.uk/contact-gov-uk-one-login"
       deleteAccountUrl: "https://home.account.gov.uk/enter-password?type=deleteAccount"


### PR DESCRIPTION
## Proposed changes
### What changed

- Set GA4 global data sensitivity flag to false in int and prod

### Why did it change

- D&A have completed their testing in staging and are happy for us to apply the same to int and prod, completing the GA4 upgrade

