### PR TITLE
PYIC-8855: add HTTPCode_ELB_5XX_Count to canary alarm and re-name alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1688,15 +1688,15 @@ Resources:
             Period: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, tg500ErrorWindow ]
             Stat: Sum
 
-  FrontTargetGroup5xxPercentErrors:
+  FrontTargetGroupAndELB5xxPercentErrors:
     # This is used by the canary deployment stack
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeployment
     Properties:
-      AlarmName: FrontTargetGroup5xxPercentAlarm
+      AlarmName: FrontTargetGroupAndELB5xxPercentAlarm
       AlarmDescription: >
-        The number of HTTP 5XX server error codes that originate from the
-        target group is greater than 5% of all traffic.
+        The sum of HTTP 5XX server error codes that originate from the
+        target group and the application load balancer is greater than 5% of all traffic.
       EvaluationPeriods: 2
       DatapointsToAlarm: 2
       Threshold: 5
@@ -1706,7 +1706,7 @@ Resources:
       - Id: e1
         Label: ErrorPercent
         ReturnData: true
-        Expression: (m1/m2)*100
+        Expression: ((m1+m3)/m2)*100
       - Id: m1
         ReturnData: false
         MetricStat:
@@ -1727,6 +1727,17 @@ Resources:
             Dimensions:
             - Name: LoadBalancer
               Value: !GetAtt PrivateLoadBalancer.LoadBalancerFullName
+          Period: 60
+          Stat: Sum
+      - Id: m3
+        ReturnData: false
+        MetricStat:
+          Metric:
+            Namespace: AWS/ApplicationELB
+            MetricName: HTTPCode_ELB_5XX_Count
+            Dimensions:
+              - Name: LoadBalancer
+                Value: !GetAtt PrivateLoadBalancer.LoadBalancerFullName
           Period: 60
           Stat: Sum
 
@@ -1975,7 +1986,7 @@ Resources:
         VpcId: !Sub ${VpcStackName}-VpcId
         ContainerName: app
         ContainerPort: 8080
-        CloudWatchAlarms: !Ref FrontTargetGroup5xxPercentErrors
+        CloudWatchAlarms: !Ref FrontTargetGroupAndELB5xxPercentErrors
         PermissionsBoundary: !If
           - UsePermissionsBoundary
           - !Ref PermissionsBoundary


### PR DESCRIPTION
**❗ Note: this needs to be QAed in dev before merging!**

## Proposed changes
### What changed

- add `HTTPCode_ELB_5XX_Count` to canary alarm
- re-name alarm from `FrontTargetGroup5xxPercentAlarm` to `FrontTargetGroupAndELB5xxPercentAlarm`

Alarm tested in dev environment by deregistering targets, forcing the ELB to return a 503 Service Temporarily Unavailable. These triggered the alarm:
<img width="1219" height="556" alt="Screenshot 2026-01-19 at 17 10 35" src="https://github.com/user-attachments/assets/19d604a8-b9f8-41c9-ad5a-f15689853860" />

### Why did it change

- Currently, we only monitor `HTTPCode_Target_5XX_Count` which means we're not monitoring any "crash loops" where the targets are unhealthy. This recently failed to catch a breaking merge in Passport CRI where ECS containers were crashing on startup. We want to capture both 5xx errors from the application and any generated by the load balancer due to it not being able to talk to the app (e.g. 502s, 503s, 504s).

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8855](https://govukverify.atlassian.net/browse/PYIC-8855)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8855]: https://govukverify.atlassian.net/browse/PYIC-8855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ