### PR TITLE
PYIC-8942 Improve special handling for progress spinner button timeouts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -51,6 +51,7 @@ declare global {
 declare module "express-session" {
   interface SessionData {
     ipvSessionId?: string;
+    previousIpvSessionId?: string;
     clientOauthSessionId?: string;
     currentPage?: string;
     pageContext?: Record<string, unknown>;

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -58,6 +58,7 @@ const directoryPath = path.resolve("views/ipv/page");
 
 const BUILD_CLIENT_OAUTH_RESPONSE_ACTION =
   "/journey/build-client-oauth-response";
+const ORCH_HANDOFF = "orchestrator";
 
 const allTemplates = fs
   .readdirSync(directoryPath)
@@ -120,7 +121,7 @@ export const handleBackendResponse = async (
   }
 
   if (isClientResponse(data) && isValidClientResponse(data)) {
-    req.session.currentPage = "orchestrator";
+    req.session.currentPage = ORCH_HANDOFF;
 
     const message = {
       description:
@@ -132,8 +133,10 @@ export const handleBackendResponse = async (
       req.session.clientOauthSessionId = undefined;
     }
 
+    req.session.previousIpvSessionId = req.session.ipvSessionId;
     req.session.ipvSessionId = undefined;
     const { redirectUrl } = data.client;
+
     return saveSessionAndRedirect(req, res, redirectUrl);
   }
 
@@ -311,17 +314,25 @@ const validateSessionAndPage = async (
     throw new NotFoundError("Invalid page id");
   }
 
-  // To handle technical error unrecoverable redirection for progress spinner
+  // To handle timeout error redirect for progress spinner button component on handoff to Orch
+  // ORCH_HANDOFF is the expected current state here - timeout after initiating redirect to Orch
+  // REUSE/SUCCESS also included in case the component fails or times out prematurely
   if (
     pageId === PAGES.PYI_TECHNICAL &&
-    !!parseQueryValue(req.query?.isUnrecoverable as string | undefined)
+    !!parseQueryValue(req.query?.spinnerTimeout as string | undefined) &&
+    [ORCH_HANDOFF, PAGES.PAGE_IPV_REUSE, PAGES.PAGE_IPV_SUCCESS].includes(
+      req.session.currentPage ?? "",
+    )
   ) {
     req.log.info({
       message: {
-        description: "Handling frontend redirect to unrecoverable error page",
+        description:
+          "Handling progress spinner button timeout redirect to error page",
       },
       level: "INFO",
       requestId: req.id,
+      previousIpvSessionId: req.session.previousIpvSessionId,
+      fromPage: req.session.currentPage,
     });
 
     req.session.currentPage = pageId;

--- a/src/app/ipv/tests/handleJourneyPageRequest.test.ts
+++ b/src/app/ipv/tests/handleJourneyPageRequest.test.ts
@@ -359,13 +359,14 @@ describe("handleJourneyPageRequest", () => {
     );
   });
 
-  it("should render pyi-technical with unrecoverable context even if ipvSessionId is missing", async () => {
+  it("should render pyi-technical with unrecoverable context for progress spinner button timeout", async () => {
     // Arrange
     const req = createRequest({
       params: { pageId: IPV_PAGES.PYI_TECHNICAL },
-      query: { isUnrecoverable: "" }, // a truthy value will be written as either ?isUnrecoverable or ?isUnrecoverable=true
+      query: { spinnerTimeout: "" }, // a truthy value will be written as either ?spinnerTimeout or ?spinnerTimeout=true
       session: {
         ipvSessionId: undefined,
+        currentPage: IPV_PAGES.PAGE_IPV_REUSE,
       },
     });
 

--- a/src/app/oauth2/middleware.ts
+++ b/src/app/oauth2/middleware.ts
@@ -27,6 +27,7 @@ export const setIpvSessionId: RequestHandler = async (req, res, next) => {
   const response = await postSessionInitialise(req, authParams);
 
   req.session.ipvSessionId = response?.data?.ipvSessionId;
+  req.session.previousIpvSessionId = undefined;
 
   return next();
 };

--- a/views/ipv/page/page-ipv-reuse.njk
+++ b/views/ipv/page/page-ipv-reuse.njk
@@ -74,7 +74,7 @@
         id: "submitButton",
         translations: translations.translation.progressButton,
         href: "/ipv/journey/" + pageId + "/next",
-        errorPage: '/ipv/page/pyi-technical?isUnrecoverable',
+        errorPage: '/ipv/page/pyi-technical?spinnerTimeout',
         text: ('general.buttons.continueToService' | translate),
         customDevErrorTimeout: customTimeout
       }) }}

--- a/views/ipv/page/page-ipv-success.njk
+++ b/views/ipv/page/page-ipv-success.njk
@@ -22,7 +22,7 @@
       id: "submitButton",
       translations: translations.translation.progressButton,
       href: "/ipv/journey/" + pageId + "/next",
-      errorPage: '/ipv/page/pyi-technical?isUnrecoverable',
+      errorPage: '/ipv/page/pyi-technical?spinnerTimeout',
       text: ('general.buttons.continueToService' | translate),
       customDevErrorTimeout: customTimeout
     }) }}


### PR DESCRIPTION
## Proposed changes
### What changed

- Set previousIpvSessionId when deleting ipvSessionId on Orch handoff and include previousIpvSessionId as ref to old session in timeout error log
- Update timeout error query value to explicitly denote spinner timeout
- 'Protect' the timeout error route by only handling if in an expected page state (i.e. reuse/success page or Orch handoff state) and include 'fromPage' in log
    - Timeout should only really occur after redirect to Orch (i.e. in Orch handoff state)
    - If it occurs directly from our reuse/success pages something is probably wrong with the component/timer

### Why did it change

- We didn't have a link to the ipvSessionId in the timeout error log nor protect the special route in any way, making it hard to see through the noise and properly trace user journeys. Users or bots may refresh/hit the error route directly, creating a lot of noise in the logging

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8942](https://govukverify.atlassian.net/browse/PYIC-8942)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8942]: https://govukverify.atlassian.net/browse/PYIC-8942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ