### PR TITLE
PYIC-8790: Add submitButton id for e2e tests

### DIFF
--- a/views/ipv/page/page-ipv-reuse.njk
+++ b/views/ipv/page/page-ipv-reuse.njk
@@ -71,6 +71,7 @@
       {% set customTimeout = progressSpinnerButtonTimeout %}
 
       {{ frontendUiProgressButton({
+        id: "submitButton",
         translations: translations.translation.progressButton,
         href: "/ipv/journey/" + pageId + "/next",
         errorPage: "/ipv/page/pyi-technical",

--- a/views/ipv/page/page-ipv-success.njk
+++ b/views/ipv/page/page-ipv-success.njk
@@ -19,6 +19,7 @@
     {% set customTimeout = progressSpinnerButtonTimeout %}
 
     {{ frontendUiProgressButton({
+      id: "submitButton",
       translations: translations.translation.progressButton,
       href: "/ipv/journey/" + pageId + "/next",
       errorPage: "/ipv/page/pyi-technical",


### PR DESCRIPTION

## Proposed changes
### What changed

- As we are now using a macro to pull in the button it didnt include the id for submitButton which our e2e tests look for

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8790](https://govukverify.atlassian.net/browse/PYIC-8790)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8790]: https://govukverify.atlassian.net/browse/PYIC-8790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ