### PR TITLE
BAU Bump min task count for exploratory perf test

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -175,7 +175,7 @@ Mappings:
       dadSpinnerRequestTimeout: 300000
       progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
-      frontendAutoScalingMinCount: 6
+      frontendAutoScalingMinCount: 20
       publishedKeysAccountId: ""
     "335257547869": # Staging
       lb500ErrorLimit: 2


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump min task count for exploratory perf test. Will revert after the test

### Why did it change

- So we can validate that scale out delay is the primary issue affecting our perf test results

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
