### PR TITLE
PYIC-8978 Remove unused webpack dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/uid-safe": "2.1.5",
     "chai": "4.5.0",
     "chai-as-promised": "7.1.2",
-    "copy-webpack-plugin": "13.0.0",
     "eslint": "9.36.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-prettier": "5.5.0",
@@ -68,12 +67,10 @@
     "sass": "1.97.2",
     "sinon": "21.0.1",
     "sinon-chai": "3.7.0",
-    "terser-webpack-plugin": "5.3.10",
     "ts-node": "10.9.2",
     "typescript": "5.9.2",
     "typescript-eslint": "8.56.1",
-    "uglify-js": "3.19.3",
-    "webpack": "5.105.2"
+    "uglify-js": "3.19.3"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.993.0",


### PR DESCRIPTION
## Proposed changes
### What changed

Remove unused webpack dependencies

### Why did it change

These packages have vulnerabilities via a transitive dependency, but we appear not to be using them

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8978](https://govukverify.atlassian.net/browse/PYIC-8978)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8978]: https://govukverify.atlassian.net/browse/PYIC-8978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ