### PR TITLE
IPS-1339: add predictive scaling

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -742,6 +742,24 @@ Resources:
       Period: "60"
       Threshold: "30"
 
+  ECSPredictiveScalingPolicy:
+    DependsOn: CoreFrontAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSPredictiveScalingPolicy
+      PolicyType: PredictiveScaling
+      ResourceId: !Sub service/${CoreFrontCluster}/${CoreFrontService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      PredictiveScalingPolicyConfiguration:
+        MaxCapacityBreachBehavior: HonorMaxCapacity
+        MetricSpecifications:
+          - PredefinedMetricPairSpecification:
+              PredefinedMetricType: ECSServiceCPUUtilization
+            TargetValue: 60
+        Mode: ForecastOnly
+        SchedulingBufferTime: 600
+
   ECSAccessLogsGroup:
     Type: AWS::Logs::LogGroup
     # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs


### PR DESCRIPTION
## Proposed changes
### What changed

- added Predictive Scaling  in ForecastOnly to ECS cluster

### Why did it change

-  Improve resource usages

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [IPS-1339](https://govukverify.atlassian.net/browse/IPS-1339)

## Checklists

Not in scope or not already documents for all items in check list.

- [ x] READMEs and documentation up-to-date
- [ x] Browser/ unit/ Selenium tests have been written/ updated
- [ x] No risk of exposure: PII, credentials, etc through logs/ code
- [ x] Ensure added/updated routes have CSRF protection if required


[IPS-1339]: https://govukverify.atlassian.net/browse/IPS-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ