### PR TITLE
PYIC-8815: remove use of cfenv library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.13.2",
         "body-parser": "2.2.0",
-        "cfenv": "1.2.4",
         "connect-dynamodb": "3.0.5",
         "cookie-parser": "1.4.7",
         "copyfiles": "2.4.1",
@@ -42,7 +41,6 @@
       },
       "devDependencies": {
         "@eslint/js": "9.39.1",
-        "@types/cfenv": "1.2.4",
         "@types/chai": "4.3.20",
         "@types/chai-as-promised": "7.1.8",
         "@types/cookie-parser": "1.4.8",
@@ -3148,13 +3146,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cfenv": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/cfenv/-/cfenv-1.2.4.tgz",
-      "integrity": "sha512-f6dsHRp+WWIby8qSfdXWQPyamrI83xrNXeZsUDZROytNl/Pti49BVR+NrblJg0VxCoqM5qx9jLhvklFsV/baPw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/chai": {
       "version": "4.3.20",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
@@ -4557,17 +4548,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/cfenv": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/cfenv/-/cfenv-1.2.4.tgz",
-      "integrity": "sha512-jWQ+3UXZauYyOXwHpMm74C0wM7+LDQmgMxWBGchg4as7+YyTL0pyx/CZ3dEvJyZVOB4SgKATc5naJky6cd9zYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "js-yaml": "4.0.x",
-        "ports": "1.1.x",
-        "underscore": "1.12.x"
-      }
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -7068,18 +7048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8527,12 +8495,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/ports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ports/-/ports-1.1.0.tgz",
-      "integrity": "sha512-XmS7dspHnkTXZC75NkG0ti2hLj8aSyg1Izp87/2cWT7QhTo1vdtWsQ4ldp4BEQ/EXqy0s4yTATJUZ3t9RGZVpg==",
-      "license": "Apache 2.0"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -10436,12 +10398,6 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/alphagov/di-ipv-core-front#readme",
   "devDependencies": {
     "@eslint/js": "9.39.1",
-    "@types/cfenv": "1.2.4",
     "@types/chai": "4.3.20",
     "@types/chai-as-promised": "7.1.8",
     "@types/cookie-parser": "1.4.8",
@@ -88,7 +87,6 @@
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.13.2",
     "body-parser": "2.2.0",
-    "cfenv": "1.2.4",
     "connect-dynamodb": "3.0.5",
     "cookie-parser": "1.4.7",
     "copyfiles": "2.4.1",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,16 +1,9 @@
-import cfenv from "cfenv";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const appEnv = cfenv.getAppEnv();
-const coreBackApiUrl = appEnv.isLocal
-  ? undefined
-  : appEnv.getServiceURL("core-back-api");
-
 export default {
-  API_BASE_URL:
-    coreBackApiUrl ?? process.env.API_BASE_URL ?? "http://localhost:4502",
+  API_BASE_URL: process.env.API_BASE_URL ?? "http://localhost:4502",
   API_CRI_CALLBACK: "/cri/callback",
   API_MOBILE_APP_CALLBACK: "/app/callback",
   API_JOURNEY_EVENT: "/journey",


### PR DESCRIPTION
## Proposed changes
### What changed

- remove use of cfenv library

### Why did it change

- cfenv is being used to parse CloudFoundry environment variables to get core-back's api url. However, this package is not well maintained (the last update was 5 years ago) and is depending directly on a vulnerable version of js-yaml. To resolve this vulnerability, we can get rid of cfenv as we're no longer use CloudFoundry and don't need to parse its environment variables (we pass environment variables into our container via our cloudformation template).

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8815](https://govukverify.atlassian.net/browse/PYIC-8815)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8815]: https://govukverify.atlassian.net/browse/PYIC-8815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ