### PR TITLE
PYCI-8866: Add progressSpinnerButtonTimeout to prod and int.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -236,6 +236,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
+      progressSpinnerButtonTimeout: 20000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "298945768017"
@@ -268,6 +269,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
+      progressSpinnerButtonTimeout: 20000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"


### PR DESCRIPTION
Our pipeline failing to deploy core-front due to the missing env variable.

## Proposed changes
### What changed

- Added missing env variable to the template for prod and int

### Why did it change

- pipeline fails to deploy due to the missing variable

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- BAU

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
