### PR TITLE
PYIC-8942 Bump progress button timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -137,7 +137,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: ""
@@ -170,7 +170,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 300000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: ""
@@ -203,7 +203,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 300000
       dadSpinnerRequestTimeout: 900000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "444977453444"
@@ -236,7 +236,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 4
       publishedKeysAccountId: "298945768017"
@@ -269,7 +269,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 40000
+      progressSpinnerButtonTimeout: 60000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump progress button timeout to 60s

### Why did it change

- We're seeing a handful of timeouts at 40s, bumping to see if it stabilises things

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8942](https://govukverify.atlassian.net/browse/PYIC-8942)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-8942]: https://govukverify.atlassian.net/browse/PYIC-8942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ