### PR TITLE
BAU: add missing return statement inside handleCrossBrowserJourneyActionRequest to prevent calling core-back again

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -419,6 +419,7 @@ export const handleCrossBrowserJourneyActionRequest: RequestHandler = async (
   const pageId = req.params.pageId;
   if (req.session.currentPage !== pageId) {
     await handleUnexpectedPage(req, res, pageId);
+    return;
   }
   // We return directly to the Oauth client when continuing from
   // the problem-different-browser page


### PR DESCRIPTION
## Proposed changes
### What changed

- add missing return statement to exit the `handleCrossBrowserJourneyActionRequest` middleware when the user continues on from the problem-different-browser page but the sessionPageId is not equal

### Why did it change

- We have been seeing a lot of 502s from the ALB since the new problem-different-browser page was added. They are being caused by repeat (unintended) calls to core-back which corrupts the socket when a user has continued on from the page but the user goes back

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
