### PR TITLE
PYIC-8798: Return 400 to the user on expired IPV Session in spinner pages.

### DIFF
--- a/assets/javascript/app/dcmaw-async.js
+++ b/assets/javascript/app/dcmaw-async.js
@@ -8,7 +8,9 @@ function generatePollApiFunction(url) {
           return 0; // Success
         } else if (data.status === "PROCESSING") {
           return 2; // Pending
-        } else if (data.status === "ERROR") {
+        } else if (data.status === "SERVER_ERROR") {
+          return 3; // Backoff
+        } else if (data.status === "CLIENT_ERROR") {
           return 3; // Backoff
         }
         throw new Error(`Unexpected status: ${data.status}`);

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -8,8 +8,8 @@ import fs from "fs";
 import path from "path";
 import { saveSessionAndRedirect } from "../shared/redirectHelper";
 import {
-  postJourneyEvent,
   getProvenIdentityUserDetails,
+  postJourneyEvent,
 } from "../../services/coreBackService";
 import { generateQrCodeImageData } from "../shared/qrCodeHelper";
 import { PHONE_TYPE } from "../../constants/device-constants";
@@ -21,16 +21,16 @@ import {
 } from "../../constants/update-details-journeys";
 import { getAppStoreRedirectUrl } from "../shared/appDownloadHelper";
 import {
-  getIpvPageTemplatePath,
   getIpvPagePath,
+  getIpvPageTemplatePath,
   getTemplatePath,
 } from "../../lib/paths";
 import PAGES from "../../constants/ipv-pages";
 import { getPhoneType } from "../shared/contextHelper";
 import {
-  sniffPhoneType,
   detectAppTriageEvent,
   OsType,
+  sniffPhoneType,
 } from "../shared/deviceSniffingHelper";
 import {
   isClientResponse,
@@ -453,8 +453,10 @@ export const checkVcReceiptStatus: RequestHandler = async (req, res, next) => {
   const status = await getAppVcReceiptStatusAndStoreJourneyResponse(req);
   if (status === AppVcReceiptStatus.PROCESSING) {
     await handleJourneyPageRequest(req, res, next, true);
-  } else if (status === AppVcReceiptStatus.ERROR) {
+  } else if (status === AppVcReceiptStatus.SERVER_ERROR) {
     throw new Error("Failed to get VC response status");
+  } else if (status === AppVcReceiptStatus.CLIENT_ERROR) {
+    throw new Error("Failed to get VC response status")
   } else if (status === AppVcReceiptStatus.COMPLETED) {
     return next();
   }

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -456,7 +456,7 @@ export const checkVcReceiptStatus: RequestHandler = async (req, res, next) => {
   } else if (status === AppVcReceiptStatus.SERVER_ERROR) {
     throw new Error("Failed to get VC response status");
   } else if (status === AppVcReceiptStatus.CLIENT_ERROR) {
-    throw new Error("Failed to get VC response status")
+    throw new Error("Failed to get VC response status");
   } else if (status === AppVcReceiptStatus.COMPLETED) {
     return next();
   }

--- a/src/app/ipv/tests/checkVcReceiptStatus.test.ts
+++ b/src/app/ipv/tests/checkVcReceiptStatus.test.ts
@@ -68,7 +68,26 @@ describe("checkVcReceiptStatus middleware", () => {
     // Arrange
     const req = createRequest();
     const res = createResponse();
-    getAppVcReceiptStatusAndStoreJourneyResponseStub.resolves("ERROR");
+    getAppVcReceiptStatusAndStoreJourneyResponseStub.resolves("SERVER_ERROR");
+
+    // Act & Assert
+    await expect(
+      (async () => await checkVcReceiptStatus(req, res, next))(),
+    ).to.be.rejectedWith(Error, "Failed to get VC response status");
+
+    // Assert
+    expect(
+      getAppVcReceiptStatusAndStoreJourneyResponseStub,
+    ).to.have.been.calledWith(req);
+    expect(res.render).to.not.have.been.called;
+    expect(next).to.have.not.been.calledOnce;
+  });
+
+  it("should throw client error if status is CLIENT_ERROR", async () => {
+    // Arrange
+    const req = createRequest();
+    const res = createResponse();
+    getAppVcReceiptStatusAndStoreJourneyResponseStub.resolves("CLIENT_ERROR");
 
     // Act & Assert
     await expect(

--- a/src/app/ipv/tests/checkVcReceiptStatus.test.ts
+++ b/src/app/ipv/tests/checkVcReceiptStatus.test.ts
@@ -64,7 +64,7 @@ describe("checkVcReceiptStatus middleware", () => {
     expect(next).to.have.not.been.calledOnce;
   });
 
-  it("should throw error if status is ERROR", async () => {
+  it("should throw error if status is SERVER_ERROR", async () => {
     // Arrange
     const req = createRequest();
     const res = createResponse();

--- a/src/app/vc-receipt-status/middleware.test.ts
+++ b/src/app/vc-receipt-status/middleware.test.ts
@@ -66,6 +66,16 @@ describe("vc receipt status middleware tests", () => {
     expect((req.session as any).journey).to.equal("journey/next");
   });
 
+  it("pollVcReceiptStatus should return CLIENT_ERROR status if appVcReceived returns 400", async () => {
+    const error = { response: { status: 400 } };
+    appVcReceivedStub.rejects(error);
+
+    await middleware.pollVcReceiptStatus(req as Request, res as Response, next);
+
+    expect(res.status).to.have.been.calledWith(400);
+    expect(res.json).to.have.been.calledWith({ status: "CLIENT_ERROR" });
+  });
+
   it("pollVcReceiptStatus should return an error when appVcReceived does not return journey response", async () => {
     appVcReceivedStub.resolves({ data: {} });
     isJourneyResponse.returns(false);
@@ -73,17 +83,17 @@ describe("vc receipt status middleware tests", () => {
     await middleware.pollVcReceiptStatus(req as Request, res as Response, next);
 
     expect(res.status).to.have.been.calledWith(500);
-    expect(res.json).to.have.been.calledWith({ status: "ERROR" });
+    expect(res.json).to.have.been.calledWith({ status: "SERVER_ERROR" });
   });
 
-  it("pollVcReceiptStatus should return ERROR status if appVcReceived throws non 404 error", async () => {
+  it("pollVcReceiptStatus should return SERVER_ERROR status if appVcReceived throws non 400-499 error", async () => {
     const error = new Error("Test error");
     appVcReceivedStub.rejects(error);
 
     await middleware.pollVcReceiptStatus(req as Request, res as Response, next);
 
     expect(res.status).to.have.been.calledWith(500);
-    expect(res.json).to.have.been.calledWith({ status: "ERROR" });
+    expect(res.json).to.have.been.calledWith({ status: "SERVER_ERROR" });
   });
 
   it("pollVcReceiptStatus should return COMPLETED status when query param snapshotTest is true", async () => {

--- a/src/app/vc-receipt-status/middleware.ts
+++ b/src/app/vc-receipt-status/middleware.ts
@@ -69,6 +69,7 @@ export const pollVcReceiptStatus: RequestHandler = async (req, res) => {
 
   if(status === AppVcReceiptStatus.CLIENT_ERROR) {
     res.status(400).json({ status })
+    return;
   }
 
   res.status(200).json({ status });

--- a/src/app/vc-receipt-status/middleware.ts
+++ b/src/app/vc-receipt-status/middleware.ts
@@ -10,7 +10,7 @@ export enum AppVcReceiptStatus {
   COMPLETED = "COMPLETED",
   PROCESSING = "PROCESSING",
   CLIENT_ERROR = "CLIENT_ERROR",
-  SERVER_ERROR = "SERVER_ERROR"
+  SERVER_ERROR = "SERVER_ERROR",
 }
 
 export const getAppVcReceiptStatusAndStoreJourneyResponse = async (
@@ -29,7 +29,7 @@ export const getAppVcReceiptStatusAndStoreJourneyResponse = async (
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 404) {
       return AppVcReceiptStatus.PROCESSING;
-    } else if( isAxiosError(error) && isClientError(error.response?.status)) {
+    } else if (isAxiosError(error) && isClientError(error.response?.status)) {
       return AppVcReceiptStatus.CLIENT_ERROR;
     }
     logger.error(error, "Error getting app vc receipt status");
@@ -38,11 +38,11 @@ export const getAppVcReceiptStatusAndStoreJourneyResponse = async (
 };
 
 const isClientError = (error: number | undefined): boolean => {
-  if(!error) {
+  if (!error) {
     return false;
   }
   return error >= 400 && error <= 499;
-}
+};
 
 export const pollVcReceiptStatus: RequestHandler = async (req, res) => {
   const isPreview = config.ENABLE_PREVIEW && req.query.preview === "true";
@@ -67,8 +67,8 @@ export const pollVcReceiptStatus: RequestHandler = async (req, res) => {
     return;
   }
 
-  if(status === AppVcReceiptStatus.CLIENT_ERROR) {
-    res.status(400).json({ status })
+  if (status === AppVcReceiptStatus.CLIENT_ERROR) {
+    res.status(400).json({ status });
     return;
   }
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Added logic that return 400 to the client when IPV session expire during polling calls. 

### Why did it change

- Even if lambda returns 400, core-front translate it to 500 which is inaccurate and perhaps may trigger alarms.

Background:
Trust & Reuse have reported seeing a daily number of EVCS ‘get VCs’ requests using an expired access token which they reject with a 401 response (apparently it also triggers some alarms on their side). We believe the vast majority if not all of these requests are coming from the check-mobile-app-vc-receipt lambda which the frontend v2 app polling calls to check if an app VC has been received yet or not. It seems, perhaps from users abandoning the journey at the app polling pages, that calls are being made beyond the 1 hour expiry of the EVCS access token (which Orch sends us at the start of a journey). 

Currently the only place we explicitly check our (IPV) session expiry (also 1 hour) is in the journey engine when transitioning between states. The actual session item in DynamoDB has a longer TTL of 24 hours.

We should add a check in the check-mobile-app-vc-receipt lambda to reject requests (with a 400 error) where the user's IPV session has expired. In turn this should drastically reduce, hopefully diminish calls to EVCS being made with an expired access token.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8798](https://govukverify.atlassian.net/browse/PYIC-8798)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8798]: https://govukverify.atlassian.net/browse/PYIC-8798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ