### PR TITLE
PYIC-9116: Bump playwright-bdd to "^8.5.1"

### DIFF
--- a/browser-tests/package-lock.json
+++ b/browser-tests/package-lock.json
@@ -13,7 +13,7 @@
         "@govuk-one-login/data-vocab": "2.0.0",
         "@playwright/test": "1.56.1",
         "dotenv": "^17.4.2",
-        "playwright-bdd": "^8.5.0"
+        "playwright-bdd": "^8.5.1"
       },
       "devDependencies": {
         "ts-node": "^10.9.2",

--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -19,7 +19,7 @@
     "@playwright/test": "1.56.1",
     "@govuk-one-login/data-vocab": "2.0.0",
     "dotenv": "^17.4.2",
-    "playwright-bdd": "^8.5.0"
+    "playwright-bdd": "^8.5.1"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump playwright-bdd to "^8.5.1"

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9116](https://govukverify.atlassian.net/browse/PYIC-9116)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-9116]: https://govukverify.atlassian.net/browse/PYIC-9116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ