### PR TITLE
PYCI-8942: Bump progress spinner timeout to 40s - all envs.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -107,7 +107,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 30000
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -140,7 +140,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 30000
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -173,7 +173,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 30000
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: ""
@@ -206,7 +206,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 900000
-      progressSpinnerButtonTimeout: 30000
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "444977453444"
@@ -239,7 +239,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 10000 # This value isn't used in int or prod but CF requires these keys to be present in the mapping
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "298945768017"
@@ -272,7 +272,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 10000 # This value isn't used in int or prod but CF requires these keys to be present in the mapping
+      progressSpinnerButtonTimeout: 40000
       enableProgressSpinnerButton: false
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"


### PR DESCRIPTION
## Proposed changes
### What changed

- Configure the progress button custom timeout at 40 seconds in all environments.

### Why did it change

- The component has a deliberately built-in 10 seconds timeout for user accessibility, however in rare cases (such as at times of low traffic) we expect the redirect may take longer than 10s and we don’t want to unnecessarily block users.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8942](https://govukverify.atlassian.net/browse/PYIC-8942)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-8942]: https://govukverify.atlassian.net/browse/PYIC-8942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ