### PR TITLE
Revert "BAU Bump min task count for exploratory perf test"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -175,7 +175,7 @@ Mappings:
       dadSpinnerRequestTimeout: 300000
       progressSpinnerButtonTimeout: 30000
       enableProgressSpinnerButton: true
-      frontendAutoScalingMinCount: 20
+      frontendAutoScalingMinCount: 6
       publishedKeysAccountId: ""
     "335257547869": # Staging
       lb500ErrorLimit: 2


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-front#2608 now that the exploratory perf test is complete