### PR TITLE
BAU: Update data-vocab to current version

### DIFF
--- a/browser-tests/package-lock.json
+++ b/browser-tests/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.12.1",
-        "@govuk-one-login/data-vocab": "2.0.0",
+        "@govuk-one-login/data-vocab": "2.0.3",
         "@playwright/test": "1.56.1",
         "dotenv": "^17.4.2",
         "playwright-bdd": "^9.2.0"
@@ -167,9 +167,9 @@
       "license": "MIT"
     },
     "node_modules/@govuk-one-login/data-vocab": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.0/c5ecfde3f00491bc70585a070a27154d47303390",
-      "integrity": "sha512-nsZOZAgR5R9vvD5LHiA5AOpov3eLsDHaljP+vzD3mBpa3YvlI31RvdRZAfM7Gv/h6eaIRH97gt7+va1hyqm31g=="
+      "version": "2.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA=="
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",

--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "1.56.1",
-    "@govuk-one-login/data-vocab": "2.0.0",
+    "@govuk-one-login/data-vocab": "2.0.3",
     "dotenv": "^17.4.2",
     "playwright-bdd": "^9.2.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1101.0",
         "@aws-sdk/client-ssm": "3.1101.0",
-        "@govuk-one-login/data-vocab": "2.0.0",
+        "@govuk-one-login/data-vocab": "2.0.3",
         "@govuk-one-login/frontend-analytics": "4.2.0",
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@govuk-one-login/data-vocab": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.0/c5ecfde3f00491bc70585a070a27154d47303390",
-      "integrity": "sha512-nsZOZAgR5R9vvD5LHiA5AOpov3eLsDHaljP+vzD3mBpa3YvlI31RvdRZAfM7Gv/h6eaIRH97gt7+va1hyqm31g=="
+      "version": "2.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA=="
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
       "version": "4.2.0",
@@ -3589,9 +3589,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5747,9 +5747,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6928,9 +6928,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7627,9 +7627,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1101.0",
     "@aws-sdk/client-ssm": "3.1101.0",
-    "@govuk-one-login/data-vocab": "2.0.0",
+    "@govuk-one-login/data-vocab": "2.0.3",
     "@govuk-one-login/frontend-analytics": "4.2.0",
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",


### PR DESCRIPTION
## Proposed changes
### What changed

Update data-vocab package

### Why did it change

So that we can switch from github to npm when downloading the package

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9193](https://govukverify.atlassian.net/browse/PYIC-9193)


[PYIC-9193]: https://govukverify.atlassian.net/browse/PYIC-9193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ