### PR TITLE
PYIC-8874: Split TLS and SSL conditions for bucket access

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -466,6 +466,14 @@ Resources:
             Condition:
               Bool:
                 "aws:SecureTransport": false
+          - Effect: Deny
+            Resource:
+              - !GetAtt AccessLogsBucket.Arn
+              - !Sub "${AccessLogsBucket.Arn}/*"
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Condition:
               NumericLessThan:
                 "s3:TlsVersion": "1.2"
 


### PR DESCRIPTION


## Proposed changes
### What changed

Bucket config

### Why did it change

When conditions are specified together they must both be satisfied for the rule to fire. We want to deny any TLS version less than 1.2 and any connection not using SSL so we need to split the two conditions up.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8874](https://govukverify.atlassian.net/browse/PYIC-8874)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8874]: https://govukverify.atlassian.net/browse/PYIC-8874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ