### PR TITLE
PYIC-8825: Disable NPM scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ typings/
 .env.test
 
 # npmrc file containing access token
-.npmrc
+/.npmrc
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,3 +1,4 @@
+ignore-scripts=true
 save-exact=true
 engine-strict=true
 ; Some govuk-one-login packages are currently not being published to github.com and return E404. To update those packages you need to comment out the line below, update the package and then re-instate the line.

--- a/browser-tests/.npmrc
+++ b/browser-tests/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/browser-tests/Dockerfile
+++ b/browser-tests/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/playwright:v1.56.1-jammy AS playwright
 
 WORKDIR /browser-tests
 
-COPY ./browser-tests/package.json ./browser-tests/package-lock.json ./
+COPY ./browser-tests/package.json ./browser-tests/package-lock.json ./browser-tests/.npmrc ./
 
 RUN npm install
 

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.21.1-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885
 ENV PORT 4501
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 RUN npm install
 COPY . ./
 RUN npm run build


### PR DESCRIPTION
There have been a couple of recent attacks where npm pre and post install scripts have been used to infect machines

## Proposed changes
### What changed

Disable NPM scripts

### Why did it change

So they can't be use to infect dev or build machines

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8825](https://govukverify.atlassian.net/browse/PYIC-8825)



[PYIC-8825]: https://govukverify.atlassian.net/browse/PYIC-8825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ