### PR TITLE
PYIC-8793: add visual regression check type to quality gate manifest

### DIFF
--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -32,7 +32,8 @@
         {
           "check-types": [
             "regression",
-            "new feature"
+            "new feature",
+            "visual regression"
           ],
           "config": {
             "file": ".github/workflows/pre-merge-checks.yaml",


### PR DESCRIPTION
## Proposed changes
### What changed

- add visual regression check type to quality gate manifest

### Why did it change

- When the [schema](https://github.com/govuk-one-login/quality-gates/blob/main/schemas/schema.json) has been updated, we can tag our browser tests for accurately with the new check-type value

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8793](https://govukverify.atlassian.net/browse/PYIC-8793)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8793]: https://govukverify.atlassian.net/browse/PYIC-8793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ