### PR TITLE
INC0016299 Set headersTimeout value greater than keepAliveTimeout

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -252,6 +252,9 @@ if (process.env.NODE_ENV !== "local") {
 // to prevent possible 502 errors where the target connection has already been closed
 // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues
 server.keepAliveTimeout = 65000;
+// It's also recommended to make the headers timeout (default 60s) longer than the keep-alive duration
+// See https://github.com/nodejs/node/issues/27363
+server.headersTimeout = 66000;
 
 process.on("SIGTERM", () => {
   logger.debug("SIGTERM signal received: closing HTTP server");


### PR DESCRIPTION
## Proposed changes
### What changed

Set headersTimeout value greater than keepAliveTimeout

### Why did it change

We've been seeing a handful of 502s from our ALB. The root cause is unclear but I've discovered a Node issue which suggests setting the Node headersTimeout value greater than the keepAliveTimeout to prevent a possible ALB 502 race condition.

Node enforces a default headersTimeout of 60000ms. We manually set keepAliveTimeout to 65000ms to handle ALB idle timeouts. This creates a 5-second window (60s-65s) where the ALB considers a connection valid but Node has internally marked it for destruction. If a request arrives in this window, Node resets the connection causing a 502.

See https://github.com/nodejs/node/issues/27363.

### Issue tracking
- INC0016299

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
