### PR TITLE
PYCI-8866: Update body-parser to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@govuk-one-login/frontend-ui": "4.0.1",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.13.2",
-        "body-parser": "2.2.1",
+        "body-parser": "2.2.2",
         "connect-dynamodb": "3.0.5",
         "cookie-parser": "1.4.7",
         "copyfiles": "2.4.1",
@@ -4325,9 +4325,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
-      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -4336,7 +4336,7 @@
         "http-errors": "^2.0.0",
         "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
+        "qs": "^6.14.1",
         "raw-body": "^3.0.1",
         "type-is": "^2.0.1"
       },
@@ -8829,9 +8829,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@govuk-one-login/frontend-ui": "4.0.1",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.13.2",
-    "body-parser": "2.2.1",
+    "body-parser": "2.2.2",
     "connect-dynamodb": "3.0.5",
     "cookie-parser": "1.4.7",
     "copyfiles": "2.4.1",


### PR DESCRIPTION
We have security vulnerability related to indirect dependency in qs library. Version 2.2.2 updated qs to version 6.14.1 which should resolve the security alert.

## Proposed changes
### What changed

- Updated body-parser to 2.2.2

### Why did it change

A high-severity security vulnerability was identified in the core-front repository. The issue is introduced via the indirect dependency qs, which is included through the following libraries:
- body-parser 2.2.1
- express 5.2.1

Upgraded body-parser to a newer version to partially mitigate the vulnerability.
The vulnerability cannot be fully resolved until a patched version of express is released.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8866](https://govukverify.atlassian.net/browse/PYIC-8866)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8866]: https://govukverify.atlassian.net/browse/PYIC-8866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ