### PR TITLE
PYIC-9193: Get all npm packages from default repository

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,4 @@
 version: 2
-registries:
-  github-npm:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    username: ${{ secrets.DEPENDABOT_GITHUB_USERNAME }}
-    password: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}
-    scope: "@govuk-one-login"
 updates:
   - package-ecosystem: "npm"
     directories:

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -29,10 +29,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24.16.0
-      - name: Setup .npmrc
-        run: |
-          cp .npmrc.template .npmrc && \
-          sed -i s/TOKEN_WITH_READ_PACKAGE_PERMISSION/${{ secrets.GITHUB_TOKEN }}/ .npmrc
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -68,14 +64,6 @@ jobs:
     steps:
       - name: Pull repository
         uses: actions/checkout@v7
-      - name: Setup .npmrc for core-front
-        run: |
-          cp ../.npmrc.template ../.npmrc && \
-          sed -i s/TOKEN_WITH_READ_PACKAGE_PERMISSION/${{ secrets.GITHUB_TOKEN }}/ ../.npmrc
-      - name: Setup .npmrc for browser-tests
-        run: |
-          cp .npmrc.template .npmrc && \
-          sed -i s/TOKEN_WITH_READ_PACKAGE_PERMISSION/${{ secrets.GITHUB_TOKEN }}/ .npmrc
       - name: Run browser tests
         run: docker compose up --exit-code-from browser-tests-tests
       - name: Upload test artifacts

--- a/.github/workflows/secure-post-merge.yaml
+++ b/.github/workflows/secure-post-merge.yaml
@@ -39,11 +39,6 @@ jobs:
         with:
           node-version: 24.16.0
 
-      - name: Setup .npmrc
-        run: |
-          cp .npmrc.template .npmrc && \
-          sed -i s/TOKEN_WITH_READ_PACKAGE_PERMISSION/${{ secrets.GITHUB_TOKEN }}/ .npmrc
-
       - name: Set up AWS creds #push to ECR and  do sam deploy
         uses: aws-actions/configure-aws-credentials@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -68,9 +68,6 @@ typings/
 .env.test
 **/.env
 
-# npmrc file containing access token
-**/.npmrc
-
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+save-exact=true
+engine-strict=true

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,7 +1,0 @@
-ignore-scripts=true
-save-exact=true
-engine-strict=true
-; Some govuk-one-login packages are currently not being published to github.com and return E404. To update those packages you need to comment out the line below, update the package and then re-instate the line.
-; Hopefully soon all govuk-one-login packages will be published to github.com and this comment can be deleted.
-@govuk-one-login:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=TOKEN_WITH_READ_PACKAGE_PERMISSION

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ git clone https://github.com/govuk-one-login/ipv-core-front.git
 ```
 
 1. Change into the `ipv-core-front` folder.
-1. [Create a GitHub personal access token](https://github.com/settings/tokens) with package:read scope
-1. Copy `.npmrc.template` to `.npmrc` and replace `TOKEN_WITH_READ_PACKAGE_PERMISSION` with your personal access token
 1. Run the following command to install the project dependencies:
 
 ```bash

--- a/browser-tests/.npmrc
+++ b/browser-tests/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+save-exact=true
+engine-strict=true

--- a/browser-tests/.npmrc.template
+++ b/browser-tests/.npmrc.template
@@ -1,7 +1,0 @@
-ignore-scripts=true
-save-exact=true
-engine-strict=true
-; Some govuk-one-login packages are currently not being published to github.com and return E404. To update those packages you need to comment out the line below, update the package and then re-instate the line.
-; Hopefully soon all govuk-one-login packages will be published to github.com and this comment can be deleted.
-@govuk-one-login:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=TOKEN_WITH_READ_PACKAGE_PERMISSION

--- a/browser-tests/package-lock.json
+++ b/browser-tests/package-lock.json
@@ -168,7 +168,7 @@
     },
     "node_modules/@govuk-one-login/data-vocab": {
       "version": "2.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/data-vocab/-/data-vocab-2.0.3.tgz",
       "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA=="
     },
     "node_modules/@jridgewell/resolve-uri": {

--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -16,8 +16,8 @@
   "license": "MIT",
   "dependencies": {
     "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "1.56.1",
     "@govuk-one-login/data-vocab": "2.0.3",
+    "@playwright/test": "1.56.1",
     "dotenv": "^17.4.2",
     "playwright-bdd": "^9.2.0"
   },

--- a/browser-tests/readme.md
+++ b/browser-tests/readme.md
@@ -16,8 +16,7 @@ For more information on each test suite, see their documentation:
 ## Quick Start
 
 ### Installation
-Copy the `.npmrc.template` file and update the name to `.npmrc`. Replace the `TOKEN_WITH_READ_PACKAGE_PERMISSION` placeholder
-with your own personal access token with read:packages scope. Then run install:
+Run install:
 ```bash
 cd browser-tests/
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -879,7 +879,7 @@
     },
     "node_modules/@govuk-one-login/data-vocab": {
       "version": "2.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/data-vocab/-/data-vocab-2.0.3.tgz",
       "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA=="
     },
     "node_modules/@govuk-one-login/frontend-analytics": {


### PR DESCRIPTION
## Proposed changes
### What changed

Stop dependabot and devs trying to access npm packages on GitHub

### Why did it change

It's causing errors in dependabot, and all of the packages are now on the main npm

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9193](https://govukverify.atlassian.net/browse/PYIC-9193)

## Checklists

- [x] READMEs and documentation up-to-date


[PYIC-9193]: https://govukverify.atlassian.net/browse/PYIC-9193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ