### PR TITLE
INC0016299 Bump ELB 5xx alarm threshold

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -226,7 +226,7 @@ Mappings:
       dadSpinnerRequestTimeout: 1800000
       frontendAutoScalingMinCount: 4
     "075701497069": # Production
-      lb500ErrorLimit: 2
+      lb500ErrorLimit: 10
       lb500ErrorWindow: 300
       tg500ErrorLimit: 300
       tg500ErrorWindow: 300


### PR DESCRIPTION
## Proposed changes
### What changed

Bump LB error limit from 2 to 10 (10 or more 5xx errors over 2 consecutive 5-minute windows)

### Why did it change

We are seeing a trickle of 502s with prod traffic which we are investigating, but the current noisiness of this alarm is not helpful

### Issue tracking
- [INC0016299](https://onelogingovuk.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D5921949283b53a10510344547daad390%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
