### PR TITLE
PYIC-8800: updates to the sorry-technical-problem screen

### DIFF
--- a/locales/cy/translation.json
+++ b/locales/cy/translation.json
@@ -1529,6 +1529,7 @@
           "postOfficeHintKbvCriError": "Byddwch yn rhoi rhywfaint o fanylion ar GOV.UK yn gyntaf.",
           "webRoute": "Profi eich hunaniaeth trwy ateb rhai cwestiynau diogelwch",
           "webRouteHint": "Bydd angen i chi roi manylion o’ch pasbort y DU neu drwydded yrru cerdyn llun y DU yn gyntaf.",
+          "webRouteHintF2fCriError": "Bydd angen i chi roi manylion o’ch pasbort y DU neu drwydded yrru cerdyn llun y DU yn gyntaf.",
           "returnToRp": "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio i ddarganfod a oes ffyrdd eraill o gael mynediad ato"
         },
         "formErrorMessage": {

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1529,6 +1529,7 @@
           "postOfficeHintKbvCriError": "You’ll enter some details on GOV.UK first.",
           "webRoute": "Prove your identity by answering some security questions",
           "webRouteHint": "You’ll enter details from your UK passport or UK photocard driving licence first.",
+          "webRouteHintF2fCriError": "You’ll enter details from your UK passport or UK photocard driving licence first.",
           "returnToRp": "Go back to the service you were trying to use to find out if there are other ways to access it"
         },
         "formErrorMessage": {

--- a/views/ipv/page/sorry-technical-problem.njk
+++ b/views/ipv/page/sorry-technical-problem.njk
@@ -74,7 +74,7 @@
                 {
                     value: "webRoute",
                     text: 'pages.sorryTechnicalProblem.content.formRadioButtons.webRoute' | translate,
-                    hint: { text: 'pages.sorryTechnicalProblem.content.formRadioButtons.webRouteHint' | translate }
+                    hint: { text: 'pages.sorryTechnicalProblem.content.formRadioButtons.webRouteHint' | translateWithContext(context) }
                 },
                 {
                     divider: "or"


### PR DESCRIPTION
## Proposed changes
### What changed

- Updates to the sorry-technical-problem screen

### Why did it change

- We have new error screens and routing for handling unexpected outages for the Passport, Driving Licence, KBV and F2F CRIs. However, the current routing allows for users to go down unnecessary routes when on a mitigation journey.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8800](https://govukverify.atlassian.net/browse/PYIC-8800)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8800]: https://govukverify.atlassian.net/browse/PYIC-8800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ