### PR TITLE
INC0019408 Temp skip sonar check while sonar is down

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -47,11 +47,12 @@ jobs:
         run: npm run test:coverage
       - name: Check translations
         run: npm run check-translations
-      - name: Run sonarcloud scan
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # obtained from https://sonarcloud.io
+      # TEMP SKIP CHECK WHILE SONAR IS DOWN
+      # - name: Run sonarcloud scan
+      #   if: ${{ github.actor != 'dependabot[bot]' }}
+      #   uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # obtained from https://sonarcloud.io
       - name: Build docker image
         run: |
           cd "${GITHUB_WORKSPACE}" || exit 1


### PR DESCRIPTION
## Proposed changes
### What changed

- Temp skip sonar check while sonar is down

### Why did it change

- We've been asked to skip this so we can get the frontend-analytics patch deployed for the GA4 incident

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- INC0019408

## Checklists

- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Ensure added/updated routes have CSRF protection if required
