### PR TITLE
PYCI-9087: Bump node js version in automated-tests.yaml

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          node-version: 22.22.1
       - name: Setup .npmrc
         run: |
           cp .npmrc.template .npmrc && \


### PR DESCRIPTION
## Proposed changes
### What changed

- Upgraded node version to 22.22.1 in automated-test workflow

### Why did it change

Node version 22.22.1 is required for lint-staged 17.05

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
