### PR TITLE
PYIC-8793: Add visual regression type to browser tests

### DIFF
--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.1.0/schemas/schema.json",
+  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.2.0/schemas/schema.json",
   "services": [
     {
       "quality-gates": [
@@ -31,8 +31,9 @@
         },
         {
           "check-types": [
+            "new feature",
             "regression",
-            "new feature"
+            "visual regression"
           ],
           "config": {
             "file": ".github/workflows/pre-merge-checks.yaml",


### PR DESCRIPTION
It's a new type that has been added recently. Also put the existing types into alphabetical order

## Proposed changes
### What changed

Add "visual regression" test type to browser tests

### Why did it change

The type has been added recently to the allowed values.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8793](https://govukverify.atlassian.net/browse/PYIC-8793)


[PYIC-8793]: https://govukverify.atlassian.net/browse/PYIC-8793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ