### PR TITLE
PYIC-8845: Add relevant paths to path-ignore in secure-post-merge GHA.

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.test.ts'
       - 'browser-tests/**'
       - 'dev-deploy/**'
+      - 'src/test-utils/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -4,7 +4,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/README.md'
+      - '**/*.md'
+      - '**/*.test.ts'
+      - 'browser-tests/**'
+      - 'dev-deploy/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes
### What changed

- Add to path-ignore to GHA (secure-post-merge.yml):
     - '\*\*/\*.md'
     - '\*\*/\*.test.ts'
     - 'browser-tests/\*\*'
     - 'dev-deploy/\*\*'
     - 'src/test-utils/\*\*'


### Why did it change

- To avoid unnecessary core-front deployment.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8845](https://govukverify.atlassian.net/browse/PYIC-8845)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8845]: https://govukverify.atlassian.net/browse/PYIC-8845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ