### PR TITLE
ATO-2075: Temporarily increase spinner timeout to 5 mins

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -269,7 +269,7 @@ Mappings:
       spinnerRequestLongWaitInterval: 60000
       mamSpinnerRequestTimeout: 600000
       dadSpinnerRequestTimeout: 1800000
-      progressSpinnerButtonTimeout: 60000
+      progressSpinnerButtonTimeout: 300000
       enableProgressSpinnerButton: true
       frontendAutoScalingMinCount: 6
       publishedKeysAccountId: "101836073728"


### PR DESCRIPTION
In order to further investigate behaviour of users timing out at the spinner button, temporarily increasing the timeout

## Proposed changes
### What changed

-

### Why did it change

-

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required
