### PR TITLE
BAU Add ids to radios so we can use them in E2E tests

### DIFF
--- a/views/ipv/page/page-multiple-doc-check.njk
+++ b/views/ipv/page/page-multiple-doc-check.njk
@@ -21,11 +21,13 @@
 {% set radioItems = [
     {
       value: "ukPassport",
+      id: "ukPassport",
       text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonText' | translate,
       hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continuePassportButtonHint' | translate }
     },
     {
       value: "drivingLicence",
+      id: "drivingLicence",
       text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonText' | translate,
       hint: { text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueDrivingLicenceButtonHint' | translate }
     }
@@ -35,6 +37,7 @@
 {% if pageContext.allowNino %}
     {% set radioItems = (radioItems.push({
         value: "nino",
+        id: "nino",
         text: 'pages.pageMultipleDocCheck.content.formRadioButtons.continueNinoButtonText' | translate
     }), radioItems) %}
 {% endif %}
@@ -45,6 +48,7 @@
     },
     {
       value: "end",
+      id: "end",
       text: 'pages.pageMultipleDocCheck.content.formRadioButtons.otherWayButtonText' | translate
     }),
     radioItems)


### PR DESCRIPTION
## Proposed changes
### What changed

- Add ids to radios on page-multiple-doc-check

### Why did it change

- So we can select via ids in E2E tests rather than depending on order of radios on the page

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
