### PR TITLE
PYIC-8731: Switch off the "alwaysShowBanner" env variable in dev01.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -80,7 +80,7 @@ Mappings:
       languageToggle: true
       useDeviceIntelligence: true
       may2025RebrandEnabled: true
-      alwaysShowBanners: true
+      alwaysShowBanners: false
       ga4Disabled: false
       analyticsDataSensitive: false
       uaDisabled: false


### PR DESCRIPTION
## Proposed changes
### What changed

- alwaysShowBanner env variable switched to false in dev01

### Why did it change

- It cause failing E2E tests in shared dev env

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8731](https://govukverify.atlassian.net/browse/PYIC-8731)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8731]: https://govukverify.atlassian.net/browse/PYIC-8731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ