### PR TITLE
PYCI-9036: Update contentID for GA4.

### DIFF
--- a/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
+++ b/views/ipv/page/no-photo-id-security-questions-find-another-way.njk
@@ -12,7 +12,12 @@
 {% set errorHref = "#noPhotoIdSecurityQuestionsFindAnotherWayForm" %}
 
 {% set isPageDataSensitive = false %}
-{% set contentID = '562a0ebb-34a0-4db1-b04c-17963686c98c' %}
+
+{% if pageContext.reason == "dropout" %}
+    {% set contentID = '5ed297db-68a9-4915-aaf1-6473b29d0965' %}
+{% else %}
+    {% set contentID = '562a0ebb-34a0-4db1-b04c-17963686c98c' %}
+{% endif %}
 
 {% set photoIdHtml %}
   {% include "components/types-of-photo-id.njk" %}

--- a/views/ipv/page/page-multiple-doc-check.njk
+++ b/views/ipv/page/page-multiple-doc-check.njk
@@ -11,7 +11,12 @@
 {% set isPageDynamic = true %}
 
 {% set isPageDataSensitive = false %}
-{% set contentID = 'fda9b096-7f35-44f6-ba3a-9959a2425a57'%}
+
+{% if pageContext.allowNino %}
+    {% set contentID = '92e2d32e-0e81-41eb-91ef-940da5432b91' %}
+{% else %}
+    {% set contentID = 'fda9b096-7f35-44f6-ba3a-9959a2425a57' %}
+{% endif %}
 
 {% set radioItems = [
     {

--- a/views/ipv/page/photo-id-security-questions-find-another-way.njk
+++ b/views/ipv/page/photo-id-security-questions-find-another-way.njk
@@ -10,7 +10,12 @@
 {% set errorHref = "#photoIdSecurityQuestionsFindAnotherWayForm" %}
 
 {% set isPageDataSensitive = false %}
-{% set contentID = '00a8c392-afbb-44d4-a6ef-2d7aaad78bac'%}
+
+{% if pageContext.reason == "dropout" %}
+    {% set contentID = '63f2929b-8d8f-40ed-8ed2-1c568f07a326' %}
+{% else %}
+    {% set contentID = '00a8c392-afbb-44d4-a6ef-2d7aaad78bac' %}
+{% endif %}
 
 {% set photoIdHtml %}
   {% include "components/types-of-photo-id.njk" %}


### PR DESCRIPTION
## Proposed changes
### What changed

Updated contentID depending on the context for the following pages:
- /no-photo-id-security-questions-find-another-way
- /page-multiple-doc-check
- /photo-id-security-questions-find-another-way

### Why did it change

- As part of the changes IPV Core is making for expired Driving Licences to existing pages, Data and Analytics have some requirements to have different content IDs for variants of the same page so that they can track users accurately.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9036](https://govukverify.atlassian.net/browse/PYIC-9036)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-9036]: https://govukverify.atlassian.net/browse/PYIC-9036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ