### PR TITLE
PYIC-9183 Bump log retention to 6 months

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -762,7 +762,7 @@ Resources:
     # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-CoreFront-ECS
-      RetentionInDays: 30
+      RetentionInDays: 180
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -1353,7 +1353,7 @@ Resources:
         - IsDevelopment
         - !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-CoreFront-REST-API-GW-AccessLogs
         - !Sub /aws/apigateway/${AWS::StackName}-CoreFront-REST-API-GW-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: 180
 
   RestApiGatewayAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -1538,7 +1538,7 @@ Resources:
         - IsDevelopment
         - !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-CoreFront-API-GW-AccessLogs
         - !Sub /aws/apigateway/${AWS::StackName}-CoreFront-API-GW-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: 180
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes
### What changed

Bump CloudWatch log retention periods to 6 months (180 days) for log groups used in staging-prod

### Why did it change

With the move off Splunk we will lose access to a year's worth of ingested logs. The new CWCAO tool is purely a logs viewing tool sourced directly from CloudWatch, so in order to investigate older issues we need to increase the CloudWatch log groups retention directly. 6 months seems a sensible balance for now, taking into account the increased cost and how far back we typically need to be able to search. The Platform team are looking at archiving logs as a longer-term solution (at which point we should be able to reduce our retention periods again).

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9183](https://govukverify.atlassian.net/browse/PYIC-9183)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] Browser/ unit/ Selenium tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Ensure added/updated routes have CSRF protection if required


[PYIC-9183]: https://govukverify.atlassian.net/browse/PYIC-9183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ