### PR TITLE
PYIC-8770: remediate core-front rule 'ecs-containers-readonly-access'

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -786,6 +786,7 @@ Resources:
         - Essential: true
           Image: CONTAINER-IMAGE-PLACEHOLDER
           Name: app
+          ReadonlyRootFilesystem: true
           Environment:
             - Name: API_BASE_URL
               Value: !Sub


### PR DESCRIPTION
## Proposed changes
### What changed

- remediate core-front rule 'ecs-containers-readonly-access'

### Why did it change

- In core-front we’re failing ecs-containers-readonly-access - AWS Config - ECS containers should only have read access to their root file systems. Set readonlyRootFilesystem to true on our ECS task definition AWS::ECS::TaskDefinition

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8770](https://govukverify.atlassian.net/browse/PYIC-8770)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8770]: https://govukverify.atlassian.net/browse/PYIC-8770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ