### PR TITLE
BAU Bump progress button timeout to 30s

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -107,7 +107,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 20000
+      progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -140,7 +140,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 20000
+      progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -173,7 +173,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 20000
+      progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: ""
@@ -206,7 +206,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 900000
-      progressSpinnerButtonTimeout: 20000
+      progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "444977453444"


### PR DESCRIPTION
## Proposed changes
### What changed

Bump progress button timeout to 30s up to staging

### Why did it change

Another team has flagged the new progress button is timing out in staging against the RP stub, likely due to low traffic cold starts. This bumps the timeout from 20s to 30s across the board for now. The progress button is only enabled up to staging so not a concern in int/prod yet.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8790](https://govukverify.atlassian.net/browse/PYIC-8790)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8790]: https://govukverify.atlassian.net/browse/PYIC-8790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ