### PR TITLE
PYIC-8718 Bump frontend-ui to latest version and remove now-unused nunjucks filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-language-toggle": "2.2.1",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-        "@govuk-one-login/frontend-ui": "4.2.2",
+        "@govuk-one-login/frontend-ui": "5.1.2",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.14.0",
         "body-parser": "2.2.2",
@@ -1300,21 +1300,27 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-4.2.2.tgz",
-      "integrity": "sha512-Grhr7M7cHge/Nm149RGTG5l4btTCQzeMcKEotUtzRyHO0+1vuOgI6002NAyKgaHUGcCDcbWSH7qXIT2eBum0jg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-5.1.2.tgz",
+      "integrity": "sha512-V3u0lgEeggPw0IE5A7/orpliGQliu2po4wlsAWaJDCYNmEn6RUuWEOKB4MvArsUYwEomvHCcq8s84TY0HxDnfQ==",
       "license": "ISC",
       "dependencies": {
+        "lodash": "^4.18.1",
         "pino": "^10.1.0"
       },
       "optionalDependencies": {
-        "@govuk-one-login/frontend-analytics": "^4.0.6",
-        "hmpo-components": "^7.1.0"
+        "@govuk-one-login/frontend-analytics": "^4.0.7"
       },
       "peerDependencies": {
         "@govuk-one-login/frontend-analytics": " ^3.0.1 || ^4.0.3",
         "express": "^5.1.0 || >= 4.21.2",
-        "govuk-frontend": "^4.10.1 || ^5.0.0"
+        "govuk-frontend": "^4.10.1 || ^5.0.0",
+        "hmpo-components": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "hmpo-components": {
+          "optional": true
+        }
       }
     },
     "node_modules/@govuk-one-login/frontend-ui/node_modules/@govuk-one-login/frontend-analytics": {
@@ -1325,29 +1331,6 @@
       "optional": true,
       "dependencies": {
         "loglevel": "^1.9.2"
-      }
-    },
-    "node_modules/@govuk-one-login/frontend-ui/node_modules/hmpo-components": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-7.1.1.tgz",
-      "integrity": "sha512-aZiW4hqCF0NT0mdgC4iEy7+xkqArUbybEXtwzT5l/pVatiSUIpSeJw3/dEFR29UoqpE3jmkHqxqr8AV4DAP6uA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "deep-clone-merge": "^1.5.5",
-        "moment": "^2.30.1",
-        "underscore": "^1.13.7"
-      },
-      "engines": {
-        "node": "20.x || 22.x"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "govuk-frontend": "^4",
-        "nunjucks": "^3.2.4"
       }
     },
     "node_modules/@govuk-one-login/frontend-vital-signs": {
@@ -4258,13 +4241,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deep-clone-merge": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/deep-clone-merge/-/deep-clone-merge-1.5.5.tgz",
-      "integrity": "sha512-ldHDqbpMP5VTZ/QrIQ6ikzYy4fWh8WPIfqEwetN/4Pxq/xPnWlnESGN41oam5DEwI+acHznEm1bp5Rn4bp4c0w==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -5318,6 +5294,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6256,6 +6233,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6803,16 +6786,6 @@
       "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -9587,13 +9560,6 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-language-toggle": "2.2.1",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-    "@govuk-one-login/frontend-ui": "4.2.2",
+    "@govuk-one-login/frontend-ui": "5.1.2",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.14.0",
     "body-parser": "2.2.2",

--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -143,21 +143,6 @@ export const configureNunjucks = (
     }
   });
 
-  // TODO PYIC-8718: remove this once the ipv-core-base.njk file for core in frontend-ui
-  // has been updated to remove the use of translateWithContextOrFallback
-  nunjucksEnv.addFilter(
-    "translateWithContextOrFallback",
-    function (this: FilterContext, key, context, options) {
-      const translate = i18next.getFixedT(this.ctx.i18n.language);
-
-      const pascalContext = kebabCaseToPascalCase(context);
-
-      const fullKey = key + pascalContext;
-
-      return translate([fullKey, key], options);
-    },
-  );
-
   // allow pushing or adding another attribute to an Object
   nunjucksEnv.addFilter("setAttribute", function (dictionary, key, value) {
     dictionary[key] = value;


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump frontend-ui to latest version with new base template and remove now-unused nunjucks filter. The major change v4-v5 of frontend-ui doesn't have any breaking changes that affect us

### Why did it change

- Latest version of frontend-ui has our updated base template using our `translate` nunjucks filter rather than `translateWithContextOrFallback` which is now unused

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8718](https://govukverify.atlassian.net/browse/PYIC-8718)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8718]: https://govukverify.atlassian.net/browse/PYIC-8718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ