### PR TITLE
Revert "BAU: Bump @govuk-one-login/frontend-ui from 5.2.2 to 5.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@govuk-one-login/frontend-analytics": "4.2.0",
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-        "@govuk-one-login/frontend-ui": "5.3.1",
+        "@govuk-one-login/frontend-ui": "5.2.2",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.19.0",
         "body-parser": "2.3.0",
@@ -900,12 +900,6 @@
         "loglevel": "^1.9.2"
       }
     },
-    "node_modules/@govuk-one-login/frontend-logger": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-logger/-/frontend-logger-0.0.2.tgz",
-      "integrity": "sha512-2ygSN0ibLoMsZIYXEaXBQTaRbHLsocHG/iRCh7POS1Tb62sBIAvv08GuiOIhY5d68jSLJZ4aeLD3RJ+oJWOAYw==",
-      "license": "ISC"
-    },
     "node_modules/@govuk-one-login/frontend-passthrough-headers": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-passthrough-headers/-/frontend-passthrough-headers-1.3.2.tgz",
@@ -918,23 +912,24 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-5.3.1.tgz",
-      "integrity": "sha512-jmLVKaF9Z4RwEIwXg+hsDso7mUQFwulhlBVHTiETmiO44y8B/lIaWNqyS+8JmDQ2Z89pWdMvWALmt5/gs+9lRw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-5.2.2.tgz",
+      "integrity": "sha512-NvapP7AhnntVLFhRnf5G7z2oecx9pH/LpHBtbXbn6Hf0rC+Ifbr2XT5G87sLZMmSqFIe8DIp29NKSPrzq5mZDg==",
       "license": "ISC",
       "dependencies": {
-        "@govuk-one-login/frontend-logger": "^0.0.2",
         "lodash-es": "^4.18.1",
         "pino": "^10.1.0"
       },
       "peerDependencies": {
         "@govuk-one-login/frontend-analytics": " ^3.0.1 || ^4.0.3",
-        "@govuk-one-login/frontend-logger": "^0.0.2",
         "express": "^5.1.0 || >= 4.21.2",
         "govuk-frontend": "^4.10.1 || ^5.0.0",
         "hmpo-components": "^7.1.0"
       },
       "peerDependenciesMeta": {
+        "@govuk-one-login/frontend-analytics": {
+          "optional": true
+        },
         "hmpo-components": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@govuk-one-login/frontend-analytics": "4.2.0",
     "@govuk-one-login/frontend-device-intelligence": "1.2.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-    "@govuk-one-login/frontend-ui": "5.3.1",
+    "@govuk-one-login/frontend-ui": "5.2.2",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.19.0",
     "body-parser": "2.3.0",


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-front#2978