### PR TITLE
PYIC-8863 add values for Data to sorry-technical-problem page

### DIFF
--- a/views/ipv/page/sorry-technical-problem.njk
+++ b/views/ipv/page/sorry-technical-problem.njk
@@ -12,7 +12,20 @@
 {% set errorHref = "#sorryTechnicalProblem" %}
 
 {% set isPageDataSensitive = false %}
-{% set contentID = 'd93801ec-7921-4358-88f3-87d196412689'%}
+
+{% if context %}
+    {% if context == 'dlOrPassportMitigation' %}
+        {% set contentID = 'cdc6ceca-ee12-47b0-a23f-e666ee9e1481'%}
+    {% elif context == 'f2fCriError' %}
+        {% set contentID = '8cf31c12-da4b-4eb4-a6e3-fbf966fa520f'%}
+    {% elif context == 'kbvCriError' %}
+        {% set contentID = 'f676cbc4-5bbf-4d8f-b2da-731d11bc7350'%}
+    {% elif context == 'kbvMitigation' %}
+        {% set contentID = 'f3f2b9da-c0d5-421a-bf18-6c9726b517e7'%}
+    {% endif %}
+{% else %}
+    {% set contentID = '63d579be-6e27-4bbb-84c3-491228e0a4e9'%}
+{% endif %}
 
 {% set whatsNeededToUseTheApp %}
     <p class="govuk-body">{{ 'pages.sorryTechnicalProblem.content.details.p1' | translate }}</p>

--- a/views/shared/ga4/on-page-load-script.njk
+++ b/views/shared/ga4/on-page-load-script.njk
@@ -16,7 +16,10 @@
                     "government digital service - digital identity",
                 statusCode: window.DI.httpStatusCode ?? 200,
                 taxonomy_level1: "web cri",
-                taxonomy_level2: "pre cri"
+                taxonomy_level2: "pre cri",
+                taxonomy_level3: undefined,
+                taxonomy_level4: undefined,
+                taxonomy_level5: undefined,
             });
     });
 </script>


### PR DESCRIPTION
## Proposed changes
### What changed

- added fields to the google analytics output for the sorry-technical-error pages

### Why did it change

- Data wants these additional values

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8863](https://govukverify.atlassian.net/browse/PYIC-8863)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8863]: https://govukverify.atlassian.net/browse/PYIC-8863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ