### PR TITLE
BAU Add log for detecting progress spinner error redirect

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -316,6 +316,14 @@ const validateSessionAndPage = async (
     pageId === PAGES.PYI_TECHNICAL &&
     !!parseQueryValue(req.query?.isUnrecoverable as string | undefined)
   ) {
+    req.log.info({
+      message: {
+        description: "Handling frontend redirect to unrecoverable error page",
+      },
+      level: "INFO",
+      requestId: req.id,
+    });
+
     req.session.currentPage = pageId;
 
     res.render(getIpvPageTemplatePath(pageId), {


### PR DESCRIPTION
## Proposed changes
### What changed

Add log for the special route for handling the new progress button component redirect to our unrecoverable error page. The component redirects here when the spinner times out

### Why did it change

So we can see if any users are hitting this when we go live (we could user our bog-standard req/res logging but this log ties it down to this specific scenario and will include an ipvSessionId making it easier to trace back to a journey id and subsequently RPs)

### Issue tracking
- [PYIC-8942](https://govukverify.atlassian.net/browse/PYIC-8942)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8942]: https://govukverify.atlassian.net/browse/PYIC-8942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ