### PR TITLE
PYCI-9087: Bump node version to 24

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -25,10 +25,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 22.22.1
+          node-version: 24
       - name: Setup .npmrc
         run: |
           cp .npmrc.template .npmrc && \

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.16.0
       - name: Setup .npmrc
         run: |
           cp .npmrc.template .npmrc && \

--- a/.github/workflows/secure-post-merge.yaml
+++ b/.github/workflows/secure-post-merge.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.16.0
 
       - name: Setup .npmrc
         run: |

--- a/.github/workflows/secure-post-merge.yaml
+++ b/.github/workflows/secure-post-merge.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Setup .npmrc
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
+FROM node:24.16.0-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
 WORKDIR /app
 
 # Install packages
@@ -25,7 +25,7 @@ RUN npm run build-service-unavailable
 # 'npm install --omit=dev' does not prune test packages which are necessary
 RUN npm install --omit=dev
 
-FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
+FROM node:24.16.0-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
 RUN addgroup -S appgroup && \
     adduser -S -H -G appgroup appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.21.1-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885 AS builder
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
 WORKDIR /app
 
 # Install packages
@@ -25,8 +25,9 @@ RUN npm run build-service-unavailable
 # 'npm install --omit=dev' does not prune test packages which are necessary
 RUN npm install --omit=dev
 
-FROM node:22.21.1-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885 AS final
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
+RUN addgroup -S appgroup && \
+    adduser -S -H -G appgroup appuser
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini", "curl"]

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.16.0-alpine3.21@sha256:9f3ae04faa4d2188825803bf890792f33cc39033c9241fc6bb201149470436ca AS builder
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
 WORKDIR /app
 
 # Install packages
@@ -25,8 +25,9 @@ RUN npm run build-service-unavailable
 # 'npm install --omit=dev' does not prune test packages which are necessary
 RUN npm install --omit=dev
 
-FROM node:22.14.0-alpine3.21@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944 AS final
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
+RUN addgroup -S appgroup && \
+    adduser -S -H -G appgroup appuser
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini", "curl"]

--- a/dev-deploy/Dockerfile
+++ b/dev-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
+FROM node:24.16.0-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS builder
 WORKDIR /app
 
 # Install packages
@@ -25,7 +25,7 @@ RUN npm run build-service-unavailable
 # 'npm install --omit=dev' does not prune test packages which are necessary
 RUN npm install --omit=dev
 
-FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
+FROM node:24.16.0-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS final
 RUN addgroup -S appgroup && \
     adduser -S -H -G appgroup appuser
 

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.21.1-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885
+FROM node:24.16.0-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885
 ENV PORT 4501
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,8 +79,8 @@
         "uglify-js": "3.19.3"
       },
       "engines": {
-        "node": "22.x",
-        "npm": "10.x"
+        "node": "24.x",
+        "npm": "11.x"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "User interface for the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.",
   "main": "src/app.ts",
   "engines": {
-    "node": "22.x",
-    "npm": "10.x"
+    "node": "24.x",
+    "npm": "11.x"
   },
   "scripts": {
     "start": "node --enable-source-maps build/app.js",


### PR DESCRIPTION


## Proposed changes
### What changed

- Upgraded node version to 24 in Dockerfiles
- Updated node in the project to 24.x and npm to 11.x
- Fixed user creation in Dockerfile

### Why did it change

- Node version 22.22.1 is required for lint-staged 17.05
- Order of commands in newer image version changed

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9135](https://govukverify.atlassian.net/browse/PYIC-9135)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required


[PYIC-9135]: https://govukverify.atlassian.net/browse/PYIC-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ