### PR TITLE
PYIC-8790: add progressSpinnerButtonTimeout to int and prod mapping set to default 5s

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,6 +55,9 @@ Conditions:
     - !Equals [ !Ref AWS::AccountId, "175872367215"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, production ]
+  IsIntOrProd: !Or
+    - !Equals [ !Ref Environment, production ]
+    - !Equals [ !Ref Environment, integration ]
   IsStagingIntProd: !Or
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
@@ -236,7 +239,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 5000
+      progressSpinnerButtonTimeout: 10000 # This value isn't used in int or prod but CF requires these keys to be present in the mapping
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "298945768017"
@@ -269,7 +272,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 5000
+      progressSpinnerButtonTimeout: 10000 # This value isn't used in int or prod but CF requires these keys to be present in the mapping
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"
@@ -926,7 +929,7 @@ Resources:
                 - dadSpinnerRequestTimeout
             - Name: PROGRESS_SPINNER_BUTTON_TIMEOUT
               Value: !If
-                - IsProduction
+                - IsIntOrProd
                 - !Ref AWS::NoValue
                 - !FindInMap
                   - EnvironmentConfiguration

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -236,6 +236,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
+      progressSpinnerButtonTimeout: 5000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "298945768017"
@@ -268,6 +269,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
+      progressSpinnerButtonTimeout: 5000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"


### PR DESCRIPTION
## Proposed changes
### What changed

- add progressSpinnerButtonTimeout to int and prod mapping set to default 5s

### Why did it change

- deployment is failing in int and prod because CF is failing to get the mapping values for progressSpinnerButtonTimeout

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8790](https://govukverify.atlassian.net/browse/PYIC-8790)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8790]: https://govukverify.atlassian.net/browse/PYIC-8790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ