### PR TITLE
PYIC-8272: DRAFT dictionary based lookup for steps

### DIFF
--- a/browser-tests/e2e-tests/.env.template
+++ b/browser-tests/e2e-tests/.env.template
@@ -2,6 +2,7 @@
 ORCHESTRATOR_STUB_URL="<insert orch stub url here with username and password in url>"
 CORE_FRONT_URL="https://identity.build.account.gov.uk"
 ASYNC_QUEUE_NAME="stubQueue_criResponseQueue_build"
+CIMIT_MANAGEMENT_API_KEY="<insert api key>"
 
 # ── Optional (sensible defaults are provided) ─────────────────────────
 # ORCH_STUB_TARGET_ENV=""

--- a/browser-tests/e2e-tests/clients/dcmaw-async-client.ts
+++ b/browser-tests/e2e-tests/clients/dcmaw-async-client.ts
@@ -12,7 +12,7 @@ const createDcmawEvidenceBlock = (
   if (
     scores.verification == undefined &&
     scores.strength == undefined &&
-    scores.verification == undefined &&
+    scores.validity == undefined &&
     scores.activityHistory == undefined
   ) {
     throw new Error(

--- a/browser-tests/e2e-tests/config/index.ts
+++ b/browser-tests/e2e-tests/config/index.ts
@@ -32,6 +32,13 @@ const config = {
     "ASYNC_DCMAW_STUB_URL",
     "https://dcmaw-async.stubs.account.gov.uk",
   ),
+  cimit: {
+    managementUrl: getEnvironmentVariableOrDefault(
+      "CIMIT_MANAGEMENT_URL",
+      "https://cimit.stubs.account.gov.uk",
+    ),
+    managementApiKey: getEnvironmentVariableOrError("CIMIT_MANAGEMENT_API_KEY"),
+  },
 };
 
 export default config;

--- a/browser-tests/e2e-tests/data/cri-stub-data-builders.ts
+++ b/browser-tests/e2e-tests/data/cri-stub-data-builders.ts
@@ -23,7 +23,7 @@ export const drivingPermit = (
   overrides?: Partial<DrivingPermitDetailsClass>,
 ): DrivingPermitDetailsClass => {
   const expDate = new Date();
-  expDate.setMonth(expDate.getFullYear() + 1);
+  expDate.setMonth(expDate.getMonth() + 6);
   return {
     expiryDate: expDate.toISOString().split("T")[0],
     issuedBy,

--- a/browser-tests/e2e-tests/data/cri-stub-data.ts
+++ b/browser-tests/e2e-tests/data/cri-stub-data.ts
@@ -3,6 +3,7 @@ import {
   aliceParkerDvla,
   alisonParkerDvla,
 } from "./custom-credentials/alice-parker";
+import { kennethDecerquieraPassport } from "./custom-credentials/kenneth-decerquiera";
 
 export interface EvidenceScores {
   strength?: number;
@@ -66,6 +67,15 @@ export const criStubData: Record<string, Record<string, CriStubDataConfig>> = {
     },
   },
   "kenneth-decerqueira-valid": {
+    "dcmaw-async": {
+      customCredentialSubject: kennethDecerquieraPassport(),
+      evidenceScores: {
+        strength: 0,
+        validity: 0,
+        activityHistory: 0,
+        verification: 0,
+      },
+    },
     passport: {
       cannedStubData: "Kenneth Decerqueira (Valid Experian) Passport",
       evidenceScores: { strength: 3, validity: 2 },

--- a/browser-tests/e2e-tests/data/custom-credentials/kenneth-decerquiera.ts
+++ b/browser-tests/e2e-tests/data/custom-credentials/kenneth-decerquiera.ts
@@ -1,0 +1,22 @@
+import { nameParts } from "../cri-stub-data-builders";
+import {
+  BirthDateClass,
+  IdentityCheckSubjectClass,
+  PassportDetailsClass,
+} from "@govuk-one-login/data-vocab/credentials";
+
+const kennethDecerquieraName = nameParts(["Kenneth"], "Decerqueira");
+
+const kennethDecerqueiraBirthDate: BirthDateClass = { value: "1965-07-08" };
+
+const kennethDecerquieraUkPassport: PassportDetailsClass = {
+  documentNumber: "321654987",
+  expiryDate: "2030-01-01",
+  icaoIssuerCode: "GBR",
+};
+
+export const kennethDecerquieraPassport = (): IdentityCheckSubjectClass => ({
+  name: [kennethDecerquieraName],
+  birthDate: [kennethDecerqueiraBirthDate],
+  passport: [kennethDecerquieraUkPassport],
+});

--- a/browser-tests/e2e-tests/features/coi-fraud-check.feature
+++ b/browser-tests/e2e-tests/features/coi-fraud-check.feature
@@ -1,4 +1,4 @@
-Feature: COI Fraud Check - Given Name Change
+Feature: COI Repeat Fraud Check - Given Name Change
   As a user with an existing identity and expired fraud details
   I want to update my name details
   So that I can verify my new identity details through the fraud check process
@@ -8,19 +8,19 @@ Feature: COI Fraud Check - Given Name Change
     And the user completes an initial P2 identity journey with expired Alice Parker details
 
   @Build @QualityGateRegressionTest
-  Scenario: Pass successfully for a given name change and show reuse screen
+  Scenario: Successful given name change during repeat fraud check and show reuse screen on return
     When the user starts a new journey
-    Then the user should see the 'confirm-your-details' page
-    When the user chooses to update their given name via the app
-    And the user goes through 'DAD' 'iphone' triage
+    And the user 'chooses to update their given names when confirming their details'
+    And the user 'has valid photo ID to update their name with the app'
+    And the user 'is on a computer or tablet'
+    And the user 'has an android'
     And the user submits 'successful' 'alice-parker-changed-first-name' details and continues from the 'DAD' journey
-    And the user submits 'alice-parker-changed-first-name' details to the 'driving-licence' CRI stub
-    Then the user should see the 'page-dcmaw-success' page
-    When the user chooses to continue
-    And the user submits 'alice-parker-changed-first-name' details to the 'fraud' CRI stub
-    Then the user should see the 'page-ipv-success' page
-    When the user chooses to continue
-    Then Alison Parker's credentials should be passed to the orch stub
+    And the user submits 'alice-parker-changed-first-name' 'driving-licence' details to the CRI
+    And the user 'acknowledges they have successfully completed the app'
+    And the user submits 'alice-parker-changed-first-name' 'fraud' details to the CRI
+    And the user 'continues to the RP after successfully proving their identity'
+    Then the user should have a 'P2' identity
+    And Alison Parker's credentials should be passed to the orch stub
 
     When the user starts a new journey
     Then the user should see the 'page-ipv-reuse' page

--- a/browser-tests/e2e-tests/features/enhanced-verification-mitigation.feature
+++ b/browser-tests/e2e-tests/features/enhanced-verification-mitigation.feature
@@ -1,0 +1,34 @@
+Feature: Enhanced Verification Mitigation
+  As a user who receives an enhanced verification CI
+  I want to mitigate it with another document and complete identity verification
+  So that I can prove my identity
+
+  Background: User starts web journey
+    Given the user starts a new journey
+    And the user 'is from the UK'
+    And the user 'has valid photo ID for the app'
+    And the user 'is on a computer or tablet'
+    And the user 'does not have an appropriate device for the app'
+    And the user 'needs another way to prove their identity from the app'
+    And the user 'has a passport for the web journey'
+    And the user submits 'kenneth-decerqueira-valid' 'passport' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'address' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'fraud' details to the CRI
+    And the user 'does not get PIP'
+    And the user 'moves on to answer security questions with Experian KBV'
+    And the user submits 'kenneth-decerqueira-valid' 'experian-kbv' details to the CRI with a 'NEEDS-ENHANCED-VERIFICATION' CI
+
+  @Build @QualityGateRegressionTest @PYIC-3612 @PYIC-3607 @PYIC-3847
+  Scenario: Same session enhanced-verification mitigation
+    When the user 're-attempts identity proving with the app'
+    # On the second app triage attempt, they have a suitable device for the app
+    And the user 'is on a computer or tablet'
+    And the user 'has an iphone'
+    And the user submits 'failed' 'kenneth-decerqueira-valid' details and continues from the 'DAD' journey
+    And the user 're-attempts identity proving via the post office'
+    And the user submits 'kenneth-decerqueira-valid' 'f2f' details to the CRI to mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+    Then the user should see the 'page-face-to-face-handoff' page
+
+    When the user starts a new journey until they get a 'page-ipv-reuse' page
+    And the user chooses to continue
+    Then the user should have a 'P2' identity

--- a/browser-tests/e2e-tests/features/f2f-passport.feature
+++ b/browser-tests/e2e-tests/features/f2f-passport.feature
@@ -6,14 +6,13 @@ Feature: F2F Passport Journey
   @Build @PYIC-8131 @QualityGateRegressionTest
   Scenario: F2F Passport claim is returned in the user identity response
     Given the user starts a new journey
-    And the user selects they are from the UK
-    And the user confirms they don't have suitable photo ID
-    Then the user should see the 'page-ipv-identity-postoffice-start' page
-    When the user selects 'next' radio option and continues
-    And the user submits 'kenneth-decerqueira-valid' details to the 'claimed-identity' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'address' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'fraud' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'f2f' CRI stub
+    And the user 'is from the UK'
+    And the user 'does not have valid photo ID for the app'
+    And the user 'has valid photo ID for the Post Office'
+    And the user submits 'kenneth-decerqueira-valid' 'claimed-identity' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'address' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'fraud' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'f2f' details to the CRI
     Then the user should see the 'page-face-to-face-handoff' page
 
     When the user starts a new journey until they get a 'page-ipv-reuse' page

--- a/browser-tests/e2e-tests/features/strategic-app.feature
+++ b/browser-tests/e2e-tests/features/strategic-app.feature
@@ -7,44 +7,35 @@ Feature: StrategicApp
   @Build @QualityGateRegressionTest
   Scenario: Happy MAM iPhone journey
     Given the user starts a new journey
-    And the user selects they are from the UK
-    And the user confirms they have suitable photo ID
-    Then the user should see the 'pyi-triage-select-device' page
-    When the user selects 'smartphone' radio option and continues
-    Then the user should see the 'pyi-triage-select-smartphone' page
-    When the user selects 'iphone' radio option and continues
-    Then the user should see the 'pyi-triage-mobile-download-app' page
+    And the user 'is from the UK'
+    And the user 'has valid photo ID for the app'
+    And the user 'is on a smartphone'
+    And the user 'has an iphone'
     When the user submits 'kennethD' 'ukChippedPassport' 'success' details to the app
     And the user returns from the app to core-front
     Then the user should see the 'check-mobile-app-result' page
     And the continue button should be enabled within 15 seconds
     When the user chooses to continue
-    Then the user should see the 'page-dcmaw-success' page
-    When the user chooses to continue
-    And the user submits 'kenneth-decerqueira-valid' details to the 'address' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'fraud' CRI stub
-    Then the user should see the 'page-ipv-success' page
-    When the user chooses to continue
+    And the user 'acknowledges they have successfully completed the app'
+    And the user submits 'kenneth-decerqueira-valid' 'address' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'fraud' details to the CRI
+    And the user 'continues to the RP after successfully proving their identity'
     Then the user should have a 'P2' identity
 
   @Build @PYIC-7471 @QualityGateRegressionTest
   Scenario: Happy DAD journey
     Given the user starts a new journey
-    And the user selects they are from the UK
-    And the user confirms they have suitable photo ID
-    Then the user should see the 'pyi-triage-select-device' page
-    When the user selects 'computer-or-tablet' radio option and continues
-    Then the user should see the 'pyi-triage-select-smartphone' page
-    When the user selects 'iphone' radio option and continues
+    And the user 'is from the UK'
+    And the user 'has valid photo ID for the app'
+    And the user 'is on a computer or tablet'
+    And the user 'has an android'
     Then the user should see the 'pyi-triage-desktop-download-app' page
     And the user should see text "Waiting for you to open the app" by 5 seconds
     When the user submits 'kennethD' 'ukChippedPassport' 'success' details to the app
     Then the continue button should be enabled within 15 seconds
     When the user chooses to continue
-    Then the user should see the 'page-dcmaw-success' page
-    When the user chooses to continue
-    And the user submits 'kenneth-decerqueira-valid' details to the 'address' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'fraud' CRI stub
-    Then the user should see the 'page-ipv-success' page
-    When the user chooses to continue
+    And the user 'acknowledges they have successfully completed the app'
+    And the user submits 'kenneth-decerqueira-valid' 'address' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'fraud' details to the CRI
+    And the user 'continues to the RP after successfully proving their identity'
     Then the user should have a 'P2' identity

--- a/browser-tests/e2e-tests/features/web-journey-passport.feature
+++ b/browser-tests/e2e-tests/features/web-journey-passport.feature
@@ -5,26 +5,24 @@ Feature: E2E Passport Journey
 
   @Build @QualityGateRegressionTest @PYIC-5477 @PYIC-6863 @PYIC-7016
   Scenario: Passport details page happy path
-    When the user starts a new journey
-    And the user selects they are from the UK
-    And the user confirms they have suitable photo ID
-    And the user drops out of the app due to an incompatible device
-    Then the user should see the 'page-multiple-doc-check' page
-    When the user selects 'ukPassport' radio option and continues
-    And the user submits 'kenneth-decerqueira-valid' details to the 'passport' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'address' CRI stub
-    And the user submits 'kenneth-decerqueira-valid' details to the 'fraud' CRI stub
-    Then the user should see the 'personal-independence-payment' page
-    When the user selects 'end' radio option and continues
-    Then the user should see the 'page-pre-experian-kbv-transition' page
-    When the user chooses to continue
-    And the user submits 'kenneth-decerqueira-valid' details to the 'experian-kbv' CRI stub
-    Then the user should see the 'page-ipv-success' page
-    When the user chooses to continue
+    Given the user starts a new journey
+    And the user 'is from the UK'
+    And the user 'has valid photo ID for the app'
+    And the user 'is on a computer or tablet'
+    And the user 'does not have an appropriate device for the app'
+    And the user 'needs another way to prove their identity from the app'
+    And the user 'has a passport for the web journey'
+    When the user submits 'kenneth-decerqueira-valid' 'passport' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'address' details to the CRI
+    And the user submits 'kenneth-decerqueira-valid' 'fraud' details to the CRI
+    And the user 'does not get PIP'
+    And the user 'moves on to answer security questions with Experian KBV'
+    And the user submits 'kenneth-decerqueira-valid' 'experian-kbv' details to the CRI
+    And the user 'continues to the RP after successfully proving their identity'
     Then the user should have a 'P2' identity
 
     When the user starts a new journey
     Then the user should see the 'page-ipv-reuse' page
     And Kenneth Decerqueira's information is displayed on the reuse screen
     When the user chooses to continue
-    Then the user should have a 'P2' identity
+    And the user should have a 'P2' identity

--- a/browser-tests/e2e-tests/fixtures/cri-stub-fixture.ts
+++ b/browser-tests/e2e-tests/fixtures/cri-stub-fixture.ts
@@ -5,15 +5,27 @@ import {
   CriStubDataConfig,
   EvidenceScores,
 } from "../data/cri-stub-data";
+import config from "../config";
 
 export interface CriStubUtils {
-  submitDetailsToCriStub: (scenario: string, cri: string) => Promise<void>;
+  submitDetailsToCriStub: (
+    scenario: string,
+    cri: string,
+    ci?: string,
+    mitigatedCi?: string,
+  ) => Promise<void>;
 }
 
 export const criStubUtils = (page: Page, utils: PageUtils): CriStubUtils => {
   const TEST_DATA_INPUT = "#test_data";
   const SEND_VC_TO_QUEUE_CHECKBOX = "#f2f_send_vc_queue";
   const OVERRIDE_VC_CHECKBOX = "#vcNotBeforeFlg";
+
+  const CI_INPUT = "#ci";
+  const MITIGATED_CI_INPUT = "#ciMitigated";
+  const CIMIT_API_KEY_INPUT = "#ciMitiApiKey";
+  const CIMIT_MANAGEMENT_URL = "#ciMitiBaseUrl";
+
   const STRENGTH_SCORE_INPUT = "#strength";
   const VALIDITY_SCORE_INTPUT = "#validity";
   const ACTIVITY_SCORE_INPUT = "#activity";
@@ -69,6 +81,8 @@ export const criStubUtils = (page: Page, utils: PageUtils): CriStubUtils => {
   const submitDetailsToCriStub = async (
     scenario: string,
     cri: string,
+    ci?: string,
+    mitigatedCi?: string,
   ): Promise<void> => {
     const testDataConfig = getCriStubTestDataConfig(scenario, cri);
 
@@ -86,6 +100,18 @@ export const criStubUtils = (page: Page, utils: PageUtils): CriStubUtils => {
 
     if (testDataConfig.overrideVcNbf) {
       await page.locator(OVERRIDE_VC_CHECKBOX).check();
+    }
+
+    if (ci) {
+      await page.locator(CI_INPUT).fill(ci);
+    }
+
+    if (mitigatedCi) {
+      await page.locator(MITIGATED_CI_INPUT).fill(mitigatedCi);
+      await page
+        .locator(CIMIT_API_KEY_INPUT)
+        .fill(config.cimit.managementApiKey);
+      await page.locator(CIMIT_MANAGEMENT_URL).fill(config.cimit.managementUrl);
     }
 
     await utils.getContinueButton().click();

--- a/browser-tests/e2e-tests/steps/common.steps.ts
+++ b/browser-tests/e2e-tests/steps/common.steps.ts
@@ -1,8 +1,34 @@
 import { createBdd } from "playwright-bdd";
 import fixtures from "../fixtures";
 import { expect } from "@playwright/test";
+import { PageActions, pageScenarioActions } from "./page-scenario-actions";
+import { PageUtils } from "../fixtures/pages-fixture";
 
 const { When, Then } = createBdd(fixtures);
+
+export const performPageActionForScenario = async (
+  { pageUtils }: { pageUtils: PageUtils },
+  scenario: keyof typeof pageScenarioActions,
+): Promise<void> => {
+  if (!(scenario in pageScenarioActions)) {
+    throw new Error(
+      `Unknown scenario: "${scenario}".\n` +
+        `Add it to pageScenarioActions in data/page-scenario-actions.ts — ` +
+        `do not create a new step definition.`,
+    );
+  }
+  const pageAction = pageScenarioActions[scenario] as PageActions;
+
+  await pageUtils.expectPage(pageAction.page);
+
+  if (pageAction.action) {
+    await pageAction.action({ pageUtils });
+  } else if (pageAction.radioValue) {
+    await pageUtils.selectRadioAndContinue(pageAction.radioValue);
+  } else {
+    await pageUtils.getContinueButton().click();
+  }
+};
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -73,6 +99,13 @@ When(
 /**
  * Generic page assertions and interactions
  */
+// This step should be used for all simple IPV page interactions (e.g. where the
+// user has to select a radio option and continues). This ensures that the Gherkin
+// scenarios align with BDD best practices of steps describing the intended
+// behaviour of the system rather than the implementation e.g. instead of
+// "the user selects 'uk' and continues", we should write "the user is from the UK"
+When("the user {string}", performPageActionForScenario);
+
 When(
   "the user selects {string} radio option and continues",
   async ({ pageUtils }, radioOption: string) => {
@@ -102,16 +135,35 @@ Then(
 /**
  * Common CRI interactions
  */
+// Put this into its own file
 When(
-  "the user submits {string} details to the {string} CRI stub",
-  async ({ criStubUtils }, scenario: string, cri: string) => {
-    await criStubUtils.submitDetailsToCriStub(scenario, cri);
+  /^the user submits '([\w-]+)' '([\w-]+)' details to the CRI( with a '([\w-]+)' CI)?$/,
+  async ({ criStubUtils }, scenario: string, cri: string, ci?: string) => {
+    await criStubUtils.submitDetailsToCriStub(scenario, cri, ci);
+  },
+);
+
+When(
+  /^the user submits '([\w-]+)' '([\w-]+)' details to the CRI to mitigate the '([\w-]+)' CI$/,
+  async (
+    { criStubUtils },
+    scenario: string,
+    cri: string,
+    mitigatedCi: string,
+  ) => {
+    await criStubUtils.submitDetailsToCriStub(
+      scenario,
+      cri,
+      undefined,
+      mitigatedCi,
+    );
   },
 );
 
 /**
  * Common end-of-journey orch stub steps
  */
+// put this into its own file
 Then(
   "the user should have a {string} identity",
   async ({ orchStubUtils }, expectedVot: string) => {

--- a/browser-tests/e2e-tests/steps/page-scenario-actions.ts
+++ b/browser-tests/e2e-tests/steps/page-scenario-actions.ts
@@ -1,0 +1,167 @@
+import { Pages } from "../../../src/test-utils/pages-and-contexts";
+import { PageUtils } from "../fixtures/pages-fixture";
+import { expect } from "@playwright/test";
+
+/**
+ * Central registry for all page radio-select-and-continue interactions.
+ *
+ * Instead of creating a new step definition for a page with radio buttons,
+ * add an entry here. The generic step `the user {string}` will handle it.
+ *
+ * See: steps/page-interactions.steps.ts
+ */
+export const pageScenarioActions = {
+  /**
+   * "live-in-uk" actions
+   */
+  "is from the UK": { page: "live-in-uk", radioValue: "uk" },
+  "is not from the UK": { page: "live-in-uk", radioValue: "international" },
+
+  /**
+   * "page-ipv-identity-document-start" actions
+   */
+  "has valid photo ID for the app": {
+    page: "page-ipv-identity-document-start",
+    radioValue: "appTriage",
+  },
+  "does not have valid photo ID for the app": {
+    page: "page-ipv-identity-document-start",
+    radioValue: "end",
+  },
+
+  /**
+   * "pyi-triage-select-device" actions
+   */
+  "is on a computer or tablet": {
+    page: "pyi-triage-select-device",
+    radioValue: "computer-or-tablet",
+  },
+  "is on a smartphone": {
+    page: "pyi-triage-select-device",
+    radioValue: "smartphone",
+  },
+
+  /**
+   * "pyi-triage-select-smartphone" actions
+   */
+  "has an android": {
+    page: "pyi-triage-select-smartphone",
+    radioValue: "android",
+  },
+  "has an iphone": {
+    page: "pyi-triage-select-smartphone",
+    radioValue: "iphone",
+  },
+  "does not have an appropriate device for the app": {
+    page: "pyi-triage-select-smartphone",
+    radioValue: "neither",
+  },
+
+  /**
+   * "pyi-triage-buffer" actions
+   */
+  "needs another way to prove their identity from the app": {
+    page: "pyi-triage-buffer",
+    radioValue: "anotherWay",
+  },
+
+  /**
+   * "check-mobile-app-result" actions
+   */
+  "successfully receives credentials after returning to the app": {
+    page: "check-mobile-app-result",
+    action: async ({ pageUtils }): Promise<void> => {
+      const continueButton = pageUtils.getContinueButton();
+      await expect(continueButton).toBeEnabled({ timeout: 15 * 1000 });
+      await continueButton.click();
+    },
+  },
+
+  /**
+   * "page-dcmaw-success" actions
+   */
+  "acknowledges they have successfully completed the app": {
+    page: "page-dcmaw-success",
+  },
+
+  /**
+   * "page-ipv-success" actions
+   */
+  "continues to the RP after successfully proving their identity": {
+    page: "page-ipv-success",
+  },
+
+  /**
+   * "page-multiple-doc-check" actions
+   */
+  "has a passport for the web journey": {
+    page: "page-multiple-doc-check",
+    radioValue: "ukPassport",
+  },
+
+  /**
+   * "personal-independence-payment" actions
+   */
+  "does not get PIP": {
+    page: "personal-independence-payment",
+    radioValue: "end",
+  },
+
+  /**
+   * "page-pre-experian-kbv-transition" actions
+   */
+  "moves on to answer security questions with Experian KBV": {
+    page: "page-pre-experian-kbv-transition",
+  },
+
+  /**
+   * "confirm-your-details" actions
+   */
+  "chooses to update their given names when confirming their details": {
+    page: "confirm-your-details",
+    action: async ({ pageUtils }): Promise<void> => {
+      await pageUtils.selectRadio("no");
+      await pageUtils.selectCheckbox("givenNames");
+      await pageUtils.getContinueButton().click();
+    },
+  },
+
+  /**
+   * "page-update-name" actions
+   */
+  "has valid photo ID to update their name with the app": {
+    page: "page-update-name",
+    radioValue: "update-name",
+  },
+
+  /**
+   * "page-ipv-identity-postoffice-start" actions
+   */
+  "has valid photo ID for the Post Office": {
+    page: "page-ipv-identity-postoffice-start",
+    radioValue: "next",
+  },
+
+  /**
+   * "photo-id-security-questions-find-another-way" actions
+   */
+  "re-attempts identity proving with the app": {
+    page: "photo-id-security-questions-find-another-way",
+    radioValue: "appTriage",
+  },
+
+  /**
+   * "pyi-post-office" actions
+   */
+  "re-attempts identity proving via the post office": {
+    page: "pyi-post-office",
+    radioValue: "next",
+  },
+
+} satisfies Record<string, PageActions>;
+
+export interface PageActions {
+  page: Pages;
+  radioValue?: string;
+  action?: ({ pageUtils }: { pageUtils: PageUtils }) => Promise<void>;
+}

--- a/browser-tests/e2e-tests/steps/repeat-fraud-check.steps.ts
+++ b/browser-tests/e2e-tests/steps/repeat-fraud-check.steps.ts
@@ -1,33 +1,35 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
 import fixtures from "../fixtures";
-import { enqueueVcWithScenario } from "../clients/dcmaw-async-client";
+import { performPageActionForScenario } from "./common.steps";
+import { enqueueDcmawAsyncVcWithScenario } from "./strategic-app.steps";
 
 const { Given, When, Then } = createBdd(fixtures);
 
 Given(
   "the user completes an initial P2 identity journey with expired Alice Parker details",
-  async ({ pageUtils, criStubUtils, scenarioContext }) => {
+  async ({ pageUtils, criStubUtils, scenarioContext, page }) => {
     // On live-in-uk page
-    await pageUtils.selectRadioAndContinue("uk");
+    await performPageActionForScenario({ pageUtils }, "is from the UK");
     // On page-ipv-identity-document-start
-    await pageUtils.selectRadioAndContinue("appTriage");
-
-    // App triage via DAD iphone
-    await pageUtils.selectRadioAndContinue("computer-or-tablet");
-    await pageUtils.selectRadioAndContinue("iphone");
-
-    const userId = scenarioContext.userId;
-    if (!userId) {
-      throw new Error("Missing userId");
-    }
-    scenarioContext.oauthState = await enqueueVcWithScenario(
-      userId,
-      "alice-parker-valid",
-      "successful",
+    await performPageActionForScenario(
+      { pageUtils },
+      "has valid photo ID for the app",
     );
 
-    await pageUtils.waitForContinueButtonToBeEnabledThenContinue(15);
+    // App triage via DAD iphone
+    await performPageActionForScenario(
+      { pageUtils },
+      "is on a computer or tablet",
+    );
+    await performPageActionForScenario({ pageUtils }, "has an iphone");
+
+    await enqueueDcmawAsyncVcWithScenario(
+      { pageUtils, page, scenarioContext },
+      "successful",
+      "alice-parker-valid",
+      "DAD",
+    );
 
     await criStubUtils.submitDetailsToCriStub(
       "alice-parker-valid",

--- a/browser-tests/e2e-tests/steps/strategic-app.steps.ts
+++ b/browser-tests/e2e-tests/steps/strategic-app.steps.ts
@@ -1,11 +1,12 @@
 import { createBdd } from "playwright-bdd";
-import { expect } from "@playwright/test";
-import fixtures from "../fixtures";
+import { expect, Page } from "@playwright/test";
+import fixtures, { ScenarioContext } from "../fixtures";
 import config from "../config";
 import {
   enqueueVc,
   enqueueVcWithScenario,
 } from "../clients/dcmaw-async-client";
+import { PageUtils } from "../fixtures/pages-fixture";
 
 const { When, Then } = createBdd(fixtures);
 
@@ -78,35 +79,39 @@ When(
   },
 );
 
+export const enqueueDcmawAsyncVcWithScenario = async (
+  {
+    pageUtils,
+    page,
+    scenarioContext,
+  }: { pageUtils: PageUtils; page: Page; scenarioContext: ScenarioContext },
+  successfulOrFailed: "successful" | "failed",
+  scenario: string,
+  appTriageJourneyType: "DAD" | "MAM",
+): Promise<void> => {
+  const userId = scenarioContext.userId;
+  if (!userId) {
+    throw new Error("Missing userId");
+  }
+
+  const oauthState = await enqueueVcWithScenario(
+    userId,
+    scenario,
+    successfulOrFailed,
+  );
+  scenarioContext.oauthState = oauthState;
+
+  if (appTriageJourneyType === "MAM") {
+    // Manually perform app callback
+    await page.goto(`${config.coreFrontUrl}/app/callback?state=${oauthState}`);
+  }
+
+  await pageUtils.waitForContinueButtonToBeEnabledThenContinue(15);
+};
+
 When(
   "the user submits {string} {string} details and continues from the {string} journey",
-  async (
-    { pageUtils, page, scenarioContext },
-    successfulOrFailed: "successful" | "failed",
-    scenario: string,
-    appTriageJourneyType: "DAD" | "MAM",
-  ) => {
-    const userId = scenarioContext.userId;
-    if (!userId) {
-      throw new Error("Missing userId");
-    }
-
-    const oauthState = await enqueueVcWithScenario(
-      userId,
-      scenario,
-      successfulOrFailed,
-    );
-    scenarioContext.oauthState = oauthState;
-
-    if (appTriageJourneyType === "MAM") {
-      // Manually perform app callback
-      await page.goto(
-        `${config.coreFrontUrl}/app/callback?state=${oauthState}`,
-      );
-    }
-
-    await pageUtils.waitForContinueButtonToBeEnabledThenContinue(15);
-  },
+  enqueueDcmawAsyncVcWithScenario,
 );
 
 /**

--- a/browser-tests/tsconfig.json
+++ b/browser-tests/tsconfig.json
@@ -11,5 +11,5 @@
     "inlineSourceMap": true,
     "types": ["node"]
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../src/test-utils/pages-and-contexts.ts"]
 }

--- a/src/test-utils/pages-and-contexts.ts
+++ b/src/test-utils/pages-and-contexts.ts
@@ -107,4 +107,6 @@ export const pagesAndContexts: Record<string, (string | undefined)[]> = {
   ],
   "we-matched-you-to-your-one-login": [],
   "you-can-change-security-code-method": [],
-};
+} as const;
+
+export type Pages = keyof typeof pagesAndContexts;


### PR DESCRIPTION
## Proposed changes
### What changed

This PR explores using a lookup object (`pageScenarioActions`) to define a set of acceptable "steps" for a given page.

Benefits:
- steps are more aligned to BDD and Gherkin best practices. Instead of:
  `the user selects 'uk' radio option, and continues`, we have `the user is from the UK`
- encourage step reuse since the dictionary entries are organised by pages and it's easy to see what steps already exist for a page
- easier pattern enforcement of page interactions - less likely to create a new step

Disadvantages:
- the `pageScenarioActions` can get quite large as we have lots of pages (though pages would be easy to find using CTRL+F)
- a lot of pages have similar functionality and options e.g. the option to retry proving via the app. In order to use these on different pages, we'd need to create new steps that are slightly different in wording as the keys need to be kept unique.
- Gherkin {string} step parameter comes in as string at runtime, so the step definition itself still needs runtime validation to check that the step exists in `pageScenarioActions`

### Why did it change

- The current implementation ([here](https://github.com/govuk-one-login/ipv-core-front/blob/f22a6ca6ae3fedea831372a87e1436ff396dc81c/browser-tests/e2e-tests/steps/common.steps.ts)) doesn't provide enough structure to follow when adding new tests. This means that the tests can easily get messy and new steps added when there might already be appropriate existing steps.

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
