### PR TITLE
bau: Add missing await key word.

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -422,7 +422,7 @@ export const handleCrossBrowserJourneyActionRequest: RequestHandler = async (
   }
   // We return directly to the Oauth client when continuing from
   // the problem-different-browser page
-  return processAction(req, res, BUILD_CLIENT_OAUTH_RESPONSE_ACTION, pageId);
+  await processAction(req, res, BUILD_CLIENT_OAUTH_RESPONSE_ACTION, pageId);
 };
 
 export const handleJourneyActionRequest: RequestHandler = async (req, res) => {


### PR DESCRIPTION
## Proposed changes
### What changed

- Added missing await to wait for backend response

### Why did it change
Over the last three days, we have observed an increased number of 502 errors returned from the ALB. An analysis of CloudWatch logs shows that all affected requests originate from core-front and report the same error message:

`
Error: Unrecognised response type received from core-back: {"errorMessage":"Missing ipv session id header","errorCode":1010,"statusCode":400}
at handleBackendResponse (/app/src/app/ipv/middleware.ts:157:9)
at processAction (/app/src/app/ipv/middleware.ts:100:37)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
`

These errors started appearing after the core-back [PR](https://github.com/govuk-one-login/ipv-core-back/pull/3598) that redirects users to the problem-different-browser page. Route responsible for displaying this page is missing away key word.

The presence of processTicksAndRejections in the stack trace indicates that a Promise is not being handled correctly. This likely creates a race condition, where the request to the backend is not awaited, allowing the Express response to be returned before the required headers are attached.

This PR addresses the issue by ensuring the Promise is properly awaited, which should prevent the race condition and hopefully resolve the observed 502 errors.

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
