### PR TITLE
PYIC-8778: Remove unused published-did-documents bucket and switch all envs to SPOT DID source

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1313,6 +1313,11 @@ Resources:
   ApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Metadata:
+      # Ignore W1001 (conditional Ref) – both deployment resources are mutually exclusive and safely handled by CloudFormation.
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1001
       checkov:
         skip:
           - id: "CKV_AWS_120"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,11 +51,14 @@ Conditions:
   IsBuild: !Equals [ !Ref AWS::AccountId, "457601271792"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, production ]
-  IsSubscriptionEnvironment: !Or
+  IsStagingIntProd: !Or
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
-  IsNotSubscriptionEnvironment: !Not [ !Condition IsSubscriptionEnvironment ]
+  IsDevOrBuild: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, dev01 ]
+    - !Equals [ !Ref Environment, dev02 ]
   UsePermissionsBoundary: !Not
     - !Equals [ !Ref PermissionsBoundary, "none" ]
   UseCodeSigning: !Not
@@ -294,12 +297,13 @@ Resources:
     Type: AWS::ApiGatewayV2::ApiMapping
     Condition: IsDevelopment
     Metadata:
+      # Ignore E3005 (linter thinks dependency may not exist) and W1001 (ref may be missing under conditions) - Both safe since they are only created in dev
       cfn-lint:
         config:
           ignore_checks:
             - E3005
             - W1001
-    DependsOn: RestApiGwDeployment202502241200NonSub
+    DependsOn: RestApiGwDeploymentWithoutDidEndpoint202511111337
     Properties:
       DomainName: !Ref DevApiDomain
       ApiId: !Ref RestApiGateway
@@ -733,7 +737,7 @@ Resources:
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnvironment
+    Condition: IsStagingIntProd
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
@@ -1078,7 +1082,7 @@ Resources:
         - !Ref AWS::NoValue
 
   RestDidDocumentResourceS3Role:
-    Condition: IsSubscriptionEnvironment
+    Condition: IsStagingIntProd
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -1169,26 +1173,26 @@ Resources:
         Types:
           - REGIONAL
 
-  # For environments that have the DID document (staging, integration, production)
-  RestApiGwDeployment202502241200Sub:
-    Condition: IsSubscriptionEnvironment
+  # For environments that host SPOT's DID endpoint (staging, integration, production)
+  RestApiGwDeploymentWithDidEndpoint202511111337:
+    Condition: IsStagingIntProd
     DependsOn:
       - RestApiGatewayMethod
       - RestDidDocumentMethod
     Type: AWS::ApiGateway::Deployment
     Properties:
       RestApiId: !Ref RestApiGateway
-      Description: "Deployment including DID document for subscription environments"
+      Description: "Deployment including SPOT's DID endpoint for staging, integration, and production environments"
 
-  # For dev/build environments that don’t have the DID document
-  RestApiGwDeployment202502241200NonSub:
-    Condition: IsNotSubscriptionEnvironment
+  # For dev/build environments that don’t host SPOTS's DID endpoint (dev01, dev02, build)
+  RestApiGwDeploymentWithoutDidEndpoint202511111337:
+    Condition: IsDevOrBuild
     DependsOn:
       - RestApiGatewayMethod
     Type: AWS::ApiGateway::Deployment
     Properties:
       RestApiId: !Ref RestApiGateway
-      Description: "Deployment without DID document for non-subscription environments"
+      Description: "Deployment without SPOT's DID endpoint for development and build environments"
 
   RestApiGatewayMethod:
     Type: AWS::ApiGateway::Method
@@ -1248,7 +1252,7 @@ Resources:
       PathPart: "did.json"
 
   RestDidDocumentMethod:
-    Condition: IsSubscriptionEnvironment
+    Condition: IsStagingIntProd
     Type: AWS::ApiGateway::Method
     Metadata:
       checkov:
@@ -1300,7 +1304,7 @@ Resources:
 
   RestApiGatewayAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnvironment
+    Condition: IsStagingIntProd
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
@@ -1316,9 +1320,9 @@ Resources:
     Properties:
       StageName: !Sub ${Environment}
       DeploymentId: !If
-        - IsSubscriptionEnvironment
-        - !Ref RestApiGwDeployment202502241200Sub
-        - !Ref RestApiGwDeployment202502241200NonSub
+        - IsStagingIntProd
+        - !Ref RestApiGwDeploymentWithDidEndpoint202511111337
+        - !Ref RestApiGwDeploymentWithoutDidEndpoint202511111337
       RestApiId: !Ref RestApiGateway
       AccessLogSetting:
         DestinationArn: !GetAtt RestApiGatewayAccessLogsGroup.Arn
@@ -1480,7 +1484,7 @@ Resources:
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnvironment
+    Condition: IsStagingIntProd
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,6 +55,7 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsNotSubscriptionEnvironment: !Not [ !Condition IsSubscriptionEnvironment ]
   UsePermissionsBoundary: !Not
     - !Equals [ !Ref PermissionsBoundary, "none" ]
   UseCodeSigning: !Not
@@ -292,12 +293,17 @@ Resources:
   DevApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
     Condition: IsDevelopment
-    DependsOn: RestApiGwDeployment202502241200
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3005
+            - W1001
+    DependsOn: RestApiGwDeployment202502241200NonSub
     Properties:
       DomainName: !Ref DevApiDomain
       ApiId: !Ref RestApiGateway
       Stage: !Ref ApiGatewayStage
-
 
   # dns rcord
   DevDNSRecord:
@@ -1163,14 +1169,26 @@ Resources:
         Types:
           - REGIONAL
 
-  RestApiGwDeployment202502241200:
+  # For environments that have the DID document (staging, integration, production)
+  RestApiGwDeployment202502241200Sub:
+    Condition: IsSubscriptionEnvironment
     DependsOn:
       - RestApiGatewayMethod
-      - !If
-        - IsSubscriptionEnvironment
-        - RestDidDocumentMethod
-        - !Ref AWS::NoValue
+      - RestDidDocumentMethod
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId: !Ref RestApiGateway
+      Description: "Deployment including DID document for subscription environments"
 
+  # For dev/build environments that don’t have the DID document
+  RestApiGwDeployment202502241200NonSub:
+    Condition: IsNotSubscriptionEnvironment
+    DependsOn:
+      - RestApiGatewayMethod
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId: !Ref RestApiGateway
+      Description: "Deployment without DID document for non-subscription environments"
 
   RestApiGatewayMethod:
     Type: AWS::ApiGateway::Method
@@ -1297,7 +1315,10 @@ Resources:
             comment: "API should have caching - not for our use case"
     Properties:
       StageName: !Sub ${Environment}
-      DeploymentId: !Ref RestApiGwDeployment202502241200
+      DeploymentId: !If
+        - IsSubscriptionEnvironment
+        - !Ref RestApiGwDeployment202502241200Sub
+        - !Ref RestApiGwDeployment202502241200NonSub
       RestApiId: !Ref RestApiGateway
       AccessLogSetting:
         DestinationArn: !GetAtt RestApiGatewayAccessLogsGroup.Arn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -411,52 +411,6 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
 
-  SpotKeysS3Bucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub published-did-documents-${Environment}
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              KMSMasterKeyID: !GetAtt S3KmsKey.Arn
-              SSEAlgorithm: "aws:kms"
-      VersioningConfiguration:
-        Status: "Enabled"
-      LoggingConfiguration:
-        DestinationBucketName: !Ref AccessLogsBucket
-        LogFilePrefix: spot-signing-keys
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        IgnorePublicAcls: true
-        BlockPublicPolicy: true
-        RestrictPublicBuckets: true
-
-  SpotKeysBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref SpotKeysS3Bucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowAccountAccess
-            Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - "s3:*"
-            Resource: !Sub "arn:aws:s3:::${SpotKeysS3Bucket}/*"
-          - Sid: AllowSpotAccountAccess
-            Effect: Allow
-            Principal:
-              AWS: !FindInMap
-                - EnvironmentConfiguration
-                - !Ref AWS::AccountId
-                - spotAccountArn
-            Action:
-              - "s3:PutObject"
-              - "s3:GetObject"
-            Resource: !Sub "arn:aws:s3:::${SpotKeysS3Bucket}/*"
-
   CoreFrontAccessLogsBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -1135,12 +1089,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - "s3:GetObject"
-                Resource: !Sub
-                  - "arn:aws:s3:::${BucketName}/did.json"
-                  - BucketName: !If
-                      - IsSubscriptionEnviroment
-                      - !Sub "govuk-one-login-spot-published-keys-${Environment}"
-                      - !Sub "published-did-documents-${Environment}"
+                Resource: !Sub "arn:aws:s3:::govuk-one-login-spot-published-keys-${Environment}/did.json"
               - Effect: Allow
                 Action:
                   - "kms:Decrypt"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,7 +51,7 @@ Conditions:
   IsBuild: !Equals [ !Ref AWS::AccountId, "457601271792"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, production ]
-  IsSubscriptionEnviroment: !Or
+  IsSubscriptionEnvironment: !Or
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
@@ -727,7 +727,7 @@ Resources:
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnviroment
+    Condition: IsSubscriptionEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
@@ -1072,6 +1072,7 @@ Resources:
         - !Ref AWS::NoValue
 
   RestDidDocumentResourceS3Role:
+    Condition: IsSubscriptionEnvironment
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -1165,10 +1166,11 @@ Resources:
   RestApiGwDeployment202502241200:
     DependsOn:
       - RestApiGatewayMethod
-      - RestDidDocumentMethod
-    Type: AWS::ApiGateway::Deployment
-    Properties:
-      RestApiId: !Ref RestApiGateway
+      - !If
+        - IsSubscriptionEnvironment
+        - RestDidDocumentMethod
+        - !Ref AWS::NoValue
+
 
   RestApiGatewayMethod:
     Type: AWS::ApiGateway::Method
@@ -1228,6 +1230,7 @@ Resources:
       PathPart: "did.json"
 
   RestDidDocumentMethod:
+    Condition: IsSubscriptionEnvironment
     Type: AWS::ApiGateway::Method
     Metadata:
       checkov:
@@ -1250,10 +1253,7 @@ Resources:
       Integration:
         Type: AWS
         IntegrationHttpMethod: GET
-        Uri: !If
-           - IsSubscriptionEnviroment
-           - !Sub "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-spot-published-keys-${Environment}/did.json"
-           - !Sub "arn:aws:apigateway:${AWS::Region}:s3:path/published-did-documents-${Environment}/did.json"
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-spot-published-keys-${Environment}/did.json"
         Credentials: !GetAtt RestDidDocumentResourceS3Role.Arn
         PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
@@ -1282,7 +1282,7 @@ Resources:
 
   RestApiGatewayAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnviroment
+    Condition: IsSubscriptionEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
@@ -1459,7 +1459,7 @@ Resources:
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsSubscriptionEnviroment
+    Condition: IsSubscriptionEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""


### PR DESCRIPTION


## Proposed changes
### What changed

- Deleted SpotKeysS3Bucket and SpotKeysBucketPolicy resources referencing published-did-documents-* 
- Updated RestDidDocumentResourceS3Role to always reference govuk-one-login-spot-published-keys-${Environment}/did.json 
- Removed conditional logic and references to the deprecated DID bucket

### Why did it change

- The following bucket has been flagged for infringing ‘s3-bucket-ssl-requests-only': published-did-documents-production, because the bucket does not have an SSL deny policy in place.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8777](https://govukverify.atlassian.net/browse/PYIC-8777)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8777]: https://govukverify.atlassian.net/browse/PYIC-8777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ