### PR TITLE
PYIC-9211: fail fast when ipvSessionId is missing and handle backend errors

### DIFF
--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -478,10 +478,6 @@ export const handleCrossBrowserJourneyActionRequest: RequestHandler = async (
 ) => {
   const pageId = req.params.pageId;
 
-  if (!req.session?.ipvSessionId) {
-    throw new UnauthorizedError("ipvSessionId is missing");
-  }
-
   if (req.session.currentPage !== pageId) {
     await handleUnexpectedPage(req, res, pageId);
     return;

--- a/src/app/ipv/middleware.ts
+++ b/src/app/ipv/middleware.ts
@@ -64,6 +64,13 @@ const allTemplates = fs
   .readdirSync(directoryPath)
   .map((file) => path.parse(file).name);
 
+export const validateIpvSession: RequestHandler = (req, _res, next) => {
+  if (!req.session?.ipvSessionId) {
+    throw new UnauthorizedError("ipvSessionId is missing");
+  }
+  return next();
+};
+
 const journeyApi = async (
   action: string,
   req: Request,
@@ -383,6 +390,10 @@ export const updateJourneyState: RequestHandler = async (req, res) => {
   const currentPageId = req.params.pageId;
   const action = req.params.action;
 
+  if (!req.session?.ipvSessionId) {
+    throw new UnauthorizedError("ipvSessionId is missing");
+  }
+
   if (action && isValidIpvPage(currentPageId)) {
     await processAction(req, res, action, currentPageId);
   } else {
@@ -466,6 +477,11 @@ export const handleCrossBrowserJourneyActionRequest: RequestHandler = async (
   res,
 ) => {
   const pageId = req.params.pageId;
+
+  if (!req.session?.ipvSessionId) {
+    throw new UnauthorizedError("ipvSessionId is missing");
+  }
+
   if (req.session.currentPage !== pageId) {
     await handleUnexpectedPage(req, res, pageId);
     return;

--- a/src/app/ipv/router.ts
+++ b/src/app/ipv/router.ts
@@ -20,6 +20,7 @@ import {
   validatePageId,
   renderProblemDifferentBrowserPage,
   handleCrossBrowserJourneyActionRequest,
+  validateIpvSession,
 } from "./middleware";
 
 import IPV_PAGES from "../../constants/ipv-pages";
@@ -60,6 +61,7 @@ router.get(
 router.post(
   getPagePath(IPV_PAGES.UPDATE_DETAILS),
   csrfSynchronisedProtection,
+  validateIpvSession,
   parseForm,
   setRequestPageId(IPV_PAGES.UPDATE_DETAILS),
   formHandleUpdateDetailsCheckBox,
@@ -71,6 +73,7 @@ router.post(
 router.post(
   getPagePath(IPV_PAGES.CONFIRM_DETAILS),
   csrfSynchronisedProtection,
+  validateIpvSession,
   parseForm,
   setRequestPageId(IPV_PAGES.CONFIRM_DETAILS),
   formHandleCoiDetailsCheck,
@@ -82,6 +85,7 @@ router.post(
 router.post(
   getPagePath(IPV_PAGES.CHECK_MOBILE_APP_RESULT),
   csrfSynchronisedProtection,
+  validateIpvSession,
   parseForm,
   setRequestPageId(IPV_PAGES.CHECK_MOBILE_APP_RESULT),
   checkVcReceiptStatus,
@@ -92,6 +96,7 @@ router.post(
 router.post(
   getPagePath(IPV_PAGES.PYI_TRIAGE_DESKTOP_DOWNLOAD_APP),
   csrfSynchronisedProtection,
+  validateIpvSession,
   parseForm,
   setRequestPageId(IPV_PAGES.PYI_TRIAGE_DESKTOP_DOWNLOAD_APP),
   checkVcReceiptStatus,
@@ -120,6 +125,6 @@ router.get("/usefeatureset", validateFeatureSet, renderFeatureSetPage);
 router.get(`/${APP_REDIRECT_PATH}/:specifiedPhoneType`, handleAppStoreRedirect);
 // Enables a link in the frontend to iterate the journey state
 // This is needed because some redirects must be done with links, not forms
-router.get("/journey/:pageId/:action", updateJourneyState);
+router.get("/journey/:pageId/:action", validateIpvSession, updateJourneyState);
 
 export default router;

--- a/src/app/ipv/tests/handleCrossBrowserJourneyActionRequest.test.ts
+++ b/src/app/ipv/tests/handleCrossBrowserJourneyActionRequest.test.ts
@@ -1,7 +1,6 @@
 import IPV_PAGES from "../../../constants/ipv-pages";
 import sinon from "sinon";
 import { expect } from "chai";
-import UnauthorizedError from "../../../errors/unauthorized-error";
 import {
   specifyCreateRequest,
   specifyCreateResponse,
@@ -88,22 +87,5 @@ describe("handleCrossBrowserJourneyActionRequest", () => {
     expect(res.redirect).to.have.been.calledOnceWith(
       `/ipv/page/${IPV_PAGES.PYI_ATTEMPT_RECOVERY}`,
     );
-  });
-
-  it("should throw UnauthorizedError if ipvSessionId is missing from session", async () => {
-    // Arrange
-    const req = createRequest({
-      params: { pageId: "problem-different-browser" },
-      session: {
-        ipvSessionId: undefined,
-        currentPage: "problem-different-browser",
-      },
-    });
-    const res = createResponse();
-
-    // Act & Assert
-    await expect(
-      middleware.handleCrossBrowserJourneyActionRequest(req, res, sinon.fake),
-    ).to.be.rejectedWith(UnauthorizedError, "ipvSessionId is missing");
   });
 });

--- a/src/app/ipv/tests/handleCrossBrowserJourneyActionRequest.test.ts
+++ b/src/app/ipv/tests/handleCrossBrowserJourneyActionRequest.test.ts
@@ -1,6 +1,7 @@
 import IPV_PAGES from "../../../constants/ipv-pages";
 import sinon from "sinon";
 import { expect } from "chai";
+import UnauthorizedError from "../../../errors/unauthorized-error";
 import {
   specifyCreateRequest,
   specifyCreateResponse,
@@ -87,5 +88,22 @@ describe("handleCrossBrowserJourneyActionRequest", () => {
     expect(res.redirect).to.have.been.calledOnceWith(
       `/ipv/page/${IPV_PAGES.PYI_ATTEMPT_RECOVERY}`,
     );
+  });
+
+  it("should throw UnauthorizedError if ipvSessionId is missing from session", async () => {
+    // Arrange
+    const req = createRequest({
+      params: { pageId: "problem-different-browser" },
+      session: {
+        ipvSessionId: undefined,
+        currentPage: "problem-different-browser",
+      },
+    });
+    const res = createResponse();
+
+    // Act & Assert
+    await expect(
+      middleware.handleCrossBrowserJourneyActionRequest(req, res, sinon.fake),
+    ).to.be.rejectedWith(UnauthorizedError, "ipvSessionId is missing");
   });
 });

--- a/src/app/ipv/tests/updateJourneyState.test.ts
+++ b/src/app/ipv/tests/updateJourneyState.test.ts
@@ -3,6 +3,7 @@ import sinon from "sinon";
 import { updateJourneyState } from "../middleware";
 import * as coreBackService from "../../../services/coreBackService";
 import NotFoundError from "../../../errors/not-found-error";
+import UnauthorizedError from "../../../errors/unauthorized-error";
 import {
   specifyCreateRequest,
   specifyCreateResponse,
@@ -68,6 +69,26 @@ describe("updateJourneyState", () => {
     await expect(updateJourneyState(req, res, next)).to.be.rejectedWith(
       NotFoundError,
       "Invalid page id",
+    );
+  });
+
+  it("should throw UnauthorizedError if ipvSessionId is missing from session", async () => {
+    // Arrange
+    const req = createRequest({
+      params: {
+        pageId: "prove-identity-no-photo-id",
+        action: "next",
+      },
+      session: {
+        ipvSessionId: undefined,
+      },
+    });
+    const res = createResponse();
+
+    // Act & Assert
+    await expect(updateJourneyState(req, res, next)).to.be.rejectedWith(
+      UnauthorizedError,
+      "ipvSessionId is missing",
     );
   });
 });

--- a/src/app/ipv/tests/validateIpvSession.test.ts
+++ b/src/app/ipv/tests/validateIpvSession.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { validateIpvSession } from "../middleware";
+import UnauthorizedError from "../../../errors/unauthorized-error";
+import {
+  specifyCreateRequest,
+  specifyCreateResponse,
+} from "../../../test-utils/mock-express";
+
+describe("validateIpvSession", () => {
+  const createRequest = specifyCreateRequest();
+  const createResponse = specifyCreateResponse();
+  const next: any = sinon.fake();
+
+  beforeEach(() => {
+    next.resetHistory();
+  });
+
+  it("should call next if ipvSessionId exists in session", () => {
+    // Arrange
+    const req = createRequest({
+      session: { ipvSessionId: "valid-session-id" },
+    });
+    const res = createResponse();
+
+    // Act
+    validateIpvSession(req, res, next);
+
+    // Assert
+    expect(next).to.have.been.calledOnce;
+  });
+
+  it("should throw UnauthorizedError if ipvSessionId is missing", () => {
+    // Arrange
+    const req = createRequest({
+      session: { ipvSessionId: undefined },
+    });
+    const res = createResponse();
+
+    // Act & Assert
+    expect(() => validateIpvSession(req, res, next)).to.throw(
+      UnauthorizedError,
+      "ipvSessionId is missing",
+    );
+  });
+});


### PR DESCRIPTION
## Proposed changes
### What changed

- Add validateIpvSession middleware to validate session presence on custom routes

<img width="800" height="370" alt="Screenshot 2026-08-13 at 11 17 15" src="https://github.com/user-attachments/assets/1c41e4c5-1ad8-46ea-8fb9-7fcf571b1b2c" />


### Why did it change

- Gracefully handle core-back error response payloads to prevent 500 crashes

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9211](https://govukverify.atlassian.net/browse/PYIC-9211)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-9211]: https://govukverify.atlassian.net/browse/PYIC-9211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ