### PR TITLE
PYIC-8804: resolve glob vulnerability issue introduced via mocha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7559,9 +7559,9 @@
       }
     },
     "node_modules/mocha/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Proposed changes
### What changed

- upgrade glob to non vulnerable version 10.5.0

### Why did it change

- glob versions 10.2.0 <= v < 10.5.0 introduced injection vulnerabilities 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8804](https://govukverify.atlassian.net/browse/PYIC-8804)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8804]: https://govukverify.atlassian.net/browse/PYIC-8804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ